### PR TITLE
Check if $_SERVER['CONTENT_TYPE'] isset()

### DIFF
--- a/lib/bugsnag.php
+++ b/lib/bugsnag.php
@@ -437,7 +437,7 @@ class Bugsnag {
         if(!empty($_POST)) {
             $requestData['request']['params'] = $_POST;
         } else {
-            if(stripos($_SERVER['CONTENT_TYPE'], 'application/json') === 0) {
+            if(isset($_SERVER['CONTENT_TYPE']) and stripos($_SERVER['CONTENT_TYPE'], 'application/json') === 0) {
                 $requestData['request']['params'] = json_decode(file_get_contents('php://input'));
             }
         }


### PR DESCRIPTION
Because it isn't always, and that causes an E_NOTICE error under E_ALL error_reporting.
