### PR TITLE
Cannot rely on HTTP_HOST 

### DIFF
--- a/src/Bugsnag/Request.php
+++ b/src/Bugsnag/Request.php
@@ -64,10 +64,17 @@ class Request {
         }
     }
 
-    private static function getCurrentUrl() {
+    private static function getCurrentUrl() 
+    {
         $schema = ((!empty($_SERVER['HTTPS']) && $_SERVER['HTTPS'] !== 'off') || $_SERVER['SERVER_PORT'] == 443) ? 'https://' : 'http://';
 
-        return $schema.$_SERVER['HTTP_HOST'].$_SERVER['REQUEST_URI'];
+        if (isset($_SERVER['HTTP_HOST']) && isset($_SERVER['REQUEST_URI'])) {
+            return $schema . $_SERVER['HTTP_HOST'] . $_SERVER['REQUEST_URI'];
+        } elseif (isset($_SERVER['REQUEST_URI'])) {
+            return $schema . $_SERVER['REQUEST_URI'];
+        } else {
+            return $schema;
+        }
     }
 
     private static function getRequestIp() {


### PR DESCRIPTION
https://bugsnag.com/errors/5217b6becf4cfd7373c945d8/events/newest

The above bug from my account shows

PHP Notice: Undefined index: HTTP_HOST

```
/var/lib/openshift/5217b6484382ecd56c001d7d/app-root/runtime/repo/vendor/bugsnag/bugsnag/src/Bugsnag/Request.php:70 • [main]
```
