### PR TITLE
Add typehint to Bugsnag_Client::notify

### DIFF
--- a/src/Bugsnag/Client.php
+++ b/src/Bugsnag/Client.php
@@ -386,8 +386,13 @@ class Bugsnag_Client
         }
     }
 
-    // Batches up errors into notifications for later sending
-    public function notify($error, $metaData = array())
+    /**
+     * Batches up errors into notifications for later sending
+     *
+     * @param \Bugsnag_Error $error - The error to batch up
+     * @param array $metaData       - Meta data with the error
+     */
+    public function notify(\Bugsnag_Error $error, $metaData = array())
     {
         // Queue or send the error
         if ($this->sendErrorsOnShutdown()) {


### PR DESCRIPTION
I'm not sure if there's much need to call this method directly but I assumed it was a string so got caught out when it tried calling methods. I think this will fail if it gets anything but a Bugsnag_Error object so the hint seems appropriate.
