### PR TITLE
cast $str to (string) for mb_detect_encoding

### DIFF
--- a/src/Bugsnag/Notification.php
+++ b/src/Bugsnag/Notification.php
@@ -78,7 +78,8 @@ class Bugsnag_Notification
     }
 
     private function transform($str) {
-        if (mb_detect_encoding((string) $str,'UTF-8',true) == false) {
+        $str = (string) $str;
+        if (mb_detect_encoding($str,'UTF-8',true) == false) {
             return utf8_encode($str);
         }
         return $str;


### PR DESCRIPTION
"mb_detect_encoding() expects parameter 1 to be string, object given". Adding (string) prevents errors in the event $str is not a string.

Alternatively, you could use strval($str).

Typehinting scalar types won't work either.

I understand, the user should know to pass the string, but because it expects a string, we might as well typecast it for preventative measures.  And ironically, because the above error is thrown, I cannot identify the source or stacktrace quickly :)

Fix for #32 
