### PR TITLE
Explicitly check that values for notifying are strings.

### DIFF
--- a/src/Bugsnag/Notification.php
+++ b/src/Bugsnag/Notification.php
@@ -91,7 +91,7 @@ class Bugsnag_Notification
               if (is_array($value)) {
                   $newData[$this->transform($key)] = $this->utf8($value);
               }
-              else {
+              elseif (is_string($value)) {
                   $newData[$this->transform($key)] = $this->transform($value);
               }
            }


### PR DESCRIPTION
Some background: we have a custom session adaptor set to $_SESSION that implements ArrayAccess. When trying out bugsnag we kept getting errors in our error handling and couldn't submit anything.

It appears that because transform always checkes mb_detect_encoding() that it's safe to assume all values are meant to be strings, so this should be a sane short term fix.

Longer term: we'd like to be able to populate the session tab, is there a change to the API where we can maybe set a function for populating session manually?
