### PR TITLE
Fix the cleanup method with boolean values

### DIFF
--- a/src/Bugsnag/Error.php
+++ b/src/Bugsnag/Error.php
@@ -224,7 +224,7 @@ class Bugsnag_Error
             }
 
             return $cleanArray;
-        } else if (is_numeric($obj)) {
+        } else if (is_numeric($obj) || is_bool($obj)) {
             return $obj;
         } else if (is_string($obj)) {
             // UTF8-encode if not already encoded


### PR DESCRIPTION
Added an additional check for boolean values.

Revision [49e5d60] added the new cleanup method but this one fails when dealing with boolean values.

This method basically uses `is_array()` + `is_numeric()` + `is_string()` checks, if no one of these succeed a `json_decode(json_encode())` trick is triggered, which fails with a boolean value, causing an infinite loop.
