### PR TITLE
Add support for groupingHash option.

### DIFF
--- a/src/Bugsnag/Client.php
+++ b/src/Bugsnag/Client.php
@@ -200,6 +200,18 @@ class Bugsnag_Client
     }
 
     /**
+     * Set a groupingHash to group the errors at Bugsnag.com
+     *
+     * @param String $groupingHash the current context
+     */
+    public function setGroupingHash($groupingHash)
+    {
+        $this->config->groupingHash = $groupingHash;
+
+        return $this;
+    }
+
+    /**
      * Set the type of application executing the code. This is usually used to
      * represent if you are running plain PHP code "php", via a framework,
      * eg "laravel", or executing through delayed worker code, eg "resque".

--- a/src/Bugsnag/Configuration.php
+++ b/src/Bugsnag/Configuration.php
@@ -24,6 +24,7 @@ class Bugsnag_Configuration
     public $stripPathRegex;
 
     public $context;
+    public $groupingHash;
     public $type;
     public $user;
     public $releaseStage = 'production';

--- a/src/Bugsnag/Diagnostics.php
+++ b/src/Bugsnag/Diagnostics.php
@@ -40,6 +40,11 @@ class Bugsnag_Diagnostics
         return $this->config->get('context', Bugsnag_Request::getContext());
     }
 
+    public function getGroupingHash()
+    {
+        return $this->config->get('groupingHash', Bugsnag_Request::getGroupingHash());
+    }
+    
     public function getUser()
     {
         $defaultUser = array();

--- a/src/Bugsnag/Error.php
+++ b/src/Bugsnag/Error.php
@@ -170,6 +170,7 @@ class Bugsnag_Error
             'device' => $this->diagnostics->getDeviceData(),
             'user' => $this->diagnostics->getUser(),
             'context' => $this->diagnostics->getContext(),
+            'groupingHash' => $this->diagnostics->getGroupingHash(),
             'payloadVersion' => $this->payloadVersion,
             'severity' => $this->severity,
             'exceptions' => $this->exceptionArray(),

--- a/src/Bugsnag/Request.php
+++ b/src/Bugsnag/Request.php
@@ -60,6 +60,15 @@ class Bugsnag_Request
         }
     }
 
+    public static function getGroupingHash()
+    {
+        if (self::isRequest() && isset($_SERVER['REQUEST_METHOD']) && isset($_SERVER["REQUEST_URI"])) {
+            return $_SERVER['REQUEST_METHOD'] . ' ' . strtok($_SERVER["REQUEST_URI"], '?');
+        } else {
+            return null;
+        }
+    }
+
     public static function getUserId()
     {
         if (self::isRequest()) {

--- a/tests/Bugsnag/DiagnosticsTest.php
+++ b/tests/Bugsnag/DiagnosticsTest.php
@@ -38,6 +38,12 @@ class DiagnosticsTest extends PHPUnit_Framework_TestCase
         $this->assertEquals($this->diagnostics->getContext(), 'herp#derp');
     }
 
+    public function testDefaultGroupingHash()
+    {
+        $this->config->groupingHash = 'herp#derp';
+        $this->assertEquals($this->diagnostics->getGroupingHash(), 'herp#derp');
+    }
+    
     public function testDefaultUser()
     {
         $this->config->user = array('id' => 123, 'email' => "test@email.com", 'name' => "Bob Hoskins");

--- a/tests/Bugsnag/RequestTest.php
+++ b/tests/Bugsnag/RequestTest.php
@@ -25,6 +25,11 @@ class RequestTest extends PHPUnit_Framework_TestCase
         $this->assertEquals(Bugsnag_Request::getContext(), "GET /blah/blah.php");
     }
 
+    public function testGetGroupingHash()
+    {
+        $this->assertEquals(Bugsnag_Request::getGroupingHash(), "GET /blah/blah.php");
+    }
+    
     public function testGetCurrentUrl()
     {
         $this->assertEquals(Bugsnag_Request::getCurrentUrl(), "http://example.com/blah/blah.php?some=param");


### PR DESCRIPTION
Added support for the groupingHash option. The default groupingHash is the request method and URI (just like the default context). This may change the default grouping behavior, as currently the groupingHash is not sent. This option can be set in the same manner that the context is set.
