### PR TITLE
Add setGroupingHash function to Bugsnag_Error class.

### DIFF
--- a/src/Bugsnag/Error.php
+++ b/src/Bugsnag/Error.php
@@ -18,6 +18,7 @@ class Bugsnag_Error
     public $diagnostics;
     public $code;
     public $previous;
+    public $groupingHash;
 
     // Static error creation methods, to ensure that Error object is always complete
     public static function fromPHPError(Bugsnag_Configuration $config, Bugsnag_Diagnostics $diagnostics, $code, $message, $file, $line, $fatal=false)
@@ -68,6 +69,13 @@ class Bugsnag_Error
         return $this;
     }
 
+    public function setGroupingHash($groupingHash)
+    {
+        $this->groupingHash = $groupingHash;
+
+        return $this;
+    }
+    
     public function setStacktrace($stacktrace)
     {
         $this->stacktrace = $stacktrace;
@@ -165,7 +173,7 @@ class Bugsnag_Error
 
     public function toArray()
     {
-        return array(
+        $errorArray = array(
             'app' => $this->diagnostics->getAppData(),
             'device' => $this->diagnostics->getDeviceData(),
             'user' => $this->diagnostics->getUser(),
@@ -175,6 +183,12 @@ class Bugsnag_Error
             'exceptions' => $this->exceptionArray(),
             'metaData' => $this->cleanupObj($this->metaData)
         );
+        
+        if (isset($this->groupingHash)) {
+        	$errorArray['groupingHash'] = $this->groupingHash;
+        }
+        
+        return $errorArray;
     }
 
     public function exceptionArray()

--- a/tests/Bugsnag/ErrorTest.php
+++ b/tests/Bugsnag/ErrorTest.php
@@ -129,4 +129,18 @@ class errorTest extends Bugsnag_TestCase
             $this->assertEquals($errorArray['exceptions'][1]['message'], 'secondly');
         }
     }
+    
+    public function testErrorGroupingHash()
+    {
+        $this->error->setGroupingHash('herp#derp');
+
+        $errorArray = $this->error->toArray();
+        $this->assertEquals($errorArray['groupingHash'], 'herp#derp');
+    }
+    
+    public function testErrorGroupingHashNotSet()
+    {
+        $errorArray = $this->error->toArray();
+        $this->assertNull($errorArray['groupingHash']);
+    }
 }


### PR DESCRIPTION
Added a setGroupingHash method to the Bugsnag_Error class. This is meant to be set in the beforeNotifyFunction. The Error.toArray() method was updated to only add the groupingHash to the array if it has been set.
