### PR TITLE
Added ext-mbstring as a dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
 
     "require": {
         "php": ">=5.2.0",
-		"ext-mbstring": "*"
+        "ext-mbstring": "*"
     },
 
     "require-dev": {


### PR DESCRIPTION
In https://github.com/bugsnag/bugsnag-php/blob/master/src/Bugsnag/Error.php#L229 `mbstring` is used. My app just broke because I hadn't installed it. It should probably be a requirement.
