### PR TITLE
Added custom curl options support

### DIFF
--- a/src/Bugsnag/Client.php
+++ b/src/Bugsnag/Client.php
@@ -264,6 +264,21 @@ class Bugsnag_Client
     }
 
     /**
+     * Set custom curl options
+     *
+     * @param Array $curlOptions an array with curl options. Eg:
+     *        array(
+     *            CURLOPT_IPRESOLVE => CURL_IPRESOLVE_V4
+     *            )
+     */
+    public function setCurlOptions(array $curlOptions)
+    {
+        $this->config->curlOptions = $curlOptions;
+
+        return $this;
+    }
+
+    /**
      * Set a custom function to call before notifying Bugsnag of an error.
      * You can use this to call your own error handling functions, or to add
      * custom tabs of data to each error on your Bugsnag dashboard.

--- a/src/Bugsnag/Configuration.php
+++ b/src/Bugsnag/Configuration.php
@@ -37,6 +37,8 @@ class Bugsnag_Configuration
     public $beforeNotifyFunction;
     public $errorReportingLevel;
 
+    public $curlOptions = array();
+
     public function __construct()
     {
         $this->timeout = Bugsnag_Configuration::$DEFAULT_TIMEOUT;

--- a/src/Bugsnag/Notification.php
+++ b/src/Bugsnag/Notification.php
@@ -108,6 +108,11 @@ class Bugsnag_Notification
         curl_setopt($http, CURLOPT_SSL_VERIFYPEER, false);
         curl_setopt($http, CURLOPT_VERBOSE, false);
 
+        if (!empty($this->config->curlOptions)) {
+            foreach ($this->config->curlOptions as $option => $value)  {
+                curl_setopt($http, $option, $value);
+            }
+        }
         // Apply proxy settings (if present)
         if (count($this->config->proxySettings)) {
             if (isset($this->config->proxySettings['host'])) {

--- a/tests/Bugsnag/ClientTest.php
+++ b/tests/Bugsnag/ClientTest.php
@@ -71,4 +71,12 @@ class ClientTest extends PHPUnit_Framework_TestCase
         $this->client->setErrorReportingLevel(E_ALL & ~E_NOTICE)
                      ->errorHandler(E_NOTICE, "Something broke", "somefile.php", 123);
     }
+
+    /**
+     * @expectedException PHPUnit_Framework_Error
+     */
+    public function testSetInvalidCurlOptions()
+    {
+        $return = $this->client->setCurlOptions("option");
+    }
 }


### PR DESCRIPTION
To have the opportunity to add curl options when notification is send.
I want to change default CURLOPT_IPRESOLVE from CURL_IPRESOLVE_WHATEVER to CURL_IPRESOLVE_V4  or CURL_IPRESOLVE_V6 .
It takes 5 sec to send notification when CURLOPT_IPRESOLVE is set to default, change this option reduce time to 0.2 sec.