### PR TITLE
Include class names for class methods in stacktrace

### DIFF
--- a/src/Bugsnag/Stacktrace.php
+++ b/src/Bugsnag/Stacktrace.php
@@ -87,7 +87,7 @@ class Bugsnag_Stacktrace
         // Construct the frame
         $frame = array(
             'lineNumber' => $line,
-            'method' => $method,
+            'method' => $class ? "$class::$method" : $method,
         );
 
         // Attach some lines of code for context
@@ -103,10 +103,6 @@ class Bugsnag_Stacktrace
             $frame['file'] = $file;
         } else {
             $frame['file'] = preg_replace($this->config->stripPathRegex, '', $file);
-        }
-
-        if (!empty($class)) {
-            $frame['class'] = $class;
         }
 
         $this->frames[] = $frame;

--- a/tests/Bugsnag/StacktraceTest.php
+++ b/tests/Bugsnag/StacktraceTest.php
@@ -86,9 +86,9 @@ class StacktraceTest extends Bugsnag_TestCase
 
         $this->assertCount(5, $stacktrace);
 
-        $this->assertFrameEquals($stacktrace[0], "__callStatic", "somefile.php", 123);
-        $this->assertFrameEquals($stacktrace[1], "notifyError", "controllers/ExampleController.php", 12);
-        $this->assertFrameEquals($stacktrace[2], "index", "controllers/ExampleController.php", 12);
+        $this->assertFrameEquals($stacktrace[0], "Illuminate\\Support\\Facades\\Facade::__callStatic", "somefile.php", 123);
+        $this->assertFrameEquals($stacktrace[1], "Bugsnag\\BugsnagLaravel\\BugsnagFacade::notifyError", "controllers/ExampleController.php", 12);
+        $this->assertFrameEquals($stacktrace[2], "ExampleController::index", "controllers/ExampleController.php", 12);
         $this->assertFrameEquals($stacktrace[3], "call_user_func_array", "[internal]", 0);
         $this->assertFrameEquals($stacktrace[4], "[main]", "Routing/Controller.php", 194);
     }
@@ -101,11 +101,11 @@ class StacktraceTest extends Bugsnag_TestCase
         $this->assertCount(7, $stacktrace);
 
         $this->assertFrameEquals($stacktrace[0], null, "somefile.php", 123);
-        $this->assertFrameEquals($stacktrace[1], "evaluatePath", "/View/Engines/PhpEngine.php", 39);
-        $this->assertFrameEquals($stacktrace[2], "get", "View/Engines/CompilerEngine.php", 57);
-        $this->assertFrameEquals($stacktrace[3], "getContents", "View/View.php", 136);
-        $this->assertFrameEquals($stacktrace[4], "renderContents", "View/View.php", 104);
-        $this->assertFrameEquals($stacktrace[5], "render", "View/View.php", 78);
+        $this->assertFrameEquals($stacktrace[1], "Illuminate\\View\\Engines\\PhpEngine::evaluatePath", "/View/Engines/PhpEngine.php", 39);
+        $this->assertFrameEquals($stacktrace[2], "Illuminate\\View\\Engines\\CompilerEngine::get", "View/Engines/CompilerEngine.php", 57);
+        $this->assertFrameEquals($stacktrace[3], "Illuminate\\View\\View::getContents", "View/View.php", 136);
+        $this->assertFrameEquals($stacktrace[4], "Illuminate\\View\\View::renderContents", "View/View.php", 104);
+        $this->assertFrameEquals($stacktrace[5], "Illuminate\\View\\View::render", "View/View.php", 78);
         $this->assertFrameEquals($stacktrace[6], "[main]", "storage/views/f2df2d6b49591efeb36fc46e6dc25e0e", 5);
     }
 


### PR DESCRIPTION
- Include the class name in the "method" property for each stack frame.
- Remove "class" property which doesn't exist according to https://bugsnag.com/docs/notifier-api