### PR TITLE
Encode non UTF-8 before send

### DIFF
--- a/src/Bugsnag/Notification.php
+++ b/src/Bugsnag/Notification.php
@@ -92,6 +92,7 @@ class Bugsnag_Notification
 
     public function postJSON($url, $data)
     {
+        $data = $this->utf8($data);
         $body = json_encode($data);
 
         // Prefer cURL if it is installed, otherwise fall back to fopen()
@@ -192,6 +193,26 @@ class Bugsnag_Notification
             }
         } else {
             error_log('Bugsnag Warning: Couldn\'t notify (fopen failed)');
+        }
+    }
+
+    private function utf8($data)
+    {
+        if (is_array($data)) {
+            $cleanArray = array();
+            foreach ($data as $key => $value) {
+                $cleanArray[$key] = $this->utf8($value);
+            }
+            return $cleanArray;
+        } elseif (is_string($data)) {
+            // UTF8-encode if not already encoded
+            if (function_exists('mb_detect_encoding') && !mb_detect_encoding($data, 'UTF-8', true)) {
+                return utf8_encode($data);
+            } else {
+                return $data;
+            }
+        } else {
+            return $data;
         }
     }
 }


### PR DESCRIPTION
I have an problem with my project that is encoded in `ISO-8859-1` if the exception message or the code snippet contains non UTF-8 the request fails as `json_encode` returns false on the data.

In this commit https://github.com/bugsnag/bugsnag-php/commit/23a34e1fadfe66bd2578deddb3553531e6c550d5 there was implmented a fix for this (same as mine) but it was rewritten in this commit https://github.com/bugsnag/bugsnag-php/commit/49e5d600014990255d1951fb4c14592d32b70b97 to only affect the metaData array.

What do you think?