### PR TITLE
Make Configuration and Diagnostics injected to Client through constructor parameters

### DIFF
--- a/tests/Bugsnag/ClientTest.php
+++ b/tests/Bugsnag/ClientTest.php
@@ -23,7 +23,7 @@ class ClientTest extends PHPUnit_Framework_TestCase
     public function testConstructThrowsWhenConfigNotStringNorConfig()
     {
         $this->setExpectedException('InvalidArgumentException');
-        new Bugsnag_Client([]);
+        new Bugsnag_Client(array());
     }
 
     public function testConstructThrowsWhenDiagnosticsIsSetWithoutConfig()

--- a/tests/Bugsnag/ClientTest.php
+++ b/tests/Bugsnag/ClientTest.php
@@ -34,6 +34,10 @@ class ClientTest extends PHPUnit_Framework_TestCase
 
     public function testConstructWithApiKey()
     {
+        if (PHP_VERSION_ID < 50300) {
+            $this->markTestSkipped('ReflectionProperty::setAccessible() is not available on PHP ' . PHP_VERSION);
+        }
+
         $client = new Bugsnag_Client('api-key');
         $config = $this->getNotAccessibleProperty($client, 'config');
         $this->assertEquals('api-key', $config->apiKey);
@@ -42,6 +46,10 @@ class ClientTest extends PHPUnit_Framework_TestCase
 
     public function testConstructWithConfigurationInstance()
     {
+        if (PHP_VERSION_ID < 50300) {
+            $this->markTestSkipped('ReflectionProperty::setAccessible() is not available on PHP ' . PHP_VERSION);
+        }
+
         $config = new Bugsnag_Configuration();
         $config->apiKey = 'api-key';
         $client = new Bugsnag_Client($config);
@@ -52,6 +60,10 @@ class ClientTest extends PHPUnit_Framework_TestCase
 
     public function testConstructWithConfigurationInstanceAndDiagnostics()
     {
+        if (PHP_VERSION_ID < 50300) {
+            $this->markTestSkipped('ReflectionProperty::setAccessible() is not available on PHP ' . PHP_VERSION);
+        }
+
         $config = new Bugsnag_Configuration();
         $config->apiKey = 'api-key';
         $diagnostics = new Bugsnag_Diagnostics($config);


### PR DESCRIPTION
Current implementation has one drawback when it comes to writing custom notification process.

There is a public method `notify(Bugsnag_Error $error, $metaData = array())` which allows to notify using custom constructed `Bugsnag_Error` instance. The only problem is that consumer cannot construct this object correctly because `Bugsnag_Error::_construct` demands passing `Bugsnag_Configuration` instance along with `Bugsnag_Diagnostics` for self initialisation. Instances of these classes are created in constructor of `Bugsang_Client` and kept there private. In the end nevertheless `Bugsang_Client::notify` method being public it is not possible to use it without faking `Bugsnag_Configuration` and `Bugsnag_Diagnostics` instances or extracting them from `Bugsang_Client` using reflection hacks.

This PR fixes this problem by allowing injection of `Bugsnag_Configuration` and `Bugsnag_Diagnostics` as constructor parameters to `Bugsang_Client`. It maintains backward compatibility with previous implementation.

Some topics for further discussion:
1. Should the set* methods be moved to `Bugsnag_Configuration` from `Bugsang_Client`?
2. Should the construction of `Bugsang_Client` be moved to a factory class?