### PR TITLE
PHP 7 Throwable support:  Error handling type hints to Throwable w/ renamed variables to reflect the change

### DIFF
--- a/src/Bugsnag/Client.php
+++ b/src/Bugsnag/Client.php
@@ -454,9 +454,9 @@ class Bugsnag_Client
      * @param Array     $metaData  optional metaData to send with this error
      * @param String    $severity  optional severity of this error (fatal/error/warning/info)
      */
-    public function notifyException(Exception $exception, array $metaData = null, $severity = null)
+    public function notifyException(Throwable $throwable, array $metaData = null, $severity = null)
     {
-        $error = Bugsnag_Error::fromPHPException($this->config, $this->diagnostics, $exception);
+        $error = Bugsnag_Error::fromPHPThrowable($this->config, $this->diagnostics, $throwable);
         $error->setSeverity($severity);
 
         $this->notify($error, $metaData);
@@ -479,13 +479,13 @@ class Bugsnag_Client
     }
 
     // Exception handler callback, should only be called internally by PHP's set_exception_handler
-    public function exceptionHandler($exception)
+    public function exceptionHandler($throwable)
     {
         if(!$this->config->autoNotify) {
             return;
         }
 
-        $error = Bugsnag_Error::fromPHPException($this->config, $this->diagnostics, $exception);
+        $error = Bugsnag_Error::fromPHPThrowable($this->config, $this->diagnostics, $throwable);
         $error->setSeverity("error");
         $this->notify($error);
     }

--- a/src/Bugsnag/Error.php
+++ b/src/Bugsnag/Error.php
@@ -30,10 +30,10 @@ class Bugsnag_Error
         return $error;
     }
 
-    public static function fromPHPException(Bugsnag_Configuration $config, Bugsnag_Diagnostics $diagnostics, Exception $exception)
+    public static function fromPHPThrowable(Bugsnag_Configuration $config, Bugsnag_Diagnostics $diagnostics, Throwable $throwable)
     {
         $error = new Bugsnag_Error($config, $diagnostics);
-        $error->setPHPException($exception);
+        $error->setPHPException($throwable);
 
         return $error;
     }
@@ -143,7 +143,7 @@ class Bugsnag_Error
     public function setPrevious($exception)
     {
         if ($exception) {
-            $this->previous = Bugsnag_Error::fromPHPException($this->config, $this->diagnostics, $exception);
+            $this->previous = Bugsnag_Error::fromPHPThrowable($this->config, $this->diagnostics, $exception);
         }
 
         return $this;

--- a/tests/Bugsnag/ErrorTest.php
+++ b/tests/Bugsnag/ErrorTest.php
@@ -105,7 +105,7 @@ class ErrorTest extends Bugsnag_TestCase
         if (version_compare(PHP_VERSION, '5.3.0', '>=')) {
             $exception = new Exception("secondly", 65533, new Exception("firstly"));
 
-            $error = Bugsnag_Error::fromPHPException($this->config, $this->diagnostics, $exception);
+            $error = Bugsnag_Error::fromPHPThrowable($this->config, $this->diagnostics, $exception);
 
             $errorArray = $error->toArray();
 


### PR DESCRIPTION
PHP 7 changes the way Exceptions are thrown.  Errors are thrown now instead of Exceptions for errors (see http://php.net/manual/en/language.errors.php7.php).  Bugsnag was hinted to just for the Exception type, which Error doesn't inherit from.  Both Error and Exception implement the Throwable interface when thrown.