### PR TITLE
Fix for stacktrace not encoded in UTF-8

### DIFF
--- a/src/Bugsnag/Error.php
+++ b/src/Bugsnag/Error.php
@@ -180,7 +180,7 @@ class Bugsnag_Error
         $exceptionArray[] = array(
             'errorClass' => $this->name,
             'message' => $this->message,
-            'stacktrace' => $this->stacktrace->toArray(),
+            'stacktrace' => $this->cleanupObj($this->stacktrace->toArray()),
         );
 
         return $exceptionArray;


### PR DESCRIPTION
Actually, the stacktrace isn't encoded in UTF-8. When try to send data, json_encode return false and the request return 401 Bad Request.

I think the line 228 can cause encoding problem too.