### PR TITLE
Fix for error or message not encoded in UTF-8

### DIFF
--- a/src/Bugsnag/Error.php
+++ b/src/Bugsnag/Error.php
@@ -180,10 +180,10 @@ class Bugsnag_Error
         $exceptionArray[] = array(
             'errorClass' => $this->name,
             'message' => $this->message,
-            'stacktrace' => $this->cleanupObj($this->stacktrace->toArray()),
+            'stacktrace' => $this->stacktrace->toArray(),
         );
 
-        return $exceptionArray;
+        return $this->cleanupObj($exceptionArray);
     }
 
     private function cleanupObj($obj)


### PR DESCRIPTION
Added compatibility with customized errors if they are not encoded in UTF-8.