### PR TITLE
Fixed phpunit version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
     },
 
     "require-dev": {
-        "phpunit/phpunit": "3.7.*"
+        "phpunit/phpunit": "~4.8|~5.0"
     },
 
     "autoload": {


### PR DESCRIPTION
PHPUnit 5 is the first version to actually support PHP 7.