### PR TITLE
Prevent undefined index error when $_SERVER['SERVER_PORT'] is not set

### DIFF
--- a/src/Bugsnag/Request.php
+++ b/src/Bugsnag/Request.php
@@ -59,7 +59,7 @@ class Bugsnag_Request
 
     public static function getCurrentUrl()
     {
-        $schema = ((!empty($_SERVER['HTTPS']) && $_SERVER['HTTPS'] !== 'off') || $_SERVER['SERVER_PORT'] == 443) ? 'https://' : 'http://';
+        $schema = ((!empty($_SERVER['HTTPS']) && $_SERVER['HTTPS'] !== 'off') || (!empty($_SERVER['SERVER_PORT']) && $_SERVER['SERVER_PORT'] == 443)) ? 'https://' : 'http://';
 
         return $schema.$_SERVER['HTTP_HOST'].$_SERVER['REQUEST_URI'];
     }


### PR DESCRIPTION
Prevent undefined index index error when $_SERVER['SERVER_PORT'] is not set
This resolve an issue on Google App Engine

Error from Google App Engine:
```
PHP Fatal error:  Uncaught exception 'ErrorException' with message 'Undefined index: SERVER_PORT' in /base/data/home/apps/s~test-service/1.390125015019760302/vendor/bugsnag/bugsnag/src/Bugsnag/Request.php:62
```