### PR TITLE
Fixed PHP7 compatibility

### DIFF
--- a/src/Bugsnag/Error.php
+++ b/src/Bugsnag/Error.php
@@ -96,8 +96,20 @@ class Bugsnag_Error
         return $this;
     }
 
-    public function setPHPException(Exception $exception)
+    public function setPHPException($exception)
     {
+        if (version_compare(PHP_VERSION, '7.0.0', '>=')) {
+            if (!$exception instanceof \Throwable) {
+                error_log('Bugsnag Warning: Exception must implement interface \Throwable.');
+                return;
+            }
+        } else {
+            if (!$exception instanceof \Exception) {
+                error_log('Bugsnag Warning: Exception must be instance of \Exception.');
+                return;
+            }
+        }
+
         $this->setName(get_class($exception))
              ->setMessage($exception->getMessage())
              ->setStacktrace(Bugsnag_Stacktrace::fromBacktrace($this->config, $exception->getTrace(), $exception->getFile(), $exception->getLine()));

--- a/tests/Bugsnag/ErrorTest.php
+++ b/tests/Bugsnag/ErrorTest.php
@@ -128,4 +128,10 @@ class ErrorTest extends Bugsnag_TestCase
         $errorArray = $this->error->toArray();
         $this->assertArrayNotHasKey('groupingHash', $errorArray);
     }
+
+    public function testSetPHPException()
+    {
+        $exception = version_compare(PHP_VERSION, '7.0.0', '>=') ? new \Error() : new Exception();
+        $this->error->setPHPException($exception);
+    }
 }


### PR DESCRIPTION
In PHP7, the exception handler should resolve also "non-exception" objects. According to [Error hierarchy in PHP7](http://php.net/manual/en/language.errors.php7.php#language.errors.php7.hierarchy).

This pull request should fix also https://github.com/bugsnag/bugsnag-laravel/issues/89. 