### PR TITLE
Making it possible to delegate plain php errors to the Bugsnag client.

### DIFF
--- a/src/Bugsnag/Client.php
+++ b/src/Bugsnag/Client.php
@@ -480,6 +480,41 @@ class Bugsnag_Client
         $this->notify($error, $metaData);
     }
 
+    /**
+     * Notify Bugsnag of a regular PHP error. This is useful when Bugsnag is not
+     * the "main" error handler and errors are delegated by someone else.
+     *
+     * @param Int $code                 error code
+     * @param String $message           error message
+     * @param String $file              file path where the error occurred
+     * @param Int $line                 error line
+     * @param bool $fatal               whether the error is recoverable or not
+     * @param array|null $metadata      optional metaData to send with this error
+     * @param null $severity            optional severity of this error (fatal/error/warning/info)
+     */
+    public function notifyPHPError(
+        $code,
+        $message,
+        $file,
+        $line,
+        $fatal = false,
+        array $metadata = null,
+        $severity = null
+    ) {
+        $error = Bugsnag_Error::fromPHPError(
+            $this->config,
+            $this->diagnostics,
+            $code,
+            $message,
+            $file,
+            $line,
+            $fatal
+        );
+        $error->setSeverity($severity);
+
+        $this->notify($error, $metadata);
+    }
+
     // Exception handler callback, should only be called internally by PHP's set_exception_handler
     public function exceptionHandler($throwable)
     {

--- a/tests/Bugsnag/ClientTest.php
+++ b/tests/Bugsnag/ClientTest.php
@@ -50,6 +50,14 @@ class ClientTest extends PHPUnit_Framework_TestCase
         $this->client->notifyError("SomeError", "Some message");
     }
 
+    public function testManualPHPErrorNotification()
+    {
+        $this->client->expects($this->once())
+            ->method('notify');
+
+        $this->client->notifyPHPError(1, "Some Message", __FILE__, 10, false);
+    }
+
     public function testManualExceptionNotification()
     {
         $this->client->expects($this->once())


### PR DESCRIPTION
Right now it is not possible to delegate error information to the Bugsnag client. The method **notifyError** lacks several important parameters and leads to information loss. Please consider adding this small feature as soon as possible.