### PR TITLE
Only filter metadata, not exceptions

### DIFF
--- a/tests/Bugsnag/ErrorTest.php
+++ b/tests/Bugsnag/ErrorTest.php
@@ -44,6 +44,16 @@ class ErrorTest extends Bugsnag_TestCase
         $this->assertEquals($errorArray['metaData']['Testing']['password'], '[FILTERED]');
     }
 
+    public function testExceptionsNotFiltered()
+    {
+        $this->config->filters = array('code');
+        $this->error->setPHPError(E_NOTICE, "Broken", "file", 123);
+
+        $errorArray = $this->error->toArray();
+        // 'Code' should not be filtered so should remain still be an array
+        $this->assertInternalType('array', $errorArray['exceptions'][0]['stacktrace'][0]['code']);
+    }
+
     public function testNoticeName()
     {
         $this->error->setPHPError(E_NOTICE, "Broken", "file", 123);


### PR DESCRIPTION
Currently any filters set using `$bugsnag->setFilters` will filter values that match the key in 'exceptions' in addition to keys in 'metadata'.  This means that the 'code' element can be assigned the string "[FILTERED]".  Although this is currently accepted by Bugsnag, it doesn't meet the schema so may not be in the future.

The correct way to prevent code snippets from being sent is to use the existing `$bugsnag->setSendCode(false)`.