### PR TITLE
Fix curl performance

### DIFF
--- a/src/Bugsnag/Notification.php
+++ b/src/Bugsnag/Notification.php
@@ -113,7 +113,7 @@ class Bugsnag_Notification
         curl_setopt($http, CURLOPT_HEADER, false);
         curl_setopt($http, CURLOPT_RETURNTRANSFER, true);
         curl_setopt($http, CURLOPT_POST, true);
-        curl_setopt($http, CURLOPT_HTTPHEADER, array(Bugsnag_Notification::$CONTENT_TYPE_HEADER));
+        curl_setopt($http, CURLOPT_HTTPHEADER, array(Bugsnag_Notification::$CONTENT_TYPE_HEADER, "Expect:"));
         curl_setopt($http, CURLOPT_POSTFIELDS, $body);
         curl_setopt($http, CURLOPT_CONNECTTIMEOUT, $this->config->timeout);
         curl_setopt($http, CURLOPT_SSL_VERIFYPEER, false);


### PR DESCRIPTION
See https://github.com/bugsnag/bugsnag-agent/issues/8 for more. Curl adds an `Expect` header which causes the agent to trip up and cause undue delays.

The other alternative is to force an `HTTP/1.0` connection.