### PR TITLE
Autoloader Fix

### DIFF
--- a/src/Bugsnag/Autoload.php
+++ b/src/Bugsnag/Autoload.php
@@ -8,8 +8,8 @@
 require_once dirname(__FILE__).DIRECTORY_SEPARATOR."Client.php";
 require_once dirname(__FILE__).DIRECTORY_SEPARATOR."Configuration.php";
 require_once dirname(__FILE__).DIRECTORY_SEPARATOR."Diagnostics.php";
-require_once dirname(__FILE__).DIRECTORY_SEPARATOR."Error.php";
 require_once dirname(__FILE__).DIRECTORY_SEPARATOR."ErrorTypes.php";
+require_once dirname(__FILE__).DIRECTORY_SEPARATOR."Error.php";
 require_once dirname(__FILE__).DIRECTORY_SEPARATOR."Notification.php";
 require_once dirname(__FILE__).DIRECTORY_SEPARATOR."Request.php";
 require_once dirname(__FILE__).DIRECTORY_SEPARATOR."Stacktrace.php";


### PR DESCRIPTION
 Class 'Bugsnag_ErrorTypes' not found in vendor/bugsnag/bugsnag/src/Bugsnag/Error.php on line 138