### PR TITLE
Use request naming for IP to fix filtering by IP

### DIFF
--- a/src/Bugsnag/Request.php
+++ b/src/Bugsnag/Request.php
@@ -41,7 +41,7 @@ class Bugsnag_Request
             }
         }
 
-        $requestData['request']['ip'] = self::getRequestIp();
+        $requestData['request']['clientIp'] = self::getRequestIp();
         if (isset($_SERVER['HTTP_USER_AGENT'])) {
             $requestData['request']['userAgent'] = $_SERVER['HTTP_USER_AGENT'];
         }


### PR DESCRIPTION
The naming of the IP field in the request metadata should be "clientIp" as this is what we use in other notifiers. Changing this will fix the problem of being unable to filter by "request ip" in the PHP notifier.