### PR TITLE
Use branch aliases

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,5 +23,10 @@
         "psr-0" : {
             "Bugsnag_" : "src/"
         }
-    }
+    },
+    "extra": {
+        "branch-alias": {
+            "dev-master": "2.7-dev"
+        }
+    },
 }

--- a/composer.json
+++ b/composer.json
@@ -28,5 +28,5 @@
         "branch-alias": {
             "dev-master": "2.7-dev"
         }
-    },
+    }
 }


### PR DESCRIPTION
Composer supports branch aliases, so someone can ask for `2.7.*@dev`, and get our master branch so they don't have to use the horrible `dev-master` hack.