### PR TITLE
Implements merging of metadata values in Bugsnag_Client::setMetaData()

### DIFF
--- a/src/Bugsnag/Client.php
+++ b/src/Bugsnag/Client.php
@@ -33,6 +33,22 @@ class Bugsnag_Client
     }
 
     /**
+     * Returns client config object or a single property
+     * if provided
+     *
+     * @param string|null $prop
+     * @return mixed
+     */
+    public function getConfig($prop = null)
+    {
+        if ($prop) {
+            return $this->config->get($prop);
+        }
+
+        return $this->config;
+    }
+
+    /**
      * Set your release stage, eg "production" or "development".
      *
      * @param string $releaseStage the app's current release stage
@@ -292,7 +308,7 @@ class Bugsnag_Client
      */
     public function setMetaData(array $metaData)
     {
-        $this->config->metaData = $metaData;
+        $this->config->metaData = array_merge_recursive($this->config->metaData, $metaData);
 
         return $this;
     }

--- a/src/Bugsnag/Configuration.php
+++ b/src/Bugsnag/Configuration.php
@@ -35,7 +35,7 @@ class Bugsnag_Configuration
     public $appVersion;
     public $hostname;
 
-    public $metaData;
+    public $metaData = array();
     public $beforeNotifyFunction;
     public $errorReportingLevel;
 

--- a/tests/Bugsnag/ClientTest.php
+++ b/tests/Bugsnag/ClientTest.php
@@ -94,4 +94,27 @@ class ClientTest extends PHPUnit_Framework_TestCase
         }
         $this->client->setCurlOptions('option');
     }
+
+    public function testGetConfig()
+    {
+        $this->assertInstanceOf('Bugsnag_Configuration', $this->client->getConfig());
+    }
+
+    public function testSetMetaData()
+    {
+        $this->client->setMetaData(array('Testing' => array('globalArray' => 'hi')));
+
+        $metaData = $this->client->getConfig('metaData');
+        $this->assertEquals($metaData['Testing']['globalArray'], 'hi');
+    }
+
+    public function testMetaDataMerging()
+    {
+        $this->client->setMetaData(array('Testing' => array('globalArray' => 'hi')));
+        $this->client->setMetaData(array('Testing' => array('localArray' => 'yo')));
+
+        $metaData = $this->client->getConfig('metaData');
+        $this->assertEquals($metaData['Testing']['globalArray'], 'hi');
+        $this->assertEquals($metaData['Testing']['localArray'], 'yo');
+    }
 }


### PR DESCRIPTION
This is intended to fix #121 and also introduces a `getConfig` method for the client which seems like a useful addition and also facilitates testing of the client config.

If exposing the client config is a problem due to the accessibility of the API key is there a better way to facilitate testing of the private config variable?