### PR TITLE
Added another test

### DIFF
--- a/tests/Bugsnag/ErrorTest.php
+++ b/tests/Bugsnag/ErrorTest.php
@@ -141,8 +141,14 @@ class ErrorTest extends Bugsnag_TestCase
 
     public function testSetPHPException()
     {
-        $exception = version_compare(PHP_VERSION, '7.0.0', '>=') ? new Error() : new Exception();
-        $this->error->setPHPException($exception);
+        $this->assertSame($this->error, $this->error->setPHPException(new Exception()));
+    }
+
+    public function testSetPHPAnotherException()
+    {
+        $exception = version_compare(PHP_VERSION, '7.0.0', '>=') ? new ParseError() : new InvalidArgumentException();
+
+        $this->assertSame($this->error, $this->error->setPHPException($exception));
     }
 
     /**


### PR DESCRIPTION
We were not actually checking that normal exceptions still worked on php 7 before.