### PR TITLE
Fixed a regression where the message was cast to empty string

### DIFF
--- a/src/Bugsnag/Error.php
+++ b/src/Bugsnag/Error.php
@@ -69,7 +69,7 @@ class Bugsnag_Error
     public function setMessage($message)
     {
         if (is_scalar($message) || method_exists($message, '__toString')) {
-            $this->message = (string) $message;
+            $this->message = $message ? (string) $message : null;
         } else {
             throw new InvalidArgumentException('Message must be a string.');
         }

--- a/src/Bugsnag/Error.php
+++ b/src/Bugsnag/Error.php
@@ -68,8 +68,10 @@ class Bugsnag_Error
 
     public function setMessage($message)
     {
-        if (is_scalar($message) || method_exists($message, '__toString')) {
-            $this->message = $message ? (string) $message : null;
+        if ($message === null) {
+            $this->message = null;
+        } elseif (is_scalar($message) || method_exists($message, '__toString')) {
+            $this->message = (string) $message;
         } else {
             throw new InvalidArgumentException('Message must be a string.');
         }

--- a/tests/Bugsnag/ErrorTest.php
+++ b/tests/Bugsnag/ErrorTest.php
@@ -180,4 +180,11 @@ class ErrorTest extends Bugsnag_TestCase
 
         $this->assertSame('foo bar baz', $this->error->message);
     }
+
+    public function testNullSetMessage()
+    {
+        $this->error->setMessage(null);
+
+        $this->assertSame(null, $this->error->message);
+    }
 }

--- a/tests/Bugsnag/ErrorTest.php
+++ b/tests/Bugsnag/ErrorTest.php
@@ -181,6 +181,13 @@ class ErrorTest extends Bugsnag_TestCase
         $this->assertSame('foo bar baz', $this->error->message);
     }
 
+    public function testEmptySetMessage()
+    {
+        $this->error->setMessage('');
+
+        $this->assertSame('', $this->error->message);
+    }
+
     public function testNullSetMessage()
     {
         $this->error->setMessage(null);


### PR DESCRIPTION
We broke this yesterday.