### PR TITLE
Dropped autoNotify and added an exception handler

### DIFF
--- a/src/Configuration.php
+++ b/src/Configuration.php
@@ -7,7 +7,6 @@ use InvalidArgumentException;
 class Configuration
 {
     public $apiKey;
-    public $autoNotify = true;
     public $batchSending = true;
     public $notifyReleaseStages;
     public $filters = ['password'];

--- a/src/Handler.php
+++ b/src/Handler.php
@@ -1,0 +1,101 @@
+<?php
+
+namespace Bugsnag;
+
+class Handler
+{
+    /**
+     * The client instance.
+     *
+     * @var \Bugsnag\Client
+     */
+    protected $client;
+
+    /**
+     * Register our exception handler.
+     *
+     * @param \Bugsnag\Client $client
+     *
+     * @return static
+     */
+    public static function register(Client $client)
+    {
+        $handler = new static($client);
+
+        set_error_handler([$handler, 'errorHandler']);
+        set_exception_handler([$handler, 'exceptionHandler']);
+        register_shutdown_function([$handler, 'shutdownHandler']);
+
+        return $handler;
+    }
+
+    /**
+     * Create a new exception handler instance.
+     *
+     * @param \Bugsnag\Client $client
+     *
+     * @return void
+     */
+    protected function __construct(Client $client)
+    {
+        $this->client = $client;
+    }
+
+    /**
+     * Exception handler callback.
+     *
+     * @param \Throwable $throwable the exception was was thrown
+     *
+     * @return void
+     */
+    public function exceptionHandler($throwable)
+    {
+        $error = Error::fromPHPThrowable($this->client->getConfig(), $this->client->getDiagnostics(), $throwable);
+
+        $error->setSeverity('error');
+
+        $this->client->notify($error);
+    }
+
+    /**
+     * Error handler callback.
+     *
+     * @param int    $errno   the level of the error raised
+     * @param string $errstr  the error message
+     * @param string $errfile the filename that the error was raised in
+     * @param int    $errline the line number the error was raised at
+     *
+     * @return void
+     */
+    public function errorHandler($errno, $errstr, $errfile = '', $errline = 0)
+    {
+        if ($this->client->getConfig()->shouldIgnoreErrorCode($errno)) {
+            return;
+        }
+
+        $error = Error::fromPHPError($this->client->getConfig(), $this->client->getDiagnostics(), $errno, $errstr, $errfile, $errline);
+
+        $this->client->notify($error);
+    }
+
+    /**
+     * Shutdown handler callback.
+     *
+     * @return void
+     */
+    public function shutdownHandler()
+    {
+        // Get last error
+        $lastError = error_get_last();
+
+        // Check if a fatal error caused this shutdown
+        if (!is_null($lastError) && ErrorTypes::isFatal($lastError['type']) && !$this->client->getConfig()->shouldIgnoreErrorCode($lastError['type'])) {
+            $error = Error::fromPHPError($this->client->getConfig(), $this->client->getDiagnostics(), $lastError['type'], $lastError['message'], $lastError['file'], $lastError['line'], true);
+            $error->setSeverity('error');
+            $this->client->notify($error);
+        }
+
+        // Flush any buffered errors
+        $this->client->shutdownHandler();
+    }
+}

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -22,63 +22,18 @@ class ClientTest extends TestCase
                              ->getMock();
     }
 
-    public function testErrorHandler()
-    {
-        $this->client->expects($this->once())
-                     ->method('notify');
-
-        $this->client->errorHandler(E_WARNING, 'Something broke', 'somefile.php', 123);
-    }
-
-    public function testExceptionHandler()
-    {
-        $this->client->expects($this->once())
-                     ->method('notify');
-
-        $this->client->exceptionHandler(new Exception('Something broke'));
-    }
-
     public function testManualErrorNotification()
     {
-        $this->client->expects($this->once())
-                     ->method('notify');
+        $this->client->expects($this->once())->method('notify');
 
         $this->client->notifyError('SomeError', 'Some message');
     }
 
     public function testManualExceptionNotification()
     {
-        $this->client->expects($this->once())
-                     ->method('notify');
+        $this->client->expects($this->once())->method('notify');
 
         $this->client->notifyException(new Exception('Something broke'));
-    }
-
-    public function testErrorReportingLevel()
-    {
-        $this->client->expects($this->once())
-                     ->method('notify');
-
-        $this->client->setErrorReportingLevel(E_NOTICE)
-                     ->errorHandler(E_NOTICE, 'Something broke', 'somefile.php', 123);
-    }
-
-    public function testErrorReportingLevelFails()
-    {
-        $this->client->expects($this->never())
-                     ->method('notify');
-
-        $this->client->setErrorReportingLevel(E_NOTICE)
-                     ->errorHandler(E_WARNING, 'Something broke', 'somefile.php', 123);
-    }
-
-    public function testErrorReportingWithoutNotice()
-    {
-        $this->client->expects($this->never())
-                     ->method('notify');
-
-        $this->client->setErrorReportingLevel(E_ALL & ~E_NOTICE)
-                     ->errorHandler(E_NOTICE, 'Something broke', 'somefile.php', 123);
     }
 
     public function testBaseUri()

--- a/tests/HandlerTest.php
+++ b/tests/HandlerTest.php
@@ -1,0 +1,80 @@
+<?php
+
+namespace Bugsnag\Tests;
+
+use Bugsnag\Client;
+use Bugsnag\Configuration;
+use Bugsnag\Handler;
+use Exception;
+use PHPUnit_Framework_TestCase as TestCase;
+
+class HandlerTest extends TestCase
+{
+    /** @var \PHPUnit_Framework_MockObject_MockObject|\Bugsnag\Client */
+    protected $client;
+
+    protected function setUp()
+    {
+        // Mock the notify function
+        $this->client = $this->getMockBuilder(Client::class)
+                             ->setMethods(['notify'])
+                             ->setConstructorArgs([new Configuration('example-api-key')])
+                             ->getMock();
+    }
+
+    /**
+     * @runTestsInSeparateProcesses
+     */
+    public function testErrorHandler()
+    {
+        $this->client->expects($this->once())->method('notify');
+
+        Handler::register($this->client)->errorHandler(E_WARNING, 'Something broke', 'somefile.php', 123);
+    }
+
+    /**
+     * @runTestsInSeparateProcesses
+     */
+    public function testExceptionHandler()
+    {
+        $this->client->expects($this->once())->method('notify');
+
+        Handler::register($this->client)->exceptionHandler(new Exception('Something broke'));
+    }
+
+    /**
+     * @runTestsInSeparateProcesses
+     */
+    public function testErrorReportingLevel()
+    {
+        $this->client->expects($this->once())->method('notify');
+
+        $this->client->setErrorReportingLevel(E_NOTICE);
+
+        Handler::register($this->client)->errorHandler(E_NOTICE, 'Something broke', 'somefile.php', 123);
+    }
+
+    /**
+     * @runTestsInSeparateProcesses
+     */
+    public function testErrorReportingLevelFails()
+    {
+        $this->client->expects($this->never())->method('notify');
+
+        $this->client->setErrorReportingLevel(E_NOTICE);
+
+        Handler::register($this->client)->errorHandler(E_WARNING, 'Something broke', 'somefile.php', 123);
+    }
+
+    /**
+     * @runTestsInSeparateProcesses
+     */
+    public function testErrorReportingWithoutNotice()
+    {
+        $this->client->expects($this->never())->method('notify');
+
+        $this->client->setErrorReportingLevel(E_ALL & ~E_NOTICE);
+
+        Handler::register($this->client)->errorHandler(E_NOTICE, 'Something broke', 'somefile.php', 123);
+    }
+}


### PR DESCRIPTION
People can now just do this:

```php
$client = new Bugnsag\Client(new Bugsnag\Configuration('API-KEY'));

Bugnsag\Handler::register($client);
```

and they'll have our exception handler all set up for them to use natively.