### PR TITLE
Fixed broken header parsing

### DIFF
--- a/src/Bugsnag/Request.php
+++ b/src/Bugsnag/Request.php
@@ -121,10 +121,6 @@ class Bugsnag_Request
      */
     public static function getRequestHeaders()
     {
-        if (function_exists('getallheaders')) {
-            return getallheaders();
-        }
-
         $headers = array();
 
         foreach ($_SERVER as $name => $value) {


### PR DESCRIPTION
I was doing some detailed testing and found the output of this function is totally different to what we were assuming, and it completely doesn't work. Our use of the server variable instead should work just fine.