### PR TITLE
Fallback to localhost when HTTP_HOST is not set

### DIFF
--- a/src/Bugsnag/Request.php
+++ b/src/Bugsnag/Request.php
@@ -101,7 +101,9 @@ class Bugsnag_Request
     {
         $schema = ((!empty($_SERVER['HTTPS']) && $_SERVER['HTTPS'] !== 'off') || (!empty($_SERVER['SERVER_PORT']) && $_SERVER['SERVER_PORT'] == 443)) ? 'https://' : 'http://';
 
-        return $schema.$_SERVER['HTTP_HOST'].$_SERVER['REQUEST_URI'];
+        $host = isset($_SERVER['HTTP_HOST']) ? $_SERVER['HTTP_HOST'] : 'localhost';
+
+        return $schema.$host.$_SERVER['REQUEST_URI'];
     }
 
     /**


### PR DESCRIPTION
This is what symfony do when building an HTTP request: https://github.com/symfony/symfony/blob/2.7/src/Symfony/Component/HttpFoundation/Request.php#L314.