### PR TITLE
Don't allow usage on a security compromised version of guzzle

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
     }],
     "require": {
         "php": ">=5.5",
-        "guzzlehttp/guzzle": "^6.0"
+        "guzzlehttp/guzzle": "^6.2.1"
     },
     "require-dev": {
         "mtdowling/burgomaster": "dev-master#72151eddf5f0cf101502b94bf5031f9c53501a04",


### PR DESCRIPTION
Patches [CVE-2016-5385](https://httpoxy.org/).