### PR TITLE
Use composer's ca bundle

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
     },
     "suggest": {
         "composer/ca-bundle": "Composer's CA bundle can be useful if you are having pear verification issues."
-    }
+    },
     "autoload": {
         "psr-4" : {
             "Bugsnag\\" : "src/"

--- a/composer.json
+++ b/composer.json
@@ -12,15 +12,13 @@
     }],
     "require": {
         "php": ">=5.5",
+        "composer/ca-bundle": "^1.0",
         "guzzlehttp/guzzle": "^6.0"
     },
     "require-dev": {
         "mtdowling/burgomaster": "dev-master#72151eddf5f0cf101502b94bf5031f9c53501a04",
         "phpunit/phpunit": "^4.8|^5.0",
         "php-mock/php-mock-phpunit": "^1.1"
-    },
-    "suggest": {
-        "composer/ca-bundle": "Composer's CA bundle can be useful if you are having peer verification issues."
     },
     "autoload": {
         "psr-4" : {

--- a/composer.json
+++ b/composer.json
@@ -19,6 +19,9 @@
         "phpunit/phpunit": "^4.8|^5.0",
         "php-mock/php-mock-phpunit": "^1.1"
     },
+    "suggest": {
+        "composer/ca-bundle": "Composer's CA bundle can be useful if you are having pear verification issues."
+    }
     "autoload": {
         "psr-4" : {
             "Bugsnag\\" : "src/"

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
         "php-mock/php-mock-phpunit": "^1.1"
     },
     "suggest": {
-        "composer/ca-bundle": "Composer's CA bundle can be useful if you are having pear verification issues."
+        "composer/ca-bundle": "Composer's CA bundle can be useful if you are having peer verification issues."
     },
     "autoload": {
         "psr-4" : {

--- a/src/Client.php
+++ b/src/Client.php
@@ -115,7 +115,7 @@ class Client
             $options['cert'] = CaBundle::getSystemCaRootBundlePath();
         }
 
-        new Guzzle($options);
+        return new Guzzle($options);
     }
 
     /**

--- a/src/Client.php
+++ b/src/Client.php
@@ -68,7 +68,7 @@ class Client
     public static function make($apiKey = null, $endpoint = null, $defaults = true)
     {
         $config = new Configuration($apiKey ?: getenv('BUGSNAG_API_KEY'));
-        $guzzle = static::makeGuzle($endpoint ?: getenv('BUGSNAG_ENDPOINT'));
+        $guzzle = static::makeGuzzle($endpoint ?: getenv('BUGSNAG_ENDPOINT'));
 
         $client = new static($config, null, $guzzle);
 
@@ -93,7 +93,7 @@ class Client
         $this->config = $config;
         $this->resolver = $resolver ?: new BasicResolver();
         $this->pipeline = new Pipeline();
-        $this->http = new HttpClient($config, $guzzle ?: static::makeGuzle());
+        $this->http = new HttpClient($config, $guzzle ?: static::makeGuzzle());
 
         $this->pipeline->pipe(new NotificationSkipper($config));
 
@@ -107,7 +107,7 @@ class Client
      *
      * @return \GuzzleHttp\ClientInterface
      */
-    protected static function makeGuzle($base = null)
+    protected static function makeGuzzle($base = null)
     {
         $options = [
             'base_uri' => $base ?: static::ENDPOINT,

--- a/src/Client.php
+++ b/src/Client.php
@@ -109,11 +109,10 @@ class Client
      */
     protected static function makeGuzle($base = null)
     {
-        $options = ['base_uri' => $base ?: static::ENDPOINT];
-
-        if (class_exists(CaBundle::class)) {
-            $options['cert'] = CaBundle::getSystemCaRootBundlePath();
-        }
+        $options = [
+            'base_uri' => $base ?: static::ENDPOINT,
+            'cert' => CaBundle::getSystemCaRootBundlePath(),
+        ];
 
         return new Guzzle($options);
     }


### PR DESCRIPTION
If people are having pear verification issues, all they'll have to do is `composer require composer/ca-bundle`, and it'll start working. This may be particularly of use to Windows users.