### PR TITLE
Added a way to signify deploys

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -230,6 +230,34 @@ class Client
     }
 
     /**
+     * Notify Bugsnag of a deployment.
+     *
+     * @param string|null $repository the repository from which you are deploying the code
+     * @param string|null $branch     the source control branch from which you are deploying
+     * @param string|null $revision   the source control revision you are currently deploying
+     *
+     * @return void
+     */
+    public function deploy($repository = null, $branch = null, $revision = null)
+    {
+        $data = [];
+
+        if ($repository) {
+            $data['repository'] = $repository;
+        }
+
+        if ($branch) {
+            $data['branch'] = $branch;
+        }
+
+        if ($revision) {
+            $data['revision'] = $revision;
+        }
+
+        $this->http->deploy($data);
+    }
+
+    /**
      * Flush any buffered reports.
      *
      * @return void

--- a/src/HttpClient.php
+++ b/src/HttpClient.php
@@ -56,6 +56,28 @@ class HttpClient
     }
 
     /**
+     * Notify Bugsnag of a deployment.
+     *
+     * @param array $data the deployment information
+     *
+     * @return void
+     */
+    public function deploy(array $data)
+    {
+        $app = $this->config->getAppData();
+
+        $data['releaseStage'] = $app['releaseStage'];
+
+        if (isset($app['version'])) {
+            $data['appVersion'] = $app['version'];
+        }
+
+        $data['apiKey'] = $this->config->getApiKey();
+
+        $this->guzzle->request('POST', 'deploy', ['json' => $data]);
+    }
+
+    /**
      * Deliver everything on the queue to Bugsnag.
      *
      * @return void

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -203,4 +203,74 @@ class ClientTest extends TestCase
         $this->client->flush();
         $this->client->flush();
     }
+
+    public function testDeployWorksOutOfTheBox()
+    {
+        $this->guzzle->expects($this->once())->method('request')->with($this->equalTo('POST'), $this->equalTo('deploy'), $this->equalTo(['json' => ['releaseStage' => 'production', 'apiKey' => 'example-api-key']]));
+
+        $this->client = new Client($this->config = new Configuration('example-api-key'), null, $this->guzzle);
+
+        $this->client->deploy();
+    }
+
+    public function testDeployWorksWithgReleaseStage()
+    {
+        $this->guzzle->expects($this->once())->method('request')->with($this->equalTo('POST'), $this->equalTo('deploy'), $this->equalTo(['json' => ['releaseStage' => 'staging', 'apiKey' => 'example-api-key']]));
+
+        $this->client = new Client($this->config = new Configuration('example-api-key'), null, $this->guzzle);
+
+        $this->config->setReleaseStage('staging');
+
+        $this->client->deploy();
+    }
+
+    public function testDeployWorksWithAppVersion()
+    {
+        $this->guzzle->expects($this->once())->method('request')->with($this->equalTo('POST'), $this->equalTo('deploy'), $this->equalTo(['json' => ['releaseStage' => 'production', 'appVersion' => '1.1.0', 'apiKey' => 'example-api-key']]));
+
+        $this->client = new Client($this->config = new Configuration('example-api-key'), null, $this->guzzle);
+
+        $this->config->setAppVersion('1.1.0');
+
+        $this->client->deploy();
+    }
+
+    public function testDeployWorksWithRepository()
+    {
+        $this->guzzle->expects($this->once())->method('request')->with($this->equalTo('POST'), $this->equalTo('deploy'), $this->equalTo(['json' => ['repository' => 'foo', 'releaseStage' => 'production', 'apiKey' => 'example-api-key']]));
+
+        $this->client = new Client($this->config = new Configuration('example-api-key'), null, $this->guzzle);
+
+        $this->client->deploy('foo');
+    }
+
+    public function testDeployWorksWithBranch()
+    {
+        $this->guzzle->expects($this->once())->method('request')->with($this->equalTo('POST'), $this->equalTo('deploy'), $this->equalTo(['json' => ['branch' => 'master', 'releaseStage' => 'production', 'apiKey' => 'example-api-key']]));
+
+        $this->client = new Client($this->config = new Configuration('example-api-key'), null, $this->guzzle);
+
+        $this->client->deploy(null, 'master');
+    }
+
+    public function testDeployWorksWithRevision()
+    {
+        $this->guzzle->expects($this->once())->method('request')->with($this->equalTo('POST'), $this->equalTo('deploy'), $this->equalTo(['json' => ['revision' => 'bar', 'releaseStage' => 'production', 'apiKey' => 'example-api-key']]));
+
+        $this->client = new Client($this->config = new Configuration('example-api-key'), null, $this->guzzle);
+
+        $this->client->deploy(null, null, 'bar');
+    }
+
+    public function testDeployWorksWithEverything()
+    {
+        $this->guzzle->expects($this->once())->method('request')->with($this->equalTo('POST'), $this->equalTo('deploy'), $this->equalTo(['json' => ['repository' => 'baz', 'branch' => 'develop', 'revision' => 'foo', 'releaseStage' => 'development', 'appVersion' => '1.3.1', 'apiKey' => 'example-api-key']]));
+
+        $this->client = new Client($this->config = new Configuration('example-api-key'), null, $this->guzzle);
+
+        $this->config->setReleaseStage('development');
+        $this->config->setAppVersion('1.3.1');
+
+        $this->client->deploy('baz', 'develop', 'foo');
+    }
 }


### PR DESCRIPTION
Our ruby library has this available, and I think it would be really cool if the PHP one had it too.

It would be really nice to just be able to write `Bugsnag::deploy()` in Laravel, and that would notify Bugsnag of the deploy.