### PR TITLE
When notifying, leave the error as a breadcrumb for next time

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -250,6 +250,8 @@ class Client
             $this->http->queue($report);
         });
 
+        $this->leaveBreadcrumb($report->getShortName(), 'error', $report->getSummary());
+
         if (!$this->config->isBatchSending()) {
             $this->flush();
         }

--- a/src/Report.php
+++ b/src/Report.php
@@ -5,6 +5,8 @@ namespace Bugsnag;
 use Bugsnag\Breadcrumbs\Breadcrumb;
 use Exception;
 use InvalidArgumentException;
+use ReflectionClass;
+use ReflectionException;
 use Throwable;
 
 class Report
@@ -285,6 +287,20 @@ class Report
     }
 
     /**
+     * Get the short name.
+     *
+     * @return string
+     */
+    public function getShortName()
+    {
+        try {
+            return (new ReflectionClass($this->name))->getShortName();
+        } catch (ReflectionException $e) {
+            return $this->name;
+        }
+    }
+
+    /**
      * Set the error message.
      *
      * @param string|null $message the error message
@@ -463,6 +479,20 @@ class Report
         }
 
         $this->breadcrumbs[] = $data;
+    }
+
+    /**
+     * Get the report summary.
+     *
+     * @return string[]
+     */
+    public function getSummary()
+    {
+        return array_filter([
+            'name' => $this->getName(),
+            'message' => $this->getMessage(),
+            'severity' => $this->getSeverity(),
+        ]);
     }
 
     /**

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -197,6 +197,43 @@ class ClientTest extends TestCase
         $this->assertFalse(isset($breadcrumbs[0]['metaData']));
     }
 
+    public function testBreadcrumsAgain()
+    {
+        $this->client = new Client($this->config = new Configuration('example-api-key'), null, $this->guzzle);
+
+        $this->client->leaveBreadcrumb('Test', 'user', ['foo' => 'bar']);
+
+        $this->client->notify($report = Report::fromNamedError($this->config, 'Name'));
+
+        $breadcrumbs = $report->toArray()['breadcrumbs'];
+
+        $this->assertCount(1, $breadcrumbs);
+
+        $this->assertCount(4, $breadcrumbs[0]);
+        $this->assertInternalType('string', $breadcrumbs[0]['timestamp']);
+        $this->assertSame('Test', $breadcrumbs[0]['name']);
+        $this->assertSame('user', $breadcrumbs[0]['type']);
+        $this->assertSame(['foo' => 'bar'], $breadcrumbs[0]['metaData']);
+
+        $this->client->notify($report = Report::fromNamedError($this->config, 'Name'));
+
+        $breadcrumbs = $report->toArray()['breadcrumbs'];
+
+        $this->assertCount(2, $breadcrumbs);
+
+        $this->assertCount(4, $breadcrumbs[0]);
+        $this->assertInternalType('string', $breadcrumbs[0]['timestamp']);
+        $this->assertSame('Test', $breadcrumbs[0]['name']);
+        $this->assertSame('user', $breadcrumbs[0]['type']);
+        $this->assertSame(['foo' => 'bar'], $breadcrumbs[0]['metaData']);
+
+        $this->assertCount(4, $breadcrumbs[1]);
+        $this->assertInternalType('string', $breadcrumbs[1]['timestamp']);
+        $this->assertSame('Name', $breadcrumbs[1]['name']);
+        $this->assertSame('error', $breadcrumbs[1]['type']);
+        $this->assertSame(['name' => 'Name', 'severity' => 'warning'], $breadcrumbs[1]['metaData']);
+    }
+
     public function testNoEnvironmentByDefault()
     {
         $_ENV['SOMETHING'] = 'blah';

--- a/tests/ReportTest.php
+++ b/tests/ReportTest.php
@@ -222,6 +222,20 @@ class ReportTest extends TestCase
         $this->assertSame('123', $this->report->getName());
     }
 
+    public function testGetShortNameClass()
+    {
+        $this->report->setName('Bugsnag\Client');
+
+        $this->assertSame('Client', $this->report->getShortName());
+    }
+
+    public function testGetShortNameFallback()
+    {
+        $this->report->setName('foo bar baz');
+
+        $this->assertSame('foo bar baz', $this->report->getShortName());
+    }
+
     public function testGoodSetMessage()
     {
         $this->report->setMessage('foo bar baz');
@@ -241,5 +255,22 @@ class ReportTest extends TestCase
         $this->report->setMessage(null);
 
         $this->assertSame(null, $this->report->getMessage());
+    }
+
+    public function testGetSummaryFull()
+    {
+        $this->report->setName('foo');
+        $this->report->setMessage('bar');
+        $this->report->setSeverity('info');
+
+        $this->assertSame(['name' => 'foo', 'message' => 'bar', 'severity' => 'info'], $this->report->getSummary());
+    }
+
+    public function testGetSummaryPartial()
+    {
+        $this->report->setName('foo');
+        $this->report->setMessage(null);
+
+        $this->assertSame(['name' => 'foo', 'severity' => 'warning'], $this->report->getSummary());
     }
 }


### PR DESCRIPTION
This probably needs some discussion, so opening a PR to the breadcrumbs branch.