### PR TITLE
Made report summaries more robust

### DIFF
--- a/src/Report.php
+++ b/src/Report.php
@@ -480,11 +480,20 @@ class Report
      */
     public function getSummary()
     {
-        return array_filter([
-            'name' => $this->getName(),
-            'message' => $this->getMessage(),
-            'severity' => $this->getSeverity(),
-        ]);
+        $summary = [];
+
+        $name = $this->getName();
+        $message = $this->getMessage();
+
+        if ($name !== $message) {
+            $summary['name'] = $name;
+        }
+
+        $summary['message'] = $message;
+
+        $summary['severity'] = $this->getSeverity();
+
+        return array_filter($summary);
     }
 
     /**

--- a/tests/ReportTest.php
+++ b/tests/ReportTest.php
@@ -268,4 +268,20 @@ class ReportTest extends TestCase
 
         $this->assertSame(['name' => 'foo', 'severity' => 'warning'], $this->report->getSummary());
     }
+
+    public function testGetSummaryEmpty()
+    {
+        $this->report->setName('foo');
+        $this->report->setMessage('');
+
+        $this->assertSame(['name' => 'foo', 'severity' => 'warning'], $this->report->getSummary());
+    }
+
+    public function testGetSummaryDuplicate()
+    {
+        $this->report->setName('bar');
+        $this->report->setMessage('bar');
+
+        $this->assertSame(['message' => 'bar', 'severity' => 'warning'], $this->report->getSummary());
+    }
 }


### PR DESCRIPTION
1. Added another test to check the empty string is treated the same as null for a message.
2. Ensure that if the name is the same as the message, we only send through the message.

Avoids things like this:

![image](https://cloud.githubusercontent.com/assets/2829600/17431382/a451c916-5af1-11e6-8698-beb642346f76.png)
