### PR TITLE
Allow access to the makeGuzzle function

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -118,14 +118,15 @@ class Client
      * Make a new guzzle client instance.
      *
      * @param string|null $base
+     * @param array       $options
      *
      * @return \GuzzleHttp\ClientInterface
      */
-    protected static function makeGuzzle($base = null)
+    public static function makeGuzzle($base = null, array $options = [])
     {
         $key = version_compare(ClientInterface::VERSION, '6') === 1 ? 'base_uri' : 'base_url';
 
-        $options = [$key => $base ?: static::ENDPOINT];
+        $options[$key] = $base ?: static::ENDPOINT;
 
         if ($path = static::getCaBundlePath()) {
             $options['verify'] = $path;


### PR DESCRIPTION
This will ensure our Laravel package stays in sync with this one. For example, we forgot to add the cert verification stuff too it.