### PR TITLE
Support using subfolder installs of custom notifier services

### DIFF
--- a/src/HttpClient.php
+++ b/src/HttpClient.php
@@ -88,7 +88,7 @@ class HttpClient
             return;
         }
 
-        $this->postJson('/', $this->build());
+        $this->postJson('', $this->build());
 
         $this->queue = [];
     }

--- a/tests/HttpClientTest.php
+++ b/tests/HttpClientTest.php
@@ -41,7 +41,7 @@ class HttpClientTest extends TestCase
         $this->assertCount(1, $invocations = $spy->getInvocations());
         $params = $invocations[0]->parameters;
         $this->assertCount(2, $params);
-        $this->assertSame('/', $params[0]);
+        $this->assertSame('', $params[0]);
         $this->assertInternalType('array', $params[1]);
         $this->assertSame('6015a72ff14038114c3d12623dfb018f', $params[1]['json']['apiKey']);
         $this->assertInternalType('array', $params[1]['json']['notifier']);
@@ -79,7 +79,7 @@ class HttpClientTest extends TestCase
         $this->assertCount(1, $invocations = $spy->getInvocations());
         $params = $invocations[0]->parameters;
         $this->assertCount(2, $params);
-        $this->assertSame('/', $params[0]);
+        $this->assertSame('', $params[0]);
         $this->assertInternalType('array', $params[1]);
         $this->assertSame('6015a72ff14038114c3d12623dfb018f', $params[1]['json']['apiKey']);
         $this->assertInternalType('array', $params[1]['json']['notifier']);
@@ -121,7 +121,7 @@ class HttpClientTest extends TestCase
         $this->assertCount(1, $invocations = $spy->getInvocations());
         $params = $invocations[0]->parameters;
         $this->assertCount(2, $params);
-        $this->assertSame('/', $params[0]);
+        $this->assertSame('', $params[0]);
         $this->assertInternalType('array', $params[1]);
         $this->assertSame('6015a72ff14038114c3d12623dfb018f', $params[1]['json']['apiKey']);
         $this->assertInternalType('array', $params[1]['json']['notifier']);


### PR DESCRIPTION
Currently, if I wanted to set a URL of `http://127.0.0.1/foo/` as the base URL, it won't work because guzzle will resolve `'/'`to `http://127.0.0.1/`and then try to `POST` to there.