### PR TITLE
Added a getter for the stacktrace

### DIFF
--- a/src/Report.php
+++ b/src/Report.php
@@ -247,6 +247,16 @@ class Report
     }
 
     /**
+     * Get the bugsnag stacktrace.
+     *
+     * @return \Bugsnag\Stacktrace
+     */
+    public function getStacktrace()
+    {
+        return $this->stacktrace;
+    }
+
+    /**
      * Set the previous throwable.
      *
      * @param \Throwable $throwable the previous throwable

--- a/src/Stacktrace.php
+++ b/src/Stacktrace.php
@@ -2,6 +2,7 @@
 
 namespace Bugsnag;
 
+use InvalidArgumentException;
 use RuntimeException;
 use SplFileObject;
 
@@ -134,9 +135,21 @@ class Stacktrace
     /**
      * Get the array representation.
      *
-     * @return array
+     * @return array[]
      */
     public function toArray()
+    {
+        return $this->frames;
+    }
+
+    /**
+     * Get the stacktrace frames.
+     *
+     * This is the same as calling toArray.
+     *
+     * @return array[]
+     */
+    public function getFrames()
     {
         return $this->frames;
     }
@@ -178,6 +191,24 @@ class Stacktrace
         $frame['file'] = $this->config->getStrippedFilePath($file);
 
         $this->frames[] = $frame;
+    }
+
+    /**
+     * Remove the frame at the given index from the stacktrace.
+     *
+     * @param int $index
+     *
+     * @throws \InvalidArgumentException
+     *
+     * @return void
+     */
+    public function removeFrame($index)
+    {
+        if (!isset($this->frames[$index])) {
+            throw new InvalidArgumentException('Invalid frame index to remove.');
+        }
+
+        array_splice($this->frames, $index, 1);
     }
 
     /**

--- a/tests/ReportTest.php
+++ b/tests/ReportTest.php
@@ -4,6 +4,7 @@ namespace Bugsnag\Tests;
 
 use Bugsnag\Configuration;
 use Bugsnag\Report;
+use Bugsnag\Stacktrace;
 use Exception;
 use InvalidArgumentException;
 use ParseError;
@@ -74,6 +75,16 @@ class ReportTest extends TestCase
         $event = $this->report->toArray();
         // 'Code' should not be filtered so should remain still be an array
         $this->assertInternalType('array', $event['exceptions'][0]['stacktrace'][0]['code']);
+    }
+
+    public function testCanGetStacktrace()
+    {
+        $this->report->setPHPError(E_NOTICE, 'Broken', 'file', 123);
+
+        $trace = $this->report->getStacktrace();
+
+        $this->assertInstanceOf(Stacktrace::class, $trace);
+        $this->assertCount(8, $trace->toArray());
     }
 
     public function testNoticeName()


### PR DESCRIPTION
It is still not possible to set a stacktrace from the outside, since the `setStacktrace` method is protected. It is possible to mutate the stacktrace after calling the new `getStacktrace` method, however we have no easy way to insert frames into anywhere other than the very end of the array, and no way to remove frames once they've already made it through the add frame method.

I don't know if we need to add this other frame manipulation ability, or what it would look like.

---

Closes #331.