### PR TITLE
Bumped branch alias

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-master": "3.2-dev"
+            "dev-master": "3.3-dev"
         }
     },
     "minimum-stability": "dev",


### PR DESCRIPTION
The new stacktrace stuff is a feature, so we should probably bump the alias to indicate the next release will be v3.3.0.