### PR TITLE
Don'y define variables within files to be required

### DIFF
--- a/example/php-expanded/index.php
+++ b/example/php-expanded/index.php
@@ -1,10 +1,7 @@
 <?php
 
-require_once 'vendor/autoload.php';
-
 // Loaded Bugsnag here
-require_once 'runtime.php';
-
+$bugsnag = require 'runtime.php';
 
 $bugsnag->leaveBreadcrumb('Example breadcrumb!');
 

--- a/example/php-expanded/runtime.php
+++ b/example/php-expanded/runtime.php
@@ -3,4 +3,4 @@
 require_once 'vendor/autoload.php';
 
 // Create a global Bugsnag client
-$bugsnag = Bugsnag\Client::make('YOUR-API-KEY-HERE');
+return Bugsnag\Client::make('YOUR-API-KEY-HERE');


### PR DESCRIPTION
This both fixes a bug, and corrects a bad practice.

The bug fix is the 2nd time this script is run, the bugsnag variable doesn't get defined since php says it's already loaded that file before. The bad practice is the variable definition within the file being required. It's conventional to just return from such files and define the result in your own variable.