### PR TITLE
Make constructor public instead of protected

### DIFF
--- a/src/Handler.php
+++ b/src/Handler.php
@@ -36,7 +36,7 @@ class Handler
      *
      * @return void
      */
-    protected function __construct(Client $client)
+    public function __construct(Client $client)
     {
         $this->client = $client;
     }


### PR DESCRIPTION
This is needed when you want to call handler methods explicitly without registering default php error/exception/shutdown handlers.  An example use case would be if you utilized your own error/exception/shutdown handlers and within that handler called these handler methods.  You may also call other handler methods unrelated to bugsnag.