### PR TITLE
Fix setStripPath and setProjectRoot regexes

### DIFF
--- a/src/Configuration.php
+++ b/src/Configuration.php
@@ -247,7 +247,7 @@ class Configuration
      */
     public function setStripPath($stripPath)
     {
-        $this->stripPathRegex = $stripPath ? '/'.preg_quote($stripPath, '/').'[\\/]?/i' : null;
+        $this->stripPathRegex = $stripPath ? '/^'.preg_quote($stripPath, '/').'[\\/]?/i' : null;
     }
 
     /**

--- a/src/Configuration.php
+++ b/src/Configuration.php
@@ -219,7 +219,7 @@ class Configuration
      */
     public function setProjectRoot($projectRoot)
     {
-        $this->projectRootRegex = $projectRoot ? '/'.preg_quote($projectRoot, '/').'[\\/]?/i' : null;
+        $this->projectRootRegex = $projectRoot ? '/^'.preg_quote($projectRoot, '/').'[\\/]?/i' : null;
 
         if ($projectRoot && !$this->stripPathRegex) {
             $this->setStripPath($projectRoot);

--- a/tests/ConfigurationTest.php
+++ b/tests/ConfigurationTest.php
@@ -48,12 +48,13 @@ class ConfigurationTest extends TestCase
 
     public function testRootPath()
     {
-        $this->assertFalse($this->config->isInProject(__FILE__));
+        $this->assertFalse($this->config->isInProject('/root/dir/afile.php'));
 
-        $this->config->setProjectRoot(__DIR__);
+        $this->config->setProjectRoot('/root/dir');
 
-        $this->assertTrue($this->config->isInProject(__FILE__));
-        $this->assertFalse($this->config->isInProject(dirname(__DIR__)));
+        $this->assertTrue($this->config->isInProject('/root/dir/afile.php'));
+        $this->assertFalse($this->config->isInProject('/root'));
+        $this->assertFalse($this->config->isInProject('/base/root/dir/afile.php'));
     }
 
     public function testAppData()

--- a/tests/StacktraceTest.php
+++ b/tests/StacktraceTest.php
@@ -93,9 +93,9 @@ class StacktraceTest extends TestCase
         $fixture = $this->getJsonFixture('backtraces/exception_handler.json');
         $stacktrace = Stacktrace::fromBacktrace($this->config, $fixture['backtrace'], $fixture['file'], $fixture['line'])->toArray();
 
-        $this->assertFrameEquals($stacktrace[0], 'crashy_function', '/Users/james/src/bugsnag/bugsnag-php/testing.php', 25);
-        $this->assertFrameEquals($stacktrace[1], 'parent_of_crashy_function', '/Users/james/src/bugsnag/bugsnag-php/testing.php', 13);
-        $this->assertFrameEquals($stacktrace[2], '[main]', '/Users/james/src/bugsnag/bugsnag-php/testing.php', 28);
+        $this->assertFrameEquals($stacktrace[0], 'crashy_function', '/dir1/dir2/dir1/testing.php', 25);
+        $this->assertFrameEquals($stacktrace[1], 'parent_of_crashy_function', '/dir1/dir2/dir1/testing.php', 13);
+        $this->assertFrameEquals($stacktrace[2], '[main]', '/dir1/dir2/dir1/testing.php', 28);
 
         $this->assertCount(3, $stacktrace);
     }
@@ -150,12 +150,12 @@ class StacktraceTest extends TestCase
     public function testStrippingPaths()
     {
         $fixture = $this->getJsonFixture('backtraces/exception_handler.json');
-        $this->config->setStripPath('/Users/james/src/bugsnag/bugsnag-php/');
+        $this->config->setStripPath('/dir1/');
         $stacktrace = Stacktrace::fromBacktrace($this->config, $fixture['backtrace'], $fixture['file'], $fixture['line'])->toArray();
 
-        $this->assertFrameEquals($stacktrace[0], 'crashy_function', 'testing.php', 25);
-        $this->assertFrameEquals($stacktrace[1], 'parent_of_crashy_function', 'testing.php', 13);
-        $this->assertFrameEquals($stacktrace[2], '[main]', 'testing.php', 28);
+        $this->assertFrameEquals($stacktrace[0], 'crashy_function', 'dir2/dir1/testing.php', 25);
+        $this->assertFrameEquals($stacktrace[1], 'parent_of_crashy_function', 'dir2/dir1/testing.php', 13);
+        $this->assertFrameEquals($stacktrace[2], '[main]', 'dir2/dir1/testing.php', 28);
 
         $this->assertCount(3, $stacktrace);
     }
@@ -168,8 +168,8 @@ class StacktraceTest extends TestCase
 
         $stacktrace->removeFrame(1);
 
-        $this->assertFrameEquals($stacktrace->toArray()[0], 'crashy_function', 'testing.php', 25);
-        $this->assertFrameEquals($stacktrace->toArray()[1], '[main]', 'testing.php', 28);
+        $this->assertFrameEquals($stacktrace->toArray()[0], 'crashy_function', '/dir1/dir2/dir1/testing.php', 25);
+        $this->assertFrameEquals($stacktrace->toArray()[1], '[main]', '/dir1/dir2/dir1/testing.php', 28);
 
         $this->assertCount(2, $stacktrace->toArray());
     }

--- a/tests/fixtures/backtraces/exception_handler.json
+++ b/tests/fixtures/backtraces/exception_handler.json
@@ -1,14 +1,14 @@
 {
-    "file": "/Users/james/src/bugsnag/bugsnag-php/testing.php",
+    "file": "/dir1/dir2/dir1/testing.php",
     "line": 25,
     "backtrace": [
         {
-            "file": "/Users/james/src/bugsnag/bugsnag-php/testing.php",
+            "file": "/dir1/dir2/dir1/testing.php",
             "line": 13,
             "function": "crashy_function"
         },
         {
-            "file": "/Users/james/src/bugsnag/bugsnag-php/testing.php",
+            "file": "/dir1/dir2/dir1/testing.php",
             "line": 28,
             "function": "parent_of_crashy_function"
         }


### PR DESCRIPTION
`setStripPath` and `setProjectRoot` has some unexpected behaviour.

For example if you `->setStripPath('/dir1/')` or `->setProjectRoot('/dir1/')` then a path like `/dir1/dir2/dir1/file.php` is stripped to `dir2file.php` - the regex strips all occurrences of `/dir1/` rather than just the root path (which I assume is the intended purpose).

So this updates the `setStripPath` and `setProjectRoot` functions to always match the start of a path string.
