### PR TITLE
Fixed callback bug

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -269,7 +269,9 @@ class Client
     {
         $this->pipeline->execute($report, function ($report) use ($callback) {
             if ($callback) {
-                $callback($report);
+                if ($callback($report) === false) {
+                    return;
+                }
             }
 
             $this->http->queue($report);

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -131,6 +131,8 @@ class ClientTest extends TestCase
     {
         $this->client = new Client($this->config = new Configuration('example-api-key'), null, $this->guzzle);
 
+        $this->client->setBatchSending(false);
+
         $this->client->registerCallback(function (Report $report) {
             if ($report->getName() === 'SkipMe') {
                 return false;

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -144,6 +144,21 @@ class ClientTest extends TestCase
         $this->client->notify(Report::fromNamedError($this->config, 'SkipMe', 'Message'));
     }
 
+    public function testDirectCallbackSkipsError()
+    {
+        $this->client = new Client($this->config = new Configuration('example-api-key'), null, $this->guzzle);
+
+        $this->client->setBatchSending(false);
+
+        $this->guzzle->expects($this->never())->method('post');
+
+        $this->client->notify(Report::fromNamedError($this->config, 'SkipMe', 'Message'), function (Report $report) {
+            if ($report->getName() === 'SkipMe') {
+                return false;
+            }
+        });
+    }
+
     public function testMetaDataWorks()
     {
         $this->client = new Client($this->config = new Configuration('example-api-key'), null, $this->guzzle);


### PR DESCRIPTION
Callbacks directly passed to notify must also be able to cancel sending by returning `false`.