### PR TITLE
Allow configuring strip path regex

### DIFF
--- a/src/Configuration.php
+++ b/src/Configuration.php
@@ -251,6 +251,22 @@ class Configuration
     }
 
     /**
+     * Set the regular expression used to strip paths from stacktraces.
+     *
+     * @param string|null $stripPathRegex
+     *
+     * @return void
+     */
+    public function setStripPathRegex($stripPathRegex)
+    {
+        if (@preg_match($stripPathRegex, null) === false) {
+            throw new InvalidArgumentException('Invalid strip path regex: '.$stripPathRegex);
+        }
+
+        $this->stripPathRegex = $stripPathRegex;
+    }
+
+    /**
      * Set the stripped file path.
      *
      * @param string $file

--- a/tests/ConfigurationTest.php
+++ b/tests/ConfigurationTest.php
@@ -22,6 +22,15 @@ class ConfigurationTest extends TestCase
         new Configuration([]);
     }
 
+    /**
+     * @expectedException \InvalidArgumentException
+     * @expectedExpcetionMessage Invalid strip path regex: [thisisnotavalidregex
+     */
+    public function testDoesNotAcceptBadStripPathRegex()
+    {
+        $this->config->setStripPathRegex('[thisisnotavalidregex');
+    }
+
     public function testNotifier()
     {
         $this->assertSame('Bugsnag PHP (Official)', $this->config->getNotifier()['name']);


### PR DESCRIPTION
We use paths that change with every release for our app. For example - `/opt/releases/app-name/201611110115/__src/Class.php`. 

This messes with the filename based grouping that happens for exceptions - We end up getting duplicate reports for the same exception on every new release. 

I saw that one way to prevent this is to set the strip path to the exact value (`/opt/releases/app-name/2016.../`).  However, it'd be easier if I could use regexes here. Seeing that internally a regex is used, this PR makes that value configurable. It doesn't mess with the original behavior.

(was #374)