### PR TITLE
Added latest php and hhvm

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,35 +24,29 @@ matrix:
       env: GUZZLE_VERSION=^5.3
     - php: 7.1
       env: GUZZLE_VERSION=^6.0
+    - php: 7.2
+      env: GUZZLE_VERSION=^5.3
+    - php: 7.2
+      env: GUZZLE_VERSION=^6.0
     - php: hhvm-3.6
-      sudo: required
-      dist: trusty
-      group: edge
       env: GUZZLE_VERSION=^5.3
     - php: hhvm-3.6
-      sudo: required
-      dist: trusty
-      group: edge
       env: GUZZLE_VERSION=^6.0
     - php: hhvm-3.9
-      sudo: required
-      dist: trusty
-      group: edge
       env: GUZZLE_VERSION=^5.3
     - php: hhvm-3.9
-      sudo: required
-      dist: trusty
-      group: edge
       env: GUZZLE_VERSION=^6.0
     - php: hhvm-3.12
-      sudo: required
-      dist: trusty
-      group: edge
       env: GUZZLE_VERSION=^5.3
     - php: hhvm-3.12
-      sudo: required
-      dist: trusty
-      group: edge
+      env: GUZZLE_VERSION=^6.0
+    - php: hhvm-3.15
+      env: GUZZLE_VERSION=^5.3
+    - php: hhvm-3.15
+      env: GUZZLE_VERSION=^6.0
+    - php: hhvm-3.18
+      env: GUZZLE_VERSION=^5.3
+    - php: hhvm-3.18
       env: GUZZLE_VERSION=^6.0
 
 before_install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: php
-
+dist: trusty
 sudo: false
 
 matrix:


### PR DESCRIPTION
Also, since a few days ago, the following is no longer needed for HHVM:

```yaml
    sudo: required
    dist: trusty
    group: edge
```

I'm not sure if you want to keep all these older HHVM versions either?