### PR TITLE
Call previously defined exception and error handlers

### DIFF
--- a/src/Handler.php
+++ b/src/Handler.php
@@ -12,21 +12,21 @@ class Handler
     protected $client;
 
     /**
-     * The previously registered error handler returned by the interpreter.
+     * The previously registered error handler.
      *
      * @var callable|null
      */
     protected $previousErrorHandler;
 
     /**
-     * The previously registered exception handler returned by the interpreter.
+     * The previously registered exception handler.
      *
      * @var callable|null
      */
     protected $previousExceptionHandler;
 
     /**
-     * Register our exception handler.
+     * Register our handlers.
      *
      * @param \Bugsnag\Client|string|null $client client instance or api key
      *
@@ -42,7 +42,7 @@ class Handler
     }
 
     /**
-     * Register our exception handler and preserve those previously registered.
+     * Register our handlers and preserve those previously registered.
      *
      * @param \Bugsnag\Client|string|null $client client instance or api key
      *
@@ -88,7 +88,7 @@ class Handler
     }
 
     /**
-     * Register the bugsnag error handler and save the returned value.
+     * Register the bugsnag exception handler and save the returned value.
      *
      * @param bool $callPrevious whether or not to call the previous handler
      *

--- a/src/Handler.php
+++ b/src/Handler.php
@@ -78,7 +78,7 @@ class Handler
      *
      * @return void
      */
-    public function registerErrorHandler($callPrevious = true)
+    public function registerErrorHandler($callPrevious)
     {
         $previous = set_error_handler([$this, 'errorHandler']);
 
@@ -94,7 +94,7 @@ class Handler
      *
      * @return void
      */
-    public function registerExceptionHandler($callPrevious = true)
+    public function registerExceptionHandler($callPrevious)
     {
         $previous = set_exception_handler([$this, 'exceptionHandler']);
 

--- a/src/Handler.php
+++ b/src/Handler.php
@@ -144,7 +144,7 @@ class Handler
         }
 
         if ($this->previousErrorHandler) {
-            call_user_func(
+            return call_user_func(
                 $this->previousErrorHandler,
                 $errno,
                 $errstr,

--- a/src/Handler.php
+++ b/src/Handler.php
@@ -12,14 +12,14 @@ class Handler
     protected $client;
 
     /**
-     * The previously registered error handler as returned by the interpreter.
+     * The previously registered error handler returned by the interpreter.
      *
      * @var callable|null
      */
     protected $previousErrorHandler;
 
     /**
-     * The previously registered exception handler as returned by the interpreter.
+     * The previously registered exception handler returned by the interpreter.
      *
      * @var callable|null
      */
@@ -45,8 +45,7 @@ class Handler
     }
 
     /**
-     * Register the bugsnag error handler and save the previous one
-     * (if it exists) to call later.
+     * Register the bugsnag error handler and save the returned value.
      *
      * @param bool $callPrevious whether or not to call the previous handler
      *
@@ -62,8 +61,7 @@ class Handler
     }
 
     /**
-     * Register the bugsnag exception handler and save the previous one
-     * (if it exists) to call later.
+     * Register the bugsnag error handler and save the returned value.
      *
      * @param bool $callPrevious whether or not to call the previous handler
      *

--- a/src/Handler.php
+++ b/src/Handler.php
@@ -29,19 +29,46 @@ class Handler
      * Register our exception handler.
      *
      * @param \Bugsnag\Client|string|null $client client instance or api key
-     * @param bool $callPrevious whether or not to call the previous handlers
      *
      * @return static
      */
-    public static function register($client = null, $callPrevious = true)
+    public static function register($client = null)
     {
         $handler = new static($client instanceof Client ? $client : Client::make($client));
 
-        $handler->registerErrorHandler($callPrevious);
-        $handler->registerExceptionHandler($callPrevious);
-        $handler->registerShutdownHandler();
+        $handler->registerBugsnagHandlers(false); // don't preserve previous handlers
 
         return $handler;
+    }
+
+    /**
+     * Register our exception handler and preserve those previously registered.
+     *
+     * @param \Bugsnag\Client|string|null $client client instance or api key
+     *
+     * @return static
+     */
+    public static function registerWithPrevious($client = null)
+    {
+        $handler = new static($client instanceof Client ? $client : Client::make($client));
+
+        $handler->registerBugsnagHandlers(true); // preserve previous handlers
+
+        return $handler;
+    }
+
+    /**
+     * Register our handlers, optionally saving those previously registered.
+     *
+     * @param bool $callPrevious whether or not to call the previous handlers
+     *
+     * @return void
+     */
+    protected function registerBugsnagHandlers($callPrevious)
+    {
+        $this->registerErrorHandler($callPrevious);
+        $this->registerExceptionHandler($callPrevious);
+        $this->registerShutdownHandler();
     }
 
     /**

--- a/tests/HandlerTest.php
+++ b/tests/HandlerTest.php
@@ -23,9 +23,6 @@ class HandlerTest extends TestCase
                              ->getMock();
     }
 
-    /**
-     * @expectedException PHPUnit_Framework_Error_Warning
-     */
     public function testErrorHandler()
     {
         $this->client->expects($this->once())->method('notify');
@@ -33,17 +30,12 @@ class HandlerTest extends TestCase
         Handler::register($this->client)->errorHandler(E_WARNING, 'Something broke', 'somefile.php', 123);
     }
 
-    public function testErrorHandlerPreviousOff()
+    /**
+     * @expectedException PHPUnit_Framework_Error_Warning
+     */
+    public function testErrorHandlerWithPrevious()
     {
-        // PHPUnit's error handler should not get called, so no exception should be raised.
-        $exception_raised = false;
-        try {
-            Handler::register($this->client, false)->errorHandler(E_WARNING, 'Something broke', 'somefile.php', 123);
-        } catch (\PHPUnit_Framework_Error_Warning $e) {
-            $exception_raised = true;
-        }
-
-        $this->assertFalse($exception_raised);
+        Handler::registerWithPrevious($this->client)->errorHandler(E_WARNING, 'Something broke', 'somefile.php', 123);
     }
 
     public function testExceptionHandler()
@@ -53,7 +45,7 @@ class HandlerTest extends TestCase
         Handler::register($this->client)->exceptionHandler(new Exception('Something broke'));
     }
 
-    public function testExceptionHandlerCallsPrevious()
+    public function testExceptionHandlerWithPrevious()
     {
         // Register a custom exception handler that stores it's parameter in the
         // parent's scope so we can assert that it was correctly called.
@@ -66,12 +58,12 @@ class HandlerTest extends TestCase
 
         $e_to_throw = new Exception('Something broke');
 
-        Handler::register($this->client)->exceptionHandler($e_to_throw);
+        Handler::registerWithPrevious($this->client)->exceptionHandler($e_to_throw);
 
         $this->assertSame($e_to_throw, $previous_exception_handler_arg);
     }
 
-    public function testExceptionHandlerCallsPreviousOff()
+    public function testExceptionHandlerWithoutPrevious()
     {
         $previous_exception_handler_called = false;
         set_exception_handler(
@@ -80,7 +72,7 @@ class HandlerTest extends TestCase
             }
         );
 
-        Handler::register($this->client, false)->exceptionHandler(new Exception());
+        Handler::register($this->client)->exceptionHandler(new Exception());
 
         $this->assertFalse($previous_exception_handler_called);
     }
@@ -98,9 +90,6 @@ class HandlerTest extends TestCase
         );
     }
 
-    /**
-     * @expectedException PHPUnit_Framework_Error_Notice
-     */
     public function testErrorReportingLevel()
     {
         $this->client->expects($this->once())->method('notify');
@@ -110,9 +99,6 @@ class HandlerTest extends TestCase
         Handler::register($this->client)->errorHandler(E_NOTICE, 'Something broke', 'somefile.php', 123);
     }
 
-    /**
-     * @expectedException PHPUnit_Framework_Error_Warning
-     */
     public function testErrorReportingLevelFails()
     {
         $this->client->expects($this->never())->method('notify');
@@ -122,9 +108,6 @@ class HandlerTest extends TestCase
         Handler::register($this->client)->errorHandler(E_WARNING, 'Something broke', 'somefile.php', 123);
     }
 
-    /**
-     * @expectedException PHPUnit_Framework_Error_Notice
-     */
     public function testErrorReportingWithoutNotice()
     {
         $this->client->expects($this->never())->method('notify');

--- a/tests/HandlerTest.php
+++ b/tests/HandlerTest.php
@@ -23,9 +23,11 @@ class HandlerTest extends TestCase
                              ->getMock();
     }
 
+    /**
+     * @expectedException PHPUnit_Framework_Error_Warning
+     */
     public function testErrorHandler()
     {
-        $this->expectException(\PHPUnit_Framework_Error_Warning::class);
         $this->client->expects($this->once())->method('notify');
 
         Handler::register($this->client)->errorHandler(E_WARNING, 'Something broke', 'somefile.php', 123);
@@ -83,9 +85,11 @@ class HandlerTest extends TestCase
         $this->assertFalse($previous_exception_handler_called);
     }
 
+    /**
+     * @expectedException PHPUnit_Framework_Error_Notice
+     */
     public function testErrorReportingLevel()
     {
-        $this->expectException(\PHPUnit_Framework_Error_Notice::class);
         $this->client->expects($this->once())->method('notify');
 
         $this->client->setErrorReportingLevel(E_NOTICE);
@@ -93,9 +97,11 @@ class HandlerTest extends TestCase
         Handler::register($this->client)->errorHandler(E_NOTICE, 'Something broke', 'somefile.php', 123);
     }
 
+    /**
+     * @expectedException PHPUnit_Framework_Error_Warning
+     */
     public function testErrorReportingLevelFails()
     {
-        $this->expectException(\PHPUnit_Framework_Error_Warning::class);
         $this->client->expects($this->never())->method('notify');
 
         $this->client->setErrorReportingLevel(E_NOTICE);
@@ -103,9 +109,11 @@ class HandlerTest extends TestCase
         Handler::register($this->client)->errorHandler(E_WARNING, 'Something broke', 'somefile.php', 123);
     }
 
+    /**
+     * @expectedException PHPUnit_Framework_Error_Notice
+     */
     public function testErrorReportingWithoutNotice()
     {
-        $this->expectException(\PHPUnit_Framework_Error_Notice::class);
         $this->client->expects($this->never())->method('notify');
 
         $this->client->setErrorReportingLevel(E_ALL & ~E_NOTICE);

--- a/tests/HandlerTest.php
+++ b/tests/HandlerTest.php
@@ -81,12 +81,13 @@ class HandlerTest extends TestCase
     {
         set_error_handler(
             function () {
-                return false;
+                return '123';
             }
         );
 
-        $this->assertFalse(
-            Handler::register($this->client)->errorHandler(E_WARNING, 'Something broke')
+        $this->assertSame(
+            '123',
+            Handler::registerWithPrevious($this->client)->errorHandler(E_WARNING, 'Something broke')
         );
     }
 

--- a/tests/HandlerTest.php
+++ b/tests/HandlerTest.php
@@ -85,6 +85,19 @@ class HandlerTest extends TestCase
         $this->assertFalse($previous_exception_handler_called);
     }
 
+    public function testCustomErrorHandlerValueReturned()
+    {
+        set_error_handler(
+            function () {
+                return false;
+            }
+        );
+
+        $this->assertFalse(
+            Handler::register($this->client)->errorHandler(E_WARNING, 'Something broke')
+        );
+    }
+
     /**
      * @expectedException PHPUnit_Framework_Error_Notice
      */


### PR DESCRIPTION
This library overwrites previously set user exception and error handlers. Both `set_error_handler` and `set_exception_handler` will return callables for the previously defined handlers if they were set. Switch the library's behavior to respect this.

Closes #392