### PR TITLE
Cawllec/console request

### DIFF
--- a/src/Request/BasicResolver.php
+++ b/src/Request/BasicResolver.php
@@ -11,15 +11,20 @@ class BasicResolver implements ResolverInterface
      */
     public function resolve()
     {
-        if (!isset($_SERVER['REQUEST_METHOD'])) {
-            if (PHP_SAPI ==='cli' && isset($_SERVER['argv'])) {
-                return new ConsoleRequest($_SERVER['argv']);
-            } else {
-                return new NullRequest();
-            }
+        if (isset($_SERVER['REQUEST_METHOD'])) {
+            return new PhpRequest($_SERVER,
+                empty($_SESSION) ? [] : $_SESSION,
+                empty($_COOKIE) ? [] : $_COOKIE,
+                static::getRequestHeaders($_SERVER),
+                static::getInputParams($_SERVER, $_POST));
         }
 
-        return new PhpRequest($_SERVER, empty($_SESSION) ? [] : $_SESSION, empty($_COOKIE) ? [] : $_COOKIE, static::getRequestHeaders($_SERVER), static::getInputParams($_SERVER, $_POST));
+        if (PHP_SAPI === 'cli' && isset($_SERVER['argv'])) {
+            return new ConsoleRequest($_SERVER['argv']);
+        }
+        
+        return new NullRequest();
+
     }
 
     /**

--- a/src/Request/BasicResolver.php
+++ b/src/Request/BasicResolver.php
@@ -12,7 +12,7 @@ class BasicResolver implements ResolverInterface
     public function resolve()
     {
         if (!isset($_SERVER['REQUEST_METHOD'])) {
-            if ((php_sapi_name() == 'cli') && (isset($_SERVER['argv']))) {
+            if ((PHP_SAPI == 'cli') && (isset($_SERVER['argv']))) {
                 return new ConsoleRequest($_SERVER['argv']);
             } else {
                 return new NullRequest();

--- a/src/Request/BasicResolver.php
+++ b/src/Request/BasicResolver.php
@@ -12,7 +12,11 @@ class BasicResolver implements ResolverInterface
     public function resolve()
     {
         if (!isset($_SERVER['REQUEST_METHOD'])) {
-            return new NullRequest();
+            if ((php_sapi_name() == 'cli') && (isset($_SERVER['argv']))) {
+                return new ConsoleRequest($_SERVER['argv']);
+            } else {
+                return new NullRequest();
+            }
         }
 
         return new PhpRequest($_SERVER, empty($_SESSION) ? [] : $_SESSION, empty($_COOKIE) ? [] : $_COOKIE, static::getRequestHeaders($_SERVER), static::getInputParams($_SERVER, $_POST));

--- a/src/Request/BasicResolver.php
+++ b/src/Request/BasicResolver.php
@@ -12,7 +12,7 @@ class BasicResolver implements ResolverInterface
     public function resolve()
     {
         if (!isset($_SERVER['REQUEST_METHOD'])) {
-            if ((PHP_SAPI == 'cli') && (isset($_SERVER['argv']))) {
+            if (PHP_SAPI ==='cli' && isset($_SERVER['argv'])) {
                 return new ConsoleRequest($_SERVER['argv']);
             } else {
                 return new NullRequest();

--- a/src/Request/ConsoleRequest.php
+++ b/src/Request/ConsoleRequest.php
@@ -13,10 +13,12 @@ class ConsoleRequest implements RequestInterface
 
     /**
      * Create a new console request instance.
+     * 
+     * @param array     $commandArray An array of the command line input
      *
      * @return void
      */
-    public function __construct($commandArray)
+    public function __construct(array $commandArray)
     {
         $this->command = $commandArray;
     }

--- a/src/Request/ConsoleRequest.php
+++ b/src/Request/ConsoleRequest.php
@@ -13,7 +13,7 @@ class ConsoleRequest implements RequestInterface
 
     /**
      * Create a new console request instance.
-     * 
+     *
      * @param array     $commandArray An array of the command line input
      *
      * @return void

--- a/src/Request/ConsoleRequest.php
+++ b/src/Request/ConsoleRequest.php
@@ -7,20 +7,20 @@ class ConsoleRequest implements RequestInterface
     /**
      * The unformated console command.
      *
-     * @var array
+     * @var string[]
      */
     protected $command;
 
     /**
      * Create a new console request instance.
      *
-     * @param array     $commandArray An array of the command line input
+     * @param string[] $command an array of the console command input
      *
      * @return void
      */
-    public function __construct(array $commandArray)
+    public function __construct(array $command)
     {
-        $this->command = $commandArray;
+        $this->command = $command;
     }
 
     /**
@@ -30,7 +30,7 @@ class ConsoleRequest implements RequestInterface
      */
     public function isRequest()
     {
-        return true;
+        return false;
     }
 
     /**
@@ -88,6 +88,7 @@ class ConsoleRequest implements RequestInterface
      */
     public function getContext()
     {
+        return implode(' ', array_slice($this->command, 0, 2));
     }
 
     /**

--- a/src/Request/ConsoleRequest.php
+++ b/src/Request/ConsoleRequest.php
@@ -1,0 +1,99 @@
+<?php
+
+namespace Bugsnag\Request;
+
+class ConsoleRequest implements RequestInterface
+{
+    /**
+     * The unformated console command.
+     *
+     * @var array
+     */
+    protected $command;
+
+    /**
+     * Create a new console request instance.
+     *
+     * @return void
+     */
+    public function __construct($commandArray)
+    {
+        $this->command = $commandArray;
+    }
+
+    /**
+     * Are we currently processing a request?
+     *
+     * @return bool
+     */
+    public function isRequest()
+    {
+        return true;
+    }
+
+    /**
+     * Get the session data.
+     *
+     * @return array
+     */
+    public function getSession()
+    {
+        return [];
+    }
+
+    /**
+     * Get the cookies.
+     *
+     * @return array
+     */
+    public function getCookies()
+    {
+        return [];
+    }
+
+    /**
+     * Get the request formatted as meta data.
+     *
+     * @return array
+     */
+    public function getMetaData()
+    {
+        if (is_array($this->command)) {
+            $commandString = implode(' ', $this->command);
+            $primaryCommand = $this->command[0];
+            $arguments = [];
+            $options = [];
+            foreach (array_slice($this->command, 1) as $arg) {
+                $arg[0] == '-' ? $options[] = $arg : $arguments[] = $arg;
+            }
+            $data = [
+                'Input' => $commandString,
+                'Command' => $primaryCommand,
+                'Arguments' => $arguments,
+                'Options' => $options,
+            ];
+        } else {
+            $data = $this->command;
+        }
+
+        return ['console' => $data];
+    }
+
+    /**
+     * Get the request context.
+     *
+     * @return string|null
+     */
+    public function getContext()
+    {
+    }
+
+    /**
+     * Get the request user id.
+     *
+     * @return string|null
+     */
+    public function getUserId()
+    {
+    }
+}

--- a/src/Request/ConsoleRequest.php
+++ b/src/Request/ConsoleRequest.php
@@ -65,7 +65,7 @@ class ConsoleRequest implements RequestInterface
         $arguments = [];
         $options = [];
         foreach (array_slice($this->command, 1) as $arg) {
-            if ($arg[0] == '-') {
+            if (isset($arg[0]) && $arg[0] === '-') {
                 $options[] = $arg;
             } else {
                 $arguments[] = $arg;

--- a/src/Request/ConsoleRequest.php
+++ b/src/Request/ConsoleRequest.php
@@ -60,23 +60,23 @@ class ConsoleRequest implements RequestInterface
      */
     public function getMetaData()
     {
-        if (is_array($this->command)) {
-            $commandString = implode(' ', $this->command);
-            $primaryCommand = $this->command[0];
-            $arguments = [];
-            $options = [];
-            foreach (array_slice($this->command, 1) as $arg) {
-                $arg[0] == '-' ? $options[] = $arg : $arguments[] = $arg;
+        $commandString = implode(' ', $this->command);
+        $primaryCommand = $this->command[0];
+        $arguments = [];
+        $options = [];
+        foreach (array_slice($this->command, 1) as $arg) {
+            if ($arg[0] == '-') {
+                $options[] = $arg;
+            } else {
+                $arguments[] = $arg;
             }
-            $data = [
-                'Input' => $commandString,
-                'Command' => $primaryCommand,
-                'Arguments' => $arguments,
-                'Options' => $options,
-            ];
-        } else {
-            $data = $this->command;
         }
+        $data = [
+            'Input' => $commandString,
+            'Command' => $primaryCommand,
+            'Arguments' => $arguments,
+            'Options' => $options,
+        ];
 
         return ['console' => $data];
     }
@@ -88,7 +88,7 @@ class ConsoleRequest implements RequestInterface
      */
     public function getContext()
     {
-        return implode(' ', array_slice($this->command, 0, 2));
+        return implode(' ', array_slice($this->command, 0, 4));
     }
 
     /**

--- a/tests/Callbacks/RequestContextTest.php
+++ b/tests/Callbacks/RequestContextTest.php
@@ -51,7 +51,7 @@ class RequestContextTest extends TestCase
 
     public function testCanConsoleContext()
     {
-        $_SERVER['argv'] = ['first', 'second', '--opt', 'arg'];
+        $_SERVER['argv'] = ['first', 'second', '--opt', 'arg', 'left', 'out'];
 
         $report = Report::fromPHPThrowable($this->config, new Exception());
 
@@ -59,7 +59,7 @@ class RequestContextTest extends TestCase
 
         $callback($report);
 
-        $this->assertSame('first second', $report->getContext());
+        $this->assertSame('first second --opt arg', $report->getContext());
     }
 
     public function testFallsBackToNull()

--- a/tests/Callbacks/RequestContextTest.php
+++ b/tests/Callbacks/RequestContextTest.php
@@ -49,8 +49,23 @@ class RequestContextTest extends TestCase
         $this->assertSame(null, $report->getContext());
     }
 
+    public function testCanConsoleContext()
+    {
+        $_SERVER['argv'] = ['first', 'second', '--opt', 'arg'];
+
+        $report = Report::fromPHPThrowable($this->config, new Exception());
+
+        $callback = new RequestContext($this->resolver);
+
+        $callback($report);
+
+        $this->assertSame('first second', $report->getContext());
+    }
+
     public function testFallsBackToNull()
     {
+        unset($_SERVER['argv']);
+
         $report = Report::fromPHPThrowable($this->config, new Exception());
 
         $callback = new RequestContext($this->resolver);

--- a/tests/Callbacks/RequestMetaDataTest.php
+++ b/tests/Callbacks/RequestMetaDataTest.php
@@ -49,8 +49,28 @@ class RequestMetaDataTest extends TestCase
         ]], $report->getMetaData());
     }
 
+    public function testCanConsoleMetaData()
+    {
+        $_SERVER['argv'] = ['some', 'test', 'command', '--opt'];
+
+        $report = Report::fromPHPThrowable($this->config, new Exception())->setMetaData(['bar' => 'baz']);
+
+        $callback = new RequestMetaData($this->resolver);
+
+        $callback($report);
+
+        $this->assertSame(['bar' => 'baz', 'console' => [
+            'Input' => 'some test command --opt',
+            'Command' => 'some',
+            'Arguments' => ['test', 'command'],
+            'Options' => ['--opt']
+        ]], $report->getMetaData());
+    }
+
     public function testFallsBackToNull()
     {
+        unset($_SERVER['argv']);
+
         $report = Report::fromPHPThrowable($this->config, new Exception())->setMetaData(['bar' => 'baz']);
 
         $callback = new RequestMetaData($this->resolver);

--- a/tests/Callbacks/RequestMetaDataTest.php
+++ b/tests/Callbacks/RequestMetaDataTest.php
@@ -63,7 +63,7 @@ class RequestMetaDataTest extends TestCase
             'Input' => 'some test command --opt',
             'Command' => 'some',
             'Arguments' => ['test', 'command'],
-            'Options' => ['--opt']
+            'Options' => ['--opt'],
         ]], $report->getMetaData());
     }
 

--- a/tests/RequestTest.php
+++ b/tests/RequestTest.php
@@ -5,6 +5,7 @@ namespace Bugsnag\Tests;
 use Bugsnag\Request\BasicResolver;
 use Bugsnag\Request\NullRequest;
 use Bugsnag\Request\PhpRequest;
+use Bugsnag\Request\ConsoleRequest;
 use Bugsnag\Request\RequestInterface;
 use Bugsnag\Request\ResolverInterface;
 use PHPUnit_Framework_TestCase as TestCase;
@@ -36,10 +37,17 @@ class RequestTest extends TestCase
         $this->assertTrue($this->resolver->resolve()->isRequest());
     }
 
-    public function testNotRequest()
+    public function testIsRequestWithConsole()
+    {
+        $_SERVER['argv'] = ['test', 'command', 'string'];
+        unset($_SERVER['REQUEST_METHOD']);
+        $this->assertTrue($this->resolver->resolve()->isRequest());
+    }
+
+    public function testNotRequestOrConsole()
     {
         unset($_SERVER['REQUEST_METHOD']);
-
+        unset($_SERVER['argv']);
         $this->assertFalse($this->resolver->resolve()->isRequest());
     }
 
@@ -49,10 +57,18 @@ class RequestTest extends TestCase
         $this->assertTrue($this->resolver->resolve() instanceof RequestInterface);
     }
 
+    public function testIsConsoleRequest()
+    {
+        $_SERVER['argv'] = ['test', 'command', 'string'];
+        unset($_SERVER['REQUEST_METHOD']);
+        $this->assertTrue($this->resolver->resolve() instanceof ConsoleRequest);
+        $this->assertTrue($this->resolver->resolve() instanceof RequestInterface);
+    }
+
     public function testIsNullRequest()
     {
         unset($_SERVER['REQUEST_METHOD']);
-
+        unset($_SERVER['argv']);
         $this->assertTrue($this->resolver->resolve() instanceof NullRequest);
         $this->assertTrue($this->resolver->resolve() instanceof RequestInterface);
     }

--- a/tests/RequestTest.php
+++ b/tests/RequestTest.php
@@ -3,9 +3,9 @@
 namespace Bugsnag\Tests;
 
 use Bugsnag\Request\BasicResolver;
+use Bugsnag\Request\ConsoleRequest;
 use Bugsnag\Request\NullRequest;
 use Bugsnag\Request\PhpRequest;
-use Bugsnag\Request\ConsoleRequest;
 use Bugsnag\Request\RequestInterface;
 use Bugsnag\Request\ResolverInterface;
 use PHPUnit_Framework_TestCase as TestCase;

--- a/tests/RequestTest.php
+++ b/tests/RequestTest.php
@@ -37,11 +37,11 @@ class RequestTest extends TestCase
         $this->assertTrue($this->resolver->resolve()->isRequest());
     }
 
-    public function testIsRequestWithConsole()
+    public function testIsNotRequestWithConsole()
     {
         $_SERVER['argv'] = ['test', 'command', 'string'];
         unset($_SERVER['REQUEST_METHOD']);
-        $this->assertTrue($this->resolver->resolve()->isRequest());
+        $this->assertFalse($this->resolver->resolve()->isRequest());
     }
 
     public function testNotRequestOrConsole()


### PR DESCRIPTION
Re [this issue in bugsnag-laravel](https://github.com/bugsnag/bugsnag-laravel/issues/211) this implements a basic console-request class that will take an array of the console commands and attach them as meta-data.

This gives a handler for framework implementations, while leaving it framework-specific on how console input is acquired.