### PR TITLE
Adds Handled unhandled properties to payload

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -267,11 +267,16 @@ class Client
      */
     public function notify(Report $report, callable $callback = null)
     {
+        $initialSeverity = $report.severity;
         $this->pipeline->execute($report, function ($report) use ($callback) {
             if ($callback) {
                 if ($callback($report) === false) {
                     return;
                 }
+            }
+
+            if ($report.severity !== $initialSeverity) {
+                $report.setDefaultSeverity(false);
             }
 
             $this->http->queue($report);

--- a/src/Client.php
+++ b/src/Client.php
@@ -267,16 +267,16 @@ class Client
      */
     public function notify(Report $report, callable $callback = null)
     {
-        $initialSeverity = $report.severity;
-        $this->pipeline->execute($report, function ($report) use ($callback) {
+        $initialSeverity = $report->getSeverity();
+        $this->pipeline->execute($report, function ($report) use ($callback, $initialSeverity) {
             if ($callback) {
                 if ($callback($report) === false) {
                     return;
                 }
             }
 
-            if ($report.severity !== $initialSeverity) {
-                $report.setDefaultSeverity(false);
+            if ($report->getSeverity() !== $initialSeverity) {
+                $report->setDefaultSeverity(false);
             }
 
             $this->http->queue($report);

--- a/src/Handler.php
+++ b/src/Handler.php
@@ -136,7 +136,7 @@ class Handler
      */
     public function exceptionHandler($throwable)
     {
-        $report = Report::fromPHPThrowable($this->client->getConfig(), $throwable);
+        $report = Report::fromPHPThrowable($this->client->getConfig(), $throwable, Report::EXCEPTION_HANDLER);
 
         $report->setSeverity('error');
 
@@ -163,7 +163,7 @@ class Handler
     public function errorHandler($errno, $errstr, $errfile = '', $errline = 0)
     {
         if (!$this->client->shouldIgnoreErrorCode($errno)) {
-            $report = Report::fromPHPError($this->client->getConfig(), $errno, $errstr, $errfile, $errline);
+            $report = Report::fromPHPError($this->client->getConfig(), $errno, $errstr, $errfile, $errline, false, Report::EXCEPTION_HANDLER);
 
             $this->client->notify($report);
         }

--- a/src/Handler.php
+++ b/src/Handler.php
@@ -181,7 +181,7 @@ class Handler
                 [
                     'type' => 'unhandledError',
                     'attributes' => [
-                        'error§Type' => ErrorTypes::getName($errno),
+                        'errorType' => ErrorTypes::getName($errno),
                     ],
                 ]
             );

--- a/src/Handler.php
+++ b/src/Handler.php
@@ -172,7 +172,7 @@ class Handler
                 false,
                 Report::ERROR_CLASS,
                 [
-                    'error_class' => ErrorTypes::getName($errno)
+                    'error_class' => ErrorTypes::getName($errno),
                 ]
             );
 

--- a/src/Handler.php
+++ b/src/Handler.php
@@ -193,7 +193,15 @@ class Handler
 
         // Check if a fatal error caused this shutdown
         if (!is_null($lastError) && ErrorTypes::isFatal($lastError['type']) && !$this->client->shouldIgnoreErrorCode($lastError['type'])) {
-            $report = Report::fromPHPError($this->client->getConfig(), $lastError['type'], $lastError['message'], $lastError['file'], $lastError['line'], true);
+            $report = Report::fromPHPError(
+                $this->client->getConfig(),
+                $lastError['type'],
+                $lastError['message'],
+                $lastError['file'],
+                $lastError['line'],
+                true,
+                Report::EXCEPTION_HANDLER
+            );
             $report->setSeverity('error');
             $this->client->notify($report);
         }

--- a/src/Handler.php
+++ b/src/Handler.php
@@ -136,7 +136,14 @@ class Handler
      */
     public function exceptionHandler($throwable)
     {
-        $report = Report::fromPHPThrowable($this->client->getConfig(), $throwable, Report::EXCEPTION_HANDLER);
+        $report = Report::fromPHPThrowable(
+            $this->client->getConfig(),
+            $throwable,
+            true,
+            [
+                'type' => 'unhandledException'
+            ]
+        );
 
         $report->setSeverity('error');
 
@@ -170,9 +177,12 @@ class Handler
                 $errfile,
                 $errline,
                 false,
-                Report::ERROR_CLASS,
+                true,
                 [
-                    'error_class' => ErrorTypes::getName($errno),
+                    'type' => 'unhandledError',
+                    'attributes' => [
+                        'error§Type' => ErrorTypes::getName($errno)
+                    ]
                 ]
             );
 
@@ -211,7 +221,10 @@ class Handler
                 $lastError['file'],
                 $lastError['line'],
                 true,
-                Report::EXCEPTION_HANDLER
+                true,
+                [
+                    'type' => 'unhandledException'
+                ]
             );
             $report->setSeverity('error');
             $this->client->notify($report);

--- a/src/Handler.php
+++ b/src/Handler.php
@@ -163,7 +163,18 @@ class Handler
     public function errorHandler($errno, $errstr, $errfile = '', $errline = 0)
     {
         if (!$this->client->shouldIgnoreErrorCode($errno)) {
-            $report = Report::fromPHPError($this->client->getConfig(), $errno, $errstr, $errfile, $errline, false, Report::EXCEPTION_HANDLER);
+            $report = Report::fromPHPError(
+                $this->client->getConfig(),
+                $errno,
+                $errstr,
+                $errfile,
+                $errline,
+                false,
+                Report::ERROR_CLASS,
+                [
+                    'error_class' => ErrorTypes::getName($errno)
+                ]
+            );
 
             $this->client->notify($report);
         }

--- a/src/Handler.php
+++ b/src/Handler.php
@@ -138,14 +138,14 @@ class Handler
     {
         $report = Report::fromPHPThrowable(
             $this->client->getConfig(),
-            $throwable,
-            true,
-            [
-                'type' => 'unhandledException',
-            ]
+            $throwable
         );
 
         $report->setSeverity('error');
+        $report->setUnhandled(true);
+        $report->setSeverityReason([
+            'type' => 'unhandledException',
+        ]);
 
         $this->client->notify($report);
 
@@ -176,15 +176,16 @@ class Handler
                 $errstr,
                 $errfile,
                 $errline,
-                false,
-                true,
-                [
-                    'type' => 'unhandledError',
-                    'attributes' => [
-                        'errorType' => ErrorTypes::getName($errno),
-                    ],
-                ]
+                false
             );
+
+            $report->setUnhandled(true);
+            $report->setSeverityReason([
+                'type' => 'unhandledError',
+                'attributes' => [
+                    'errorType' => ErrorTypes::getName($errno),
+                ],
+            ]);
 
             $this->client->notify($report);
         }
@@ -220,13 +221,13 @@ class Handler
                 $lastError['message'],
                 $lastError['file'],
                 $lastError['line'],
-                true,
-                true,
-                [
-                    'type' => 'unhandledException',
-                ]
+                true
             );
             $report->setSeverity('error');
+            $report->setUnhandled(true);
+            $report->setSeverityReason([
+                'type' => 'unhandledException',
+            ]);
             $this->client->notify($report);
         }
 

--- a/src/Report.php
+++ b/src/Report.php
@@ -237,13 +237,17 @@ class Report
      *
      * @return static
      */
-    public static function fromNamedError(Configuration $config, $name, $message = null)
+    public static function fromNamedError(Configuration $config, $name, $message = null, $severityReason = null, array $attributes = null)
     {
         $report = new static($config);
 
         $report->setName($name)
               ->setMessage($message)
               ->setStacktrace(Stacktrace::generate($config));
+
+        if ($severityReason) {
+            $report->setUnhandledData($severityReason, $attributes);
+        }
 
         return $report;
     }

--- a/src/Report.php
+++ b/src/Report.php
@@ -123,19 +123,16 @@ class Report
      * @param string                 $file           the error file
      * @param int                    $line           the error line
      * @param bool                   $fatal          if the error was fatal
-     * @param bool                   $unhandled      if the error is unhandled or not
-     * @param string                 $severityReason the severity reason
      *
      * @return static
      */
-    public static function fromPHPError(Configuration $config, $code, $message, $file, $line,
-        $fatal = false, $unhandled = false, array $severityReason = ['type' => 'handledError'])
+    public static function fromPHPError(Configuration $config, $code, $message, $file, $line, $fatal = false)
     {
         $report = new static($config);
 
         $report->setPHPError($code, $message, $file, $line, $fatal)
-               ->setUnhandled($unhandled)
-               ->setSeverityReason($severityReason);
+               ->setUnhandled(false)
+               ->setSeverityReason(['type' => 'handledError']);
 
         return $report;
     }
@@ -145,18 +142,16 @@ class Report
      *
      * @param \Bugsnag\Configuration $config         the config instance
      * @param \Throwable             $throwable      the throwable instance
-     * @param bool                   $unhandled      if the error is unhandled or not
-     * @param string                 $severityReason the severity reason
      *
      * @return static
      */
-    public static function fromPHPThrowable(Configuration $config, $throwable, $unhandled = false, array $severityReason = ['type' => 'handledException'])
+    public static function fromPHPThrowable(Configuration $config, $throwable)
     {
         $report = new static($config);
 
         $report->setPHPThrowable($throwable)
-               ->setUnhandled($unhandled)
-               ->setSeverityReason($severityReason);
+               ->setUnhandled(false)
+               ->setSeverityReason(['type' => 'handledException']);
 
         return $report;
     }
@@ -167,20 +162,18 @@ class Report
      * @param \Bugsnag\Configuration $config  the config instance
      * @param string                 $name    the error name
      * @param string|null            $message the error message
-     * @param bool                   $unhandled      if the error is unhandled or not
-     * @param string                 $severityReason the severity reason
      *
      * @return static
      */
-    public static function fromNamedError(Configuration $config, $name, $message = null, $unhandled = false, array $severityReason = ['type' => 'handledError'])
+    public static function fromNamedError(Configuration $config, $name, $message = null)
     {
         $report = new static($config);
 
         $report->setName($name)
               ->setMessage($message)
               ->setStacktrace(Stacktrace::generate($config))
-              ->setUnhandled($unhandled)
-              ->setSeverityReason($severityReason);
+              ->setUnhandled(false)
+              ->setSeverityReason(['type' => 'handledError']);
 
         return $report;
     }
@@ -300,7 +293,7 @@ class Report
      *
      * @return $this
      */
-    protected function setUnhandled($unhandled)
+    public function setUnhandled($unhandled)
     {
         $this->unhandled = $unhandled;
 

--- a/src/Report.php
+++ b/src/Report.php
@@ -300,7 +300,7 @@ class Report
      *
      * @return $this
      */
-    protected function setUnhandled(bool $unhandled)
+    protected function setUnhandled($unhandled)
     {
         $this->unhandled = $unhandled;
 

--- a/src/Report.php
+++ b/src/Report.php
@@ -215,8 +215,7 @@ class Report
      *
      * @return static
      */
-    public static function fromPHPThrowable(Configuration $config, $throwable, array $unhandledConfig = null,
-        $severityReason = null, array $attributes = [])
+    public static function fromPHPThrowable(Configuration $config, $throwable, $severityReason = null, array $attributes = [])
     {
         $report = new static($config);
 
@@ -450,7 +449,7 @@ class Report
     {
         return $this->message;
     }
-
+    
     /**
      * Set the error severity.
      *

--- a/src/Report.php
+++ b/src/Report.php
@@ -192,7 +192,7 @@ class Report
      * @return static
      */
     public static function fromPHPError(Configuration $config, $code, $message, $file, $line,
-        $fatal = false, $severityReason = null, array $attributes = [])
+        $fatal = false, $severityReason = null, array $attributes = null)
     {
         $report = new static($config);
 
@@ -215,7 +215,7 @@ class Report
      *
      * @return static
      */
-    public static function fromPHPThrowable(Configuration $config, $throwable, $severityReason = null, array $attributes = [])
+    public static function fromPHPThrowable(Configuration $config, $throwable, $severityReason = null, array $attributes = null)
     {
         $report = new static($config);
 
@@ -345,7 +345,9 @@ class Report
     {
         $this->unhandled = true;
         $this->unhandledPayload["type"] = $severityReason;
-        $this->unhandledPayload["attributes"] = $attributes;
+        if ($attributes) {
+            $this->unhandledPayload["attributes"] = $attributes;
+        }
         return $this;
     }
 

--- a/src/Report.php
+++ b/src/Report.php
@@ -418,11 +418,6 @@ class Report
     {
         if (in_array($severity, ['error', 'warning', 'info', null], true)) {
             $this->severity = $severity;
-            if (!$this->unhandled) {
-                $this->setSeverityReason([
-                    'type' => 'userSpecifiedSeverity',
-                ]);
-            }
         } else {
             throw new InvalidArgumentException('The severity must be either "error", "warning", or "info".');
         }

--- a/src/Report.php
+++ b/src/Report.php
@@ -341,7 +341,7 @@ class Report
      *
      * @return $this
      */
-    protected function setUnhandledData(string $severityReason, array $attributes = null)
+    protected function setUnhandledData($severityReason, array $attributes = null)
     {
         $this->unhandled = true;
         $this->unhandledPayload['type'] = $severityReason;
@@ -357,7 +357,7 @@ class Report
      *
      * @return $this
      */
-    public function setDefaultSeverity(bool $defaultSeverity)
+    public function setDefaultSeverity($defaultSeverity)
     {
         $this->defaultSeverity = $defaultSeverity;
 

--- a/src/Report.php
+++ b/src/Report.php
@@ -344,10 +344,11 @@ class Report
     protected function setUnhandledData(string $severityReason, array $attributes = null)
     {
         $this->unhandled = true;
-        $this->unhandledPayload["type"] = $severityReason;
+        $this->unhandledPayload['type'] = $severityReason;
         if ($attributes) {
-            $this->unhandledPayload["attributes"] = $attributes;
+            $this->unhandledPayload['attributes'] = $attributes;
         }
+
         return $this;
     }
 

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -443,4 +443,29 @@ class ClientTest extends TestCase
 
         $this->client->deploy('baz', 'develop', 'foo');
     }
+
+    public function testDefaultSeverityUnmodified()
+    {
+        $this->client = new Client($this->config = new Configuration('example-api-key'), null, $this->guzzle);
+
+        $this->client->notify($report = Report::fromNamedError($this->config, 'Name'));
+
+        $event = $report->toArray();
+
+        $this->assertTrue($event['defaultSeverity']);
+    }
+
+    public function testDefaultSeverityModifiedByCallback()
+    {
+        $this->client = new Client($this->config = new Configuration('example-api-key'), null, $this->guzzle);
+
+        $this->client->notify($report = Report::fromNamedError($this->config, 'Name'), function ($report) {
+            $report->setSeverity('warning');
+        });
+
+        $event = $report->toArray();
+        
+        $this->assertSame($event['severity'], 'warning');
+        $this->assertTrue($event['defaultSeverity']);
+    }
 }

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -464,7 +464,7 @@ class ClientTest extends TestCase
         });
 
         $event = $report->toArray();
-        
+
         $this->assertSame($event['severity'], 'warning');
         $this->assertTrue($event['defaultSeverity']);
     }

--- a/tests/ReportTest.php
+++ b/tests/ReportTest.php
@@ -333,14 +333,4 @@ class ReportTest extends TestCase
         $this->assertTrue($data['unhandled']);
         $this->assertSame($data['severityReason'], ['type' => 'unhandledException']);
     }
-
-    public function testOverridingSeverityChangedSeverityReason()
-    {
-        $exception = new Exception('exception');
-        $report = Report::fromPHPThrowable($this->config, $exception);
-        $report->setSeverity('warning');
-        $data = $report->toArray();
-        $this->assertSame($data['severity'], 'warning');
-        $this->assertSame($data['severityReason'], ['type' => 'userSpecifiedSeverity']);
-    }
 }

--- a/tests/ReportTest.php
+++ b/tests/ReportTest.php
@@ -306,6 +306,7 @@ class ReportTest extends TestCase
     {
         $data = $this->report->toArray();
         $this->assertFalse($data['unhandled']);
+        $this->assertFalse(isset($data['severityReason']));
     }
 
     public function testSetSeverityReason()

--- a/tests/ReportTest.php
+++ b/tests/ReportTest.php
@@ -300,7 +300,7 @@ class ReportTest extends TestCase
     }
 
     /**
-     * Testing handled/unhandled
+     * Testing handled/unhandled.
      */
     public function testDefaultsToHandled()
     {

--- a/tests/ReportTest.php
+++ b/tests/ReportTest.php
@@ -309,14 +309,17 @@ class ReportTest extends TestCase
         $namedErrorData = Report::fromNamedError($this->config, 'E_ERROR', null)->toArray();
         $phpErrorData = Report::fromPHPError($this->config, E_WARNING, null, 'file', 1, false)->toArray();
         $this->assertFalse($throwableData['unhandled']);
+        $this->assertSame($throwableData['severity'], 'warning');
         $this->assertSame($throwableData['severityReason'], [
             'type' => 'handledException'
         ]);
         $this->assertFalse($namedErrorData['unhandled']);
+        $this->assertSame($namedErrorData['severity'], 'warning');
         $this->assertSame($namedErrorData['severityReason'], [
             'type' => 'handledError'
         ]);
         $this->assertFalse($phpErrorData['unhandled']);
+        $this->assertSame($phpErrorData['severity'], 'warning');
         $this->assertSame($phpErrorData['severityReason'], [
             'type' => 'handledError'
         ]);

--- a/tests/ReportTest.php
+++ b/tests/ReportTest.php
@@ -298,4 +298,32 @@ class ReportTest extends TestCase
 
         $this->assertSame(['message' => 'bar', 'severity' => 'warning'], $this->report->getSummary());
     }
+
+    /**
+     * Testing handled/unhandled
+     */
+    public function testDefaultsToHandled()
+    {
+        $data = $this->report->toArray();
+        $this->assertFalse($data['unhandled']);
+    }
+
+    public function testSetSeverityReason()
+    {
+        $exception = new Exception('exception');
+        $report = Report::fromPHPThrowable($this->config, $exception, Report::EXCEPTION_HANDLER);
+        $data = $report->toArray();
+        $this->assertTrue($data['unhandled']);
+        $this->assertSame($data['severityReason'], ['type' => Report::EXCEPTION_HANDLER]);
+    }
+
+    public function testAttributesAssigned()
+    {
+        $exception = new Exception('exception');
+        $report = Report::fromPHPThrowable($this->config,
+            $exception, Report::MIDDLEWARE_HANDLER, ['name' => 'laravel']);
+        $data = $report->toArray();
+        $this->assertSame($data['severityReason'],
+            ['type' => Report::MIDDLEWARE_HANDLER, 'attributes' => ['name' => 'laravel']]);
+    }
 }

--- a/tests/ReportTest.php
+++ b/tests/ReportTest.php
@@ -328,7 +328,9 @@ class ReportTest extends TestCase
     public function testSettingSeverityReason()
     {
         $exception = new Exception('exception');
-        $report = Report::fromPHPThrowable($this->config, $exception, true, ['type' => 'unhandledException']);
+        $report = Report::fromPHPThrowable($this->config, $exception);
+        $report->setUnhandled(true);
+        $report->setSeverityReason(['type' => 'unhandledException']);
         $data = $report->toArray();
         $this->assertTrue($data['unhandled']);
         $this->assertSame($data['severityReason'], ['type' => 'unhandledException']);


### PR DESCRIPTION
- Adds `defaultSeverity`, `unhandled`, and `severityReasons` payload properties to support upcoming handled/unhandled functionality
- Properties added when creating a report, functionality a user should not use directly
- Systems error handlers setup with correct severityReasons
_references [PLAT_208](https://bugsnag.atlassian.net/browse/PLAT-208)_