### PR TITLE
Catch exceptions when getting session data in RequestSession callback

### DIFF
--- a/src/Callbacks/RequestSession.php
+++ b/src/Callbacks/RequestSession.php
@@ -35,7 +35,16 @@ class RequestSession
      */
     public function __invoke(Report $report)
     {
-        if ($data = $this->resolver->resolve()->getSession()) {
+        $request = $this->resolver->resolve();
+        $data = null;
+
+        try {
+            $data = $request->getSession();
+        } catch (\Exception $e) {
+            // Cannot obtain session data
+        }
+
+        if ($data) {
             $report->setMetaData(['session' => $data]);
         }
     }


### PR DESCRIPTION
Fixes #405

Just a quick proposal so we have something to talk about. For example...

Contains an empty `\Exception` handler, which is obviously not ideal (I'm not sure what you'd like to happen in the case of an exception thrown from the session handler; but silently swallowing it is probably not quite right? Log instead? Add some different metadata?)