### PR TITLE
Ensured can handle empty console arg array correctly

### DIFF
--- a/src/Request/ConsoleRequest.php
+++ b/src/Request/ConsoleRequest.php
@@ -60,6 +60,11 @@ class ConsoleRequest implements RequestInterface
      */
     public function getMetaData()
     {
+        if (count($this->command) == 0) {
+            return ['console' => [
+                'Command' => 'Command could not be retreived']
+            ];
+        }
         $commandString = implode(' ', $this->command);
         $primaryCommand = $this->command[0];
         $arguments = [];

--- a/src/Request/ConsoleRequest.php
+++ b/src/Request/ConsoleRequest.php
@@ -62,7 +62,7 @@ class ConsoleRequest implements RequestInterface
     {
         if (count($this->command) == 0) {
             return ['console' => [
-                'Command' => 'Command could not be retreived']
+                'Command' => 'Command could not be retrieved']
             ];
         }
         $commandString = implode(' ', $this->command);

--- a/src/Request/ConsoleRequest.php
+++ b/src/Request/ConsoleRequest.php
@@ -62,7 +62,7 @@ class ConsoleRequest implements RequestInterface
     {
         if (count($this->command) == 0) {
             return ['console' => [
-                'Command' => 'Command could not be retrieved']
+                'Command' => 'Command could not be retrieved', ],
             ];
         }
         $commandString = implode(' ', $this->command);

--- a/tests/Callbacks/RequestMetaDataTest.php
+++ b/tests/Callbacks/RequestMetaDataTest.php
@@ -78,7 +78,7 @@ class RequestMetaDataTest extends TestCase
         $callback($report);
 
         $this->assertSame(['bar' => 'baz', 'console' => [
-            'Command' => 'Command could not be retreived',
+            'Command' => 'Command could not be retrieved',
         ]], $report->getMetaData());
     }
 

--- a/tests/Callbacks/RequestMetaDataTest.php
+++ b/tests/Callbacks/RequestMetaDataTest.php
@@ -67,6 +67,21 @@ class RequestMetaDataTest extends TestCase
         ]], $report->getMetaData());
     }
 
+    public function testCanHandleEmptyConsoleArray()
+    {
+        $_SERVER['argv'] = [];
+
+        $report = Report::fromPHPThrowable($this->config, new Exception())->setMetaData(['bar' => 'baz']);
+        
+        $callback = new RequestMetaData($this->resolver);
+
+        $callback($report);
+
+        $this->assertSame(['bar' => 'baz', 'console' => [
+            'Command' => 'Command could not be retreived',
+        ]], $report->getMetaData());
+    }
+
     public function testFallsBackToNull()
     {
         unset($_SERVER['argv']);


### PR DESCRIPTION
Fixes issue reported here #411 

- Ensures defaults in place if an empty array is provided to as console commands.