### PR TITLE
Adds Bugsnag-logger configuration options

### DIFF
--- a/src/Configuration.php
+++ b/src/Configuration.php
@@ -102,6 +102,27 @@ class Configuration
     protected $errorReportingLevel;
 
     /**
+     * The level logs must match or exceed to send a notification
+     * 
+     * @var string|null
+     */
+    protected $logNotifyLevel;
+
+    /**
+     * The level logs must match or exceed be set to a "warning" severity
+     * 
+     * @var string|null
+     */
+    protected $logWarningLevel;
+
+    /**
+     * The level logs must match or exceed be set to an "error" severity
+     * 
+     * @var string|null
+     */
+    protected $logErrorLevel;
+
+    /**
      * Create a new config instance.
      *
      * @param string $apiKey your bugsnag api key
@@ -485,5 +506,69 @@ class Configuration
         }
 
         return !(error_reporting() & $code);
+    }
+
+    /**
+     * Set the Level at which a bugsnag-logger will generate a notification to Bugsnag
+     * 
+     * If this is not set, the logger will default to using the 'notice' level.
+     * 
+     * @param string|null $logLevel the log-level to send notifications at
+     * 
+     * @return $this
+     */
+    public function setLogNotifyLevel(string $logNotifyLevel)
+    {
+        $this->logNotifyLevel = $logNotifyLevel;
+
+        return $this;
+    }
+
+    /**
+     * Set the Level at which a bugsnag-logger generated notification will use the
+     * 'warning' severity.
+     * 
+     * If this is not set, the logger will default to using the 'warning' level.
+     * 
+     * @param string|null $logWarningLevel the log-level to send 
+     * 
+     * @return $this
+     */
+    public function setLogWarningLevel(string $logWarningLevel)
+    {
+        $this->logWarningLevel = $logWarningLevel;
+
+        return $this;
+    }
+
+    /**
+     * Set the Level at which a bugsnag-logger generated notification will use the
+     * 'error' severity.
+     * 
+     * If this is not set, the logger will default to using the 'error' level.
+     * 
+     * @param string|null $logLevel the log-level to send notifications at
+     * 
+     * @return $this
+     */
+    public function setLogErrorLevel(string $logErrorLevel)
+    {
+        $this->logErrorLevel = $logErrorLevel;
+
+        return $this;
+    }
+
+    /**
+     * Gets the log level settings to be used by the bugsnag-logger
+     * 
+     * @return array
+     */
+    public function getLogLevels()
+    {
+        return [
+            "notifyLevel" => $this->logNotifyLevel,
+            "warningLevel" => $this->logWarningLevel,
+            "errorLevel" => $this->logErrorLevel
+        ];
     }
 }

--- a/src/Configuration.php
+++ b/src/Configuration.php
@@ -102,22 +102,22 @@ class Configuration
     protected $errorReportingLevel;
 
     /**
-     * The level logs must match or exceed to send a notification
-     * 
+     * The level logs must match or exceed to send a notification.
+     *
      * @var string|null
      */
     protected $logNotifyLevel;
 
     /**
-     * The level logs must match or exceed be set to a "warning" severity
-     * 
+     * The level logs must match or exceed be set to a "warning" severity.
+     *
      * @var string|null
      */
     protected $logWarningLevel;
 
     /**
-     * The level logs must match or exceed be set to an "error" severity
-     * 
+     * The level logs must match or exceed be set to an "error" severity.
+     *
      * @var string|null
      */
     protected $logErrorLevel;
@@ -509,12 +509,12 @@ class Configuration
     }
 
     /**
-     * Set the Level at which a bugsnag-logger will generate a notification to Bugsnag
-     * 
+     * Set the Level at which a bugsnag-logger will generate a notification to Bugsnag.
+     *
      * If this is not set, the logger will default to using the 'notice' level.
-     * 
+     *
      * @param string|null $logLevel the log-level to send notifications at
-     * 
+     *
      * @return $this
      */
     public function setLogNotifyLevel(string $logNotifyLevel)
@@ -527,11 +527,11 @@ class Configuration
     /**
      * Set the Level at which a bugsnag-logger generated notification will use the
      * 'warning' severity.
-     * 
+     *
      * If this is not set, the logger will default to using the 'warning' level.
-     * 
-     * @param string|null $logWarningLevel the log-level to send 
-     * 
+     *
+     * @param string|null $logWarningLevel the log-level to send
+     *
      * @return $this
      */
     public function setLogWarningLevel(string $logWarningLevel)
@@ -544,11 +544,11 @@ class Configuration
     /**
      * Set the Level at which a bugsnag-logger generated notification will use the
      * 'error' severity.
-     * 
+     *
      * If this is not set, the logger will default to using the 'error' level.
-     * 
+     *
      * @param string|null $logLevel the log-level to send notifications at
-     * 
+     *
      * @return $this
      */
     public function setLogErrorLevel(string $logErrorLevel)
@@ -559,16 +559,16 @@ class Configuration
     }
 
     /**
-     * Gets the log level settings to be used by the bugsnag-logger
-     * 
+     * Gets the log level settings to be used by the bugsnag-logger.
+     *
      * @return array
      */
     public function getLogLevels()
     {
         return [
-            "notifyLevel" => $this->logNotifyLevel,
-            "warningLevel" => $this->logWarningLevel,
-            "errorLevel" => $this->logErrorLevel
+            'notifyLevel' => $this->logNotifyLevel,
+            'warningLevel' => $this->logWarningLevel,
+            'errorLevel' => $this->logErrorLevel,
         ];
     }
 }

--- a/src/Configuration.php
+++ b/src/Configuration.php
@@ -109,20 +109,6 @@ class Configuration
     protected $logNotifyLevel;
 
     /**
-     * The level logs must match or exceed be set to a "warning" severity.
-     *
-     * @var string|null
-     */
-    protected $logWarningLevel;
-
-    /**
-     * The level logs must match or exceed be set to an "error" severity.
-     *
-     * @var string|null
-     */
-    protected $logErrorLevel;
-
-    /**
      * Create a new config instance.
      *
      * @param string $apiKey your bugsnag api key
@@ -525,50 +511,12 @@ class Configuration
     }
 
     /**
-     * Set the Level at which a bugsnag-logger generated notification will use the
-     * 'warning' severity.
-     *
-     * If this is not set, the logger will default to using the 'warning' level.
-     *
-     * @param string|null $logWarningLevel the log-level to send
-     *
-     * @return $this
-     */
-    public function setLogWarningLevel(string $logWarningLevel)
-    {
-        $this->logWarningLevel = $logWarningLevel;
-
-        return $this;
-    }
-
-    /**
-     * Set the Level at which a bugsnag-logger generated notification will use the
-     * 'error' severity.
-     *
-     * If this is not set, the logger will default to using the 'error' level.
-     *
-     * @param string|null $logLevel the log-level to send notifications at
-     *
-     * @return $this
-     */
-    public function setLogErrorLevel(string $logErrorLevel)
-    {
-        $this->logErrorLevel = $logErrorLevel;
-
-        return $this;
-    }
-
-    /**
-     * Gets the log level settings to be used by the bugsnag-logger.
+     * Gets the log level to be used by the bugsnag-logger.
      *
      * @return array
      */
-    public function getLogLevels()
+    public function getLogNotifyLevel()
     {
-        return [
-            'notifyLevel' => $this->logNotifyLevel,
-            'warningLevel' => $this->logWarningLevel,
-            'errorLevel' => $this->logErrorLevel,
-        ];
+        return $this->logNotifyLevel;
     }
 }


### PR DESCRIPTION
This adds 3 new configuration options for use with the [Bugsnag PSR logger](https://github.com/bugsnag/bugsnag-psr-logger):

NotifyLevel: The LogLevel at which notifications will be sent to bugsnag
WarningLevel: The LogLevel at which notifications will be given a severity "warning"
ErrorLevel: The LogLevel at which notifications will be given a severity "error"