### PR TITLE
Fix: Ensure that the "type" parameter has a sensible default

### DIFF
--- a/src/Report.php
+++ b/src/Report.php
@@ -273,6 +273,9 @@ class Report
      */
     public function getSeverityReason()
     {
+        if (!array_key_exists('type', $this->severityReason)) {
+            $this->severityReason['type'] = 'userSpecifiedSeverity';
+        }
         return $this->severityReason;
     }
 

--- a/tests/ReportTest.php
+++ b/tests/ReportTest.php
@@ -340,7 +340,6 @@ class ReportTest extends TestCase
     {
         $exception = new Exception('exception');
         $report = Report::fromPHPThrowable($this->config, $exception);
-        $report->setUnhandled(true);
         $report->setSeverityReason(['foo' => 'bar']);
         $data = $report->toArray();
         $this->assertSame($data['severityReason'], ['foo' => 'bar', 'type' => 'userSpecifiedSeverity']);

--- a/tests/ReportTest.php
+++ b/tests/ReportTest.php
@@ -335,4 +335,14 @@ class ReportTest extends TestCase
         $this->assertTrue($data['unhandled']);
         $this->assertSame($data['severityReason'], ['type' => 'unhandledException']);
     }
+
+    public function testDefaultSeverityTypeSet()
+    {
+        $exception = new Exception('exception');
+        $report = Report::fromPHPThrowable($this->config, $exception);
+        $report->setUnhandled(true);
+        $report->setSeverityReason(['foo' => 'bar']);
+        $data = $report->toArray();
+        $this->assertSame($data['severityReason'], ['foo' => 'bar', 'type' => 'userSpecifiedSeverity']);
+    }
 }


### PR DESCRIPTION
Ensures that the "type" parameter in the "severityReason" has a sensible default.