### PR TITLE
Add 'addMetaData' method to reports

### DIFF
--- a/src/Report.php
+++ b/src/Report.php
@@ -498,14 +498,16 @@ class Report
 
     /**
      * Adds a tab to the meta data.
+     * Conflicting keys will be merged if able, otherwise the new values will be accepted.
+     * Null values will be deleted from the metadata.
      * 
-     * @param array[] $data an array of custom data to attach
+     * @param array[] $metadata an array of custom data to attach to the report
      * 
      * @return $this
      */
-    public function addMetaData(array $tab)
+    public function addMetaData(array $metadata)
     {
-        $this->metaData = array_replace_recursive($this->metaData, $tab);
+        $this->metaData = array_replace_recursive($this->metaData, $metadata);
         $this->metaData = array_filter($this->metaData, function($val) {
             return !is_null($val);
         });

--- a/src/Report.php
+++ b/src/Report.php
@@ -709,9 +709,9 @@ class Report
 
     /**
      * Recursively remove null elements.
-     * 
+     *
      * @param array $array  the array to remove null elements from
-     * 
+     *
      * @return array
      */
     protected function removeNullElements($array)
@@ -723,6 +723,7 @@ class Report
                 unset($array[$key]);
             }
         }
+
         return $array;
     }
 }

--- a/src/Report.php
+++ b/src/Report.php
@@ -497,6 +497,22 @@ class Report
     }
 
     /**
+     * Adds a tab to the meta data.
+     * 
+     * @param array[] $data an array of custom data to attach
+     * 
+     * @return $this
+     */
+    public function addMetaData(array $tab)
+    {
+        $this->metaData = array_replace_recursive($this->metaData, $tab);
+        $this->metaData = array_filter($this->metaData, function($val) {
+            return !is_null($val);
+        });
+        return $this;
+    }
+
+    /**
      * Get the error meta data.
      *
      * @return array[]

--- a/src/Report.php
+++ b/src/Report.php
@@ -500,15 +500,15 @@ class Report
      * Adds a tab to the meta data.
      * Conflicting keys will be merged if able, otherwise the new values will be accepted.
      * Null values will be deleted from the metadata.
-     * 
+     *
      * @param array[] $metadata an array of custom data to attach to the report
-     * 
+     *
      * @return $this
      */
     public function addMetaData(array $metadata)
     {
         $this->metaData = array_replace_recursive($this->metaData, $metadata);
-        $this->metaData = array_filter($this->metaData, function($val) {
+        $this->metaData = array_filter($this->metaData, function ($val) {
             return !is_null($val);
         });
 

--- a/src/Report.php
+++ b/src/Report.php
@@ -508,9 +508,7 @@ class Report
     public function addMetaData(array $metadata)
     {
         $this->metaData = array_replace_recursive($this->metaData, $metadata);
-        $this->metaData = array_filter($this->metaData, function ($val) {
-            return !is_null($val);
-        });
+        $this->metaData = $this->removeNullElements($this->metaData);
 
         return $this;
     }
@@ -707,5 +705,24 @@ class Report
         }
 
         return false;
+    }
+
+    /**
+     * Recursively remove null elements.
+     * 
+     * @param array $array  the array to remove null elements from
+     * 
+     * @return array
+     */
+    protected function removeNullElements($array)
+    {
+        foreach ($array as $key => $val) {
+            if (is_array($val)) {
+                $array[$key] = $this->removeNullElements($val);
+            } elseif (is_null($val)) {
+                unset($array[$key]);
+            }
+        }
+        return $array;
     }
 }

--- a/tests/ReportTest.php
+++ b/tests/ReportTest.php
@@ -52,6 +52,35 @@ class ReportTest extends TestCase
 
         $this->assertSame(['Testing' => ['globalArray' => 'hi']], $this->report->toArray()['metaData']);
     }
+    
+    public function testAddMetaDataCreate()
+    {
+        $this->report->addMetaData(['Testing' => ['globalArray' => 'hi']]);
+
+        $this->assertSame(['Testing' => ['globalArray' => 'hi']], $this->report->toArray()['metaData']);
+    }
+
+    public function testAddMetaDataDeletesIfNull()
+    {
+        $this->report->setMetaData(['Testing' => ['globalArray' => 'hi'], 'Delete' => 'test']);
+
+        $this->assertSame(['Testing' => ['globalArray' => 'hi'], 'Delete' => 'test'], $this->report->toArray()['metaData']);
+
+        $this->report->addMetaData(['Delete' => null]);
+
+        $this->assertSame(['Testing' => ['globalArray' => 'hi']], $this->report->toArray()['metaData']);
+    }
+
+    public function testAddMetaDataMerge()
+    {
+        $this->report->setMetaData(['Testing' => ['array' => 'hi'], 'Replace' => 'Scalar']);
+
+        $this->assertSame(['Testing' => ['array' => 'hi'], 'Replace' => 'Scalar'], $this->report->toArray()['metaData']);
+
+        $this->report->addMetaData(['Testing' => ['second' => 'array'], 'Replace' => ['array' => 'replacement']]);
+
+        $this->assertSame(['Testing' => ['array' => 'hi', 'second' => 'array'], 'Replace' => ['array' => 'replacement']], $this->report->toArray()['metaData']);
+    }
 
     public function testUser()
     {

--- a/tests/ReportTest.php
+++ b/tests/ReportTest.php
@@ -62,11 +62,11 @@ class ReportTest extends TestCase
 
     public function testAddMetaDataDeletesIfNull()
     {
-        $this->report->setMetaData(['Testing' => ['globalArray' => 'hi'], 'Delete' => 'test']);
+        $this->report->setMetaData(['Testing' => ['globalArray' => 'hi', 'Delete' => 'test'], 'Delete' => 'test']);
 
-        $this->assertSame(['Testing' => ['globalArray' => 'hi'], 'Delete' => 'test'], $this->report->toArray()['metaData']);
+        $this->assertSame(['Testing' => ['globalArray' => 'hi', 'Delete' => 'test'], 'Delete' => 'test'], $this->report->toArray()['metaData']);
 
-        $this->report->addMetaData(['Delete' => null]);
+        $this->report->addMetaData(['Testing' => ['Delete' => null], 'Delete' => null]);
 
         $this->assertSame(['Testing' => ['globalArray' => 'hi']], $this->report->toArray()['metaData']);
     }


### PR DESCRIPTION
Adds an 'addMetaData' method to the `Report` object to allow easy creation/deletion/updating of report metadata.
- Accepts an array 
- Adds new properties into the metadata array if they don't already exist
- Merges conflicting properties recursively if necessary, favouring new metadata
- Deletes properties with values that are null

Implements [#268](https://github.com/bugsnag/bugsnag-laravel/issues/268)