### PR TITLE
Updates deploy to build API

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -309,7 +309,8 @@ class Client
     }
 
     /**
-     * Notify Bugsnag of a deployment. This function is being deprecated in favour of `build`.
+     * Notify Bugsnag of a deployment.
+     * @deprecated This function is being deprecated in favour of `build`.
      *
      * @param string|null $repository the repository from which you are deploying the code
      * @param string|null $branch     the source control branch from which you are deploying

--- a/src/Client.php
+++ b/src/Client.php
@@ -325,29 +325,34 @@ class Client
     /**
      * Notify Bugsnag of a build.
      *
-     * @param string|null $repository the repository from which you are deploying the code
-     * @param string|null $revision   the source control revision you are currently deploying
-     * @param string|null $provider   the provider of the source control for the build
+     * @param string|null $repository  the repository from which you are deploying the code
+     * @param string|null $revision    the source control revision you are currently deploying
+     * @param string|null $provider    the provider of the source control for the build
+     * @param string|null $builderName the name of who or what is making the build
      *
      * @return void
      */
-    public function build($repository = null, $revision = null, $provider = null)
+    public function build($repository = null, $revision = null, $provider = null, $builderName = null)
     {
-        $sourceControl = [];
+        $data = [];
 
         if ($repository) {
-            $sourceControl['repository'] = $repository;
+            $data['repository'] = $repository;
         }
 
         if ($revision) {
-            $sourceControl['revision'] = $revision;
+            $data['revision'] = $revision;
         }
 
         if ($provider) {
-            $sourceControl['provider'] = $provider;
+            $data['provider'] = $provider;
         }
 
-        $this->http->sendBuildReport($sourceControl);
+        if ($builderName) {
+            $data['builder'] = $builderName;
+        }
+
+        $this->http->sendBuildReport($data);
     }
 
     /**

--- a/src/Client.php
+++ b/src/Client.php
@@ -309,7 +309,7 @@ class Client
     }
 
     /**
-     * Notify Bugsnag of a deployment.
+     * Notify Bugsnag of a deployment. This function is being deprecated in favour of `build`
      *
      * @param string|null $repository the repository from which you are deploying the code
      * @param string|null $branch     the source control branch from which you are deploying
@@ -319,21 +319,35 @@ class Client
      */
     public function deploy($repository = null, $branch = null, $revision = null)
     {
-        $data = [];
+        $this->build($repository, $revision);
+    }
+
+    /**
+     * Notify Bugsnag of a build.
+     *
+     * @param string|null $repository the repository from which you are deploying the code
+     * @param string|null $revision   the source control revision you are currently deploying
+     * @param string|null $provider   the provider of the source control for the build
+     *
+     * @return void
+     */
+    public function build($repository = null, $revision = null, $provider = null)
+    {
+        $sourceControl = [];
 
         if ($repository) {
-            $data['repository'] = $repository;
-        }
-
-        if ($branch) {
-            $data['branch'] = $branch;
+            $sourceControl['repository'] = $repository;
         }
 
         if ($revision) {
-            $data['revision'] = $revision;
+            $sourceControl['revision'] = $revision;
         }
 
-        $this->http->deploy($data);
+        if ($provider) {
+            $sourceControl['provider'] = $provider;
+        }
+
+        $this->http->sendBuildReport($sourceControl);
     }
 
     /**

--- a/src/Client.php
+++ b/src/Client.php
@@ -333,7 +333,7 @@ class Client
      *
      * @return void
      */
-    public function build($repository = null, $revision = null, $provider = null, $builderName = null)
+    public function build($repository = null, $revision = null, $provider = null, $builderName = null, $buildTool = null)
     {
         $data = [];
 
@@ -351,6 +351,10 @@ class Client
 
         if ($builderName) {
             $data['builder'] = $builderName;
+        }
+
+        if ($buildTool) {
+            $data['buildTool'] = $buildTool;
         }
 
         $this->http->sendBuildReport($data);

--- a/src/Client.php
+++ b/src/Client.php
@@ -334,7 +334,7 @@ class Client
      *
      * @return void
      */
-    public function build($repository = null, $revision = null, $provider = null, $builderName = null, $buildTool = null)
+    public function build($repository = null, $revision = null, $provider = null, $builderName = null)
     {
         $data = [];
 
@@ -352,10 +352,6 @@ class Client
 
         if ($builderName) {
             $data['builder'] = $builderName;
-        }
-
-        if ($buildTool) {
-            $data['buildTool'] = $buildTool;
         }
 
         $this->http->sendBuildReport($data);

--- a/src/Configuration.php
+++ b/src/Configuration.php
@@ -14,6 +14,13 @@ class Configuration
     const SESSION_ENDPOINT = 'https://sessions.bugsnag.com';
 
     /**
+     * The default build endpoint.
+     *
+     * @var string
+     */
+    const BUILD_ENDPOINT = 'https://build.bugsnag.com';
+
+    /**
      * The Bugnsag API Key.
      *
      * @var string
@@ -128,6 +135,13 @@ class Configuration
      * @var string
      */
     protected $sessionEndpoint = self::SESSION_ENDPOINT;
+
+    /**
+     * The endpoint to deliver build notifications to.
+     *
+     * @var string
+     */
+    protected $buildEndpoint;
 
     /**
      * Create a new config instance.
@@ -567,5 +581,32 @@ class Configuration
     public function shouldCaptureSessions()
     {
         return $this->autoCaptureSessions;
+    }
+
+    /**
+     * Sets the build endpoint.
+     *
+     * @param string $endpoint the build endpoint
+     *
+     * @return $this
+     */
+    public function setBuildEndpoint($endpoint)
+    {
+        $this->buildEndpoint = $endpoint;
+
+        return $this;
+    }
+
+    /**
+     * Returns the build endpoint.
+     *
+     * @return string
+     */
+    public function getBuildEndpoint()
+    {
+        if (isset($this->buildEndpoint)) {
+            return $this->buildEndpoint;
+        }
+        return self::BUILD_ENDPOINT;
     }
 }

--- a/src/HttpClient.php
+++ b/src/HttpClient.php
@@ -134,6 +134,12 @@ class HttpClient
             $data['builderName'] = $buildInfo['builder'];
         }
 
+        if (isset($buildInfo['buildTool'])) {
+            $data['buildTool'] = $buildInfo['buildTool'];
+        } else {
+            $data['buildTool'] = 'bugsnag-php';
+        }
+
         $data['releaseStage'] = $app['releaseStage'];
 
         if (isset($app['version'])) {

--- a/src/HttpClient.php
+++ b/src/HttpClient.php
@@ -124,7 +124,7 @@ class HttpClient
 
         if (isset($buildInfo['builder'])) {
             $data['builderName'] = $buildInfo['builder'];
-        } else {
+        } elseif ($this->functionAvailable('exec')) {
             $data['builderName'] = exec('whoami');
         }
 
@@ -145,6 +145,19 @@ class HttpClient
         $endpoint = $this->config->getBuildEndpoint();
 
         $this->guzzle->post($endpoint, ['json' => $data]);
+    }
+
+    /**
+     * Checks whether the function is available
+     *
+     * @param string $func function name
+     *
+     * @return bool
+     */
+    protected function functionAvailable($func)
+    {
+        $disabled = explode(',', ini_get('disable_functions'));
+        return function_exists($func) && !in_array($func, $disabled);
     }
 
     /**

--- a/src/HttpClient.php
+++ b/src/HttpClient.php
@@ -3,6 +3,7 @@
 namespace Bugsnag;
 
 use Exception;
+use Bugsnag\Utils;
 use GuzzleHttp\ClientInterface;
 use RuntimeException;
 
@@ -124,8 +125,8 @@ class HttpClient
 
         if (isset($buildInfo['builder'])) {
             $data['builderName'] = $buildInfo['builder'];
-        } elseif ($this->functionAvailable('exec')) {
-            $data['builderName'] = exec('whoami');
+        } else{
+            $data['builderName'] = Utils::getBuilderName();
         }
 
         if (isset($buildInfo['buildTool'])) {
@@ -145,19 +146,6 @@ class HttpClient
         $endpoint = $this->config->getBuildEndpoint();
 
         $this->guzzle->post($endpoint, ['json' => $data]);
-    }
-
-    /**
-     * Checks whether the function is available
-     *
-     * @param string $func function name
-     *
-     * @return bool
-     */
-    protected function functionAvailable($func)
-    {
-        $disabled = explode(',', ini_get('disable_functions'));
-        return function_exists($func) && !in_array($func, $disabled);
     }
 
     /**

--- a/src/HttpClient.php
+++ b/src/HttpClient.php
@@ -96,7 +96,7 @@ class HttpClient
     /**
      * Notify Bugsnag of a build.
      *
-     * @param array $data the build information
+     * @param array $buildInfo the build information
      *
      * @return void
      */

--- a/src/HttpClient.php
+++ b/src/HttpClient.php
@@ -99,12 +99,20 @@ class HttpClient
      *
      * @return void
      */
-    public function sendBuildReport(array $sourceControl)
+    public function sendBuildReport(array $buildInfo)
     {
         $app = $this->config->getAppData();
 
-        if (isset($sourceControl['repository']) && !isset($sourceControl['provider'])) {
-            $url = $sourceControl['repository'];
+        $data = [];
+        $sourceControl = [];
+        if (isset($buildInfo['repository'])) {
+            $sourceControl['repository'] = $buildInfo['repository'];
+        }
+
+        if (isset($buildInfo['provider'])) {
+            $sourceControl['provider'] = $buildInfo['provider'];
+        } elseif (isset($buildInfo['repository'])) {
+            $url = $buildInfo['repository'];
             if (strpos($url, 'github.com') != false) {
                 $sourceControl['provider'] = 'github';
             } elseif (strpos($url, 'bitbucket.com') != false) {
@@ -114,8 +122,16 @@ class HttpClient
             }
         }
 
+        if (isset($buildInfo['revision'])) {
+            $sourceControl['revision'] = $buildInfo['revision'];
+        }
+
         if (!empty($sourceControl)) {
             $data['sourceControl'] = $sourceControl;
+        }
+
+        if (isset($buildInfo['builder'])) {
+            $data['builderName'] = $buildInfo['builder'];
         }
 
         $data['releaseStage'] = $app['releaseStage'];

--- a/src/HttpClient.php
+++ b/src/HttpClient.php
@@ -3,7 +3,6 @@
 namespace Bugsnag;
 
 use Exception;
-use Bugsnag\Utils;
 use GuzzleHttp\ClientInterface;
 use RuntimeException;
 
@@ -125,7 +124,7 @@ class HttpClient
 
         if (isset($buildInfo['builder'])) {
             $data['builderName'] = $buildInfo['builder'];
-        } else{
+        } else {
             $data['builderName'] = Utils::getBuilderName();
         }
 

--- a/src/HttpClient.php
+++ b/src/HttpClient.php
@@ -112,15 +112,6 @@ class HttpClient
 
         if (isset($buildInfo['provider'])) {
             $sourceControl['provider'] = $buildInfo['provider'];
-        } elseif (isset($buildInfo['repository'])) {
-            $url = $buildInfo['repository'];
-            if (strpos($url, 'github.com') != false) {
-                $sourceControl['provider'] = 'github';
-            } elseif (strpos($url, 'bitbucket.com') != false) {
-                $sourceControl['provider'] = 'bitbucket';
-            } elseif (strpos($url, 'gitlab.com')) {
-                $sourceControl['provider'] = 'gitlab';
-            }
         }
 
         if (isset($buildInfo['revision'])) {
@@ -133,6 +124,8 @@ class HttpClient
 
         if (isset($buildInfo['builder'])) {
             $data['builderName'] = $buildInfo['builder'];
+        } else {
+            $data['builderName'] = exec('whoami');
         }
 
         if (isset($buildInfo['buildTool'])) {

--- a/src/HttpClient.php
+++ b/src/HttpClient.php
@@ -71,7 +71,7 @@ class HttpClient
 
     /**
      * Notify Bugsnag of a deployment.
-     * This method should no longer be used in favour of sendBuildReport.
+     * @deprecated This method should no longer be used in favour of sendBuildReport.
      *
      * @param array $data the deployment information
      *

--- a/src/Utils.php
+++ b/src/Utils.php
@@ -14,6 +14,7 @@ class Utils
     public static function functionAvailable($func)
     {
         $disabled = explode(',', ini_get('disable_functions'));
+
         return function_exists($func) && !in_array($func, $disabled);
     }
 
@@ -25,7 +26,7 @@ class Utils
     public static function getBuilderName()
     {
         $builderName = null;
-        if (Utils::functionAvailable('exec')) {
+        if (self::functionAvailable('exec')) {
             $output = [];
             $success = 0;
             exec('whoami', $output, $success);
@@ -36,6 +37,7 @@ class Utils
         if (is_null($builderName)) {
             $builderName = get_current_user();
         }
+
         return $builderName;
     }
 }

--- a/src/Utils.php
+++ b/src/Utils.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Bugsnag;
+
+class Utils
+{
+    /**
+     * Checks whether the given function name is available.
+     *
+     * @param string $func the function name
+     *
+     * @return bool
+     */
+    public static function functionAvailable($func)
+    {
+        $disabled = explode(',', ini_get('disable_functions'));
+        return function_exists($func) && !in_array($func, $disabled);
+    }
+
+    /**
+     * Gets the current user's identity for build reporting.
+     *
+     * @return string
+     */
+    public static function getBuilderName()
+    {
+        $builderName = null;
+        if (Utils::functionAvailable('exec')) {
+            $output = [];
+            $success = 0;
+            exec('whoami', $output, $success);
+            if ($success == 0) {
+                $builderName = $output[0];
+            }
+        }
+        if (is_null($builderName)) {
+            $builderName = get_current_user();
+        }
+        return $builderName;
+    }
+}

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -523,7 +523,19 @@ class ClientTest extends TestCase
         $this->client->build('baz', 'foo', 'github', 'me');
     }
 
-    public function testBuildAutoDetectsProvider()
+    public function testBuildAutoDetectsProviderGithub()
+    {
+        $this->guzzle->expects($this->once())->method('post')->with($this->equalTo('https://build.bugsnag.com'), $this->equalTo(['json' => ['sourceControl' => ['repository' => 'http://test.github.com', 'provider' => 'github'], 'releaseStage' => 'development', 'appVersion' => '1.3.1', 'apiKey' => 'example-api-key']]));
+
+        $this->client = new Client($this->config = new Configuration('example-api-key'), null, $this->guzzle);
+
+        $this->config->setReleaseStage('development');
+        $this->config->setAppVersion('1.3.1');
+
+        $this->client->build('http://test.github.com');
+    }
+
+    public function testBuildAutoDetectsProviderGitlab()
     {
         $this->guzzle->expects($this->once())->method('post')->with($this->equalTo('https://build.bugsnag.com'), $this->equalTo(['json' => ['sourceControl' => ['repository' => 'http://test.gitlab.com', 'provider' => 'gitlab'], 'releaseStage' => 'development', 'appVersion' => '1.3.1', 'apiKey' => 'example-api-key']]));
 
@@ -533,6 +545,18 @@ class ClientTest extends TestCase
         $this->config->setAppVersion('1.3.1');
 
         $this->client->build('http://test.gitlab.com');
+    }
+
+    public function testBuildAutoDetectsProviderBitbucket()
+    {
+        $this->guzzle->expects($this->once())->method('post')->with($this->equalTo('https://build.bugsnag.com'), $this->equalTo(['json' => ['sourceControl' => ['repository' => 'http://test.bitbucket.com', 'provider' => 'bitbucket'], 'releaseStage' => 'development', 'appVersion' => '1.3.1', 'apiKey' => 'example-api-key']]));
+
+        $this->client = new Client($this->config = new Configuration('example-api-key'), null, $this->guzzle);
+
+        $this->config->setReleaseStage('development');
+        $this->config->setAppVersion('1.3.1');
+
+        $this->client->build('http://test.bitbucket.com');
     }
 
     public function testSeverityReasonUnmodified()

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -376,16 +376,16 @@ class ClientTest extends TestCase
 
     public function testDeployWorksOutOfTheBox()
     {
-        $this->guzzle->expects($this->once())->method('post')->with($this->equalTo('https://build.bugsnag.com'), $this->equalTo(['json' => ['releaseStage' => 'production', 'apiKey' => 'example-api-key', 'buildTool' => 'bugsnag-php']]));
+        $this->guzzle->expects($this->once())->method('post')->with($this->equalTo('https://build.bugsnag.com'), $this->equalTo(['json' => ['releaseStage' => 'production', 'apiKey' => 'example-api-key', 'buildTool' => 'bugsnag-php', 'builderName' => exec('whoami')]]));
 
         $this->client = new Client($this->config = new Configuration('example-api-key'), null, $this->guzzle);
 
         $this->client->deploy();
     }
 
-    public function testDeployWorksWithgReleaseStage()
+    public function testDeployWorksWithReleaseStage()
     {
-        $this->guzzle->expects($this->once())->method('post')->with($this->equalTo('https://build.bugsnag.com'), $this->equalTo(['json' => ['releaseStage' => 'staging', 'apiKey' => 'example-api-key', 'buildTool' => 'bugsnag-php']]));
+        $this->guzzle->expects($this->once())->method('post')->with($this->equalTo('https://build.bugsnag.com'), $this->equalTo(['json' => ['releaseStage' => 'staging', 'apiKey' => 'example-api-key', 'buildTool' => 'bugsnag-php', 'builderName' => exec('whoami')]]));
 
         $this->client = new Client($this->config = new Configuration('example-api-key'), null, $this->guzzle);
 
@@ -396,7 +396,7 @@ class ClientTest extends TestCase
 
     public function testDeployWorksWithAppVersion()
     {
-        $this->guzzle->expects($this->once())->method('post')->with($this->equalTo('https://build.bugsnag.com'), $this->equalTo(['json' => ['releaseStage' => 'production', 'appVersion' => '1.1.0', 'apiKey' => 'example-api-key', 'buildTool' => 'bugsnag-php']]));
+        $this->guzzle->expects($this->once())->method('post')->with($this->equalTo('https://build.bugsnag.com'), $this->equalTo(['json' => ['releaseStage' => 'production', 'appVersion' => '1.1.0', 'apiKey' => 'example-api-key', 'buildTool' => 'bugsnag-php', 'builderName' => exec('whoami')]]));
 
         $this->client = new Client($this->config = new Configuration('example-api-key'), null, $this->guzzle);
 
@@ -407,7 +407,7 @@ class ClientTest extends TestCase
 
     public function testDeployWorksWithRepository()
     {
-        $this->guzzle->expects($this->once())->method('post')->with($this->equalTo('https://build.bugsnag.com'), $this->equalTo(['json' => ['sourceControl' => ['repository' => 'foo'], 'releaseStage' => 'production', 'apiKey' => 'example-api-key', 'buildTool' => 'bugsnag-php']]));
+        $this->guzzle->expects($this->once())->method('post')->with($this->equalTo('https://build.bugsnag.com'), $this->equalTo(['json' => ['sourceControl' => ['repository' => 'foo'], 'releaseStage' => 'production', 'apiKey' => 'example-api-key', 'buildTool' => 'bugsnag-php', 'builderName' => exec('whoami')]]));
 
         $this->client = new Client($this->config = new Configuration('example-api-key'), null, $this->guzzle);
 
@@ -416,7 +416,7 @@ class ClientTest extends TestCase
 
     public function testDeployWorksWithBranch()
     {
-        $this->guzzle->expects($this->once())->method('post')->with($this->equalTo('https://build.bugsnag.com'), $this->equalTo(['json' => ['releaseStage' => 'production', 'apiKey' => 'example-api-key', 'buildTool' => 'bugsnag-php']]));
+        $this->guzzle->expects($this->once())->method('post')->with($this->equalTo('https://build.bugsnag.com'), $this->equalTo(['json' => ['releaseStage' => 'production', 'apiKey' => 'example-api-key', 'buildTool' => 'bugsnag-php', 'builderName' => exec('whoami')]]));
 
         $this->client = new Client($this->config = new Configuration('example-api-key'), null, $this->guzzle);
 
@@ -425,7 +425,7 @@ class ClientTest extends TestCase
 
     public function testDeployWorksWithRevision()
     {
-        $this->guzzle->expects($this->once())->method('post')->with($this->equalTo('https://build.bugsnag.com'), $this->equalTo(['json' => ['sourceControl' => ['revision' => 'bar'], 'releaseStage' => 'production', 'apiKey' => 'example-api-key', 'buildTool' => 'bugsnag-php']]));
+        $this->guzzle->expects($this->once())->method('post')->with($this->equalTo('https://build.bugsnag.com'), $this->equalTo(['json' => ['sourceControl' => ['revision' => 'bar'], 'releaseStage' => 'production', 'apiKey' => 'example-api-key', 'buildTool' => 'bugsnag-php', 'builderName' => exec('whoami')]]));
 
         $this->client = new Client($this->config = new Configuration('example-api-key'), null, $this->guzzle);
 
@@ -434,7 +434,7 @@ class ClientTest extends TestCase
 
     public function testDeployWorksWithEverything()
     {
-        $this->guzzle->expects($this->once())->method('post')->with($this->equalTo('https://build.bugsnag.com'), $this->equalTo(['json' => ['sourceControl' => ['repository' => 'baz', 'revision' => 'foo'], 'releaseStage' => 'development', 'appVersion' => '1.3.1', 'apiKey' => 'example-api-key', 'buildTool' => 'bugsnag-php']]));
+        $this->guzzle->expects($this->once())->method('post')->with($this->equalTo('https://build.bugsnag.com'), $this->equalTo(['json' => ['sourceControl' => ['repository' => 'baz', 'revision' => 'foo'], 'releaseStage' => 'development', 'appVersion' => '1.3.1', 'apiKey' => 'example-api-key', 'buildTool' => 'bugsnag-php', 'builderName' => exec('whoami')]]));
 
         $this->client = new Client($this->config = new Configuration('example-api-key'), null, $this->guzzle);
 
@@ -446,16 +446,16 @@ class ClientTest extends TestCase
 
     public function testBuildWorksOutOfTheBox()
     {
-        $this->guzzle->expects($this->once())->method('post')->with($this->equalTo('https://build.bugsnag.com'), $this->equalTo(['json' => ['releaseStage' => 'production', 'apiKey' => 'example-api-key', 'buildTool' => 'bugsnag-php']]));
+        $this->guzzle->expects($this->once())->method('post')->with($this->equalTo('https://build.bugsnag.com'), $this->equalTo(['json' => ['releaseStage' => 'production', 'apiKey' => 'example-api-key', 'buildTool' => 'bugsnag-php', 'builderName' => exec('whoami')]]));
 
         $this->client = new Client($this->config = new Configuration('example-api-key'), null, $this->guzzle);
 
         $this->client->build();
     }
 
-    public function testBuildWorksWithgReleaseStage()
+    public function testBuildWorksWithReleaseStage()
     {
-        $this->guzzle->expects($this->once())->method('post')->with($this->equalTo('https://build.bugsnag.com'), $this->equalTo(['json' => ['releaseStage' => 'staging', 'apiKey' => 'example-api-key', 'buildTool' => 'bugsnag-php']]));
+        $this->guzzle->expects($this->once())->method('post')->with($this->equalTo('https://build.bugsnag.com'), $this->equalTo(['json' => ['releaseStage' => 'staging', 'apiKey' => 'example-api-key', 'buildTool' => 'bugsnag-php', 'builderName' => exec('whoami')]]));
 
         $this->client = new Client($this->config = new Configuration('example-api-key'), null, $this->guzzle);
 
@@ -466,7 +466,7 @@ class ClientTest extends TestCase
 
     public function testBuildWorksWithAppVersion()
     {
-        $this->guzzle->expects($this->once())->method('post')->with($this->equalTo('https://build.bugsnag.com'), $this->equalTo(['json' => ['releaseStage' => 'production', 'appVersion' => '1.1.0', 'apiKey' => 'example-api-key', 'buildTool' => 'bugsnag-php']]));
+        $this->guzzle->expects($this->once())->method('post')->with($this->equalTo('https://build.bugsnag.com'), $this->equalTo(['json' => ['releaseStage' => 'production', 'appVersion' => '1.1.0', 'apiKey' => 'example-api-key', 'buildTool' => 'bugsnag-php', 'builderName' => exec('whoami')]]));
 
         $this->client = new Client($this->config = new Configuration('example-api-key'), null, $this->guzzle);
 
@@ -477,7 +477,7 @@ class ClientTest extends TestCase
 
     public function testBuildWorksWithRepository()
     {
-        $this->guzzle->expects($this->once())->method('post')->with($this->equalTo('https://build.bugsnag.com'), $this->equalTo(['json' => ['sourceControl' => ['repository' => 'foo'], 'releaseStage' => 'production', 'apiKey' => 'example-api-key', 'buildTool' => 'bugsnag-php']]));
+        $this->guzzle->expects($this->once())->method('post')->with($this->equalTo('https://build.bugsnag.com'), $this->equalTo(['json' => ['sourceControl' => ['repository' => 'foo'], 'releaseStage' => 'production', 'apiKey' => 'example-api-key', 'buildTool' => 'bugsnag-php', 'builderName' => exec('whoami')]]));
 
         $this->client = new Client($this->config = new Configuration('example-api-key'), null, $this->guzzle);
 
@@ -486,7 +486,7 @@ class ClientTest extends TestCase
 
     public function testBuildWorksWithProvider()
     {
-        $this->guzzle->expects($this->once())->method('post')->with($this->equalTo('https://build.bugsnag.com'), $this->equalTo(['json' => ['sourceControl' => ['provider' => 'github'], 'releaseStage' => 'production', 'apiKey' => 'example-api-key', 'buildTool' => 'bugsnag-php']]));
+        $this->guzzle->expects($this->once())->method('post')->with($this->equalTo('https://build.bugsnag.com'), $this->equalTo(['json' => ['sourceControl' => ['provider' => 'github'], 'releaseStage' => 'production', 'apiKey' => 'example-api-key', 'buildTool' => 'bugsnag-php', 'builderName' => exec('whoami')]]));
 
         $this->client = new Client($this->config = new Configuration('example-api-key'), null, $this->guzzle);
 
@@ -495,7 +495,7 @@ class ClientTest extends TestCase
 
     public function testBuildWorksWithRevision()
     {
-        $this->guzzle->expects($this->once())->method('post')->with($this->equalTo('https://build.bugsnag.com'), $this->equalTo(['json' => ['sourceControl' => ['revision' => 'bar'], 'releaseStage' => 'production', 'apiKey' => 'example-api-key', 'buildTool' => 'bugsnag-php']]));
+        $this->guzzle->expects($this->once())->method('post')->with($this->equalTo('https://build.bugsnag.com'), $this->equalTo(['json' => ['sourceControl' => ['revision' => 'bar'], 'releaseStage' => 'production', 'apiKey' => 'example-api-key', 'buildTool' => 'bugsnag-php', 'builderName' => exec('whoami')]]));
 
         $this->client = new Client($this->config = new Configuration('example-api-key'), null, $this->guzzle);
 
@@ -513,59 +513,23 @@ class ClientTest extends TestCase
 
     public function testBuildWorksWithBuildTool()
     {
-        $this->guzzle->expects($this->once())->method('post')->with($this->equalTo('https://build.bugsnag.com'), $this->equalTo(['json' => ['releaseStage' => 'production', 'apiKey' => 'example-api-key', 'buildTool' => 'bugsnag-test']]));
+        $this->guzzle->expects($this->once())->method('post')->with($this->equalTo('https://build.bugsnag.com'), $this->equalTo(['json' => ['releaseStage' => 'production', 'apiKey' => 'example-api-key', 'buildTool' => 'bugsnag-php', 'builderName' => exec('whoami')]]));
 
         $this->client = new Client($this->config = new Configuration('example-api-key'), null, $this->guzzle);
 
-        $this->client->build(null, null, null, null, 'bugsnag-test');
+        $this->client->build(null, null, null, null);
     }
 
     public function testBuildWorksWithEverything()
     {
-        $this->guzzle->expects($this->once())->method('post')->with($this->equalTo('https://build.bugsnag.com'), $this->equalTo(['json' => ['builderName' => 'me', 'sourceControl' => ['repository' => 'baz', 'revision' => 'foo', 'provider' => 'github'], 'releaseStage' => 'development', 'appVersion' => '1.3.1', 'apiKey' => 'example-api-key', 'buildTool' => 'bugsnag-test']]));
+        $this->guzzle->expects($this->once())->method('post')->with($this->equalTo('https://build.bugsnag.com'), $this->equalTo(['json' => ['builderName' => 'me', 'sourceControl' => ['repository' => 'baz', 'revision' => 'foo', 'provider' => 'github'], 'releaseStage' => 'development', 'appVersion' => '1.3.1', 'apiKey' => 'example-api-key', 'buildTool' => 'bugsnag-php']]));
 
         $this->client = new Client($this->config = new Configuration('example-api-key'), null, $this->guzzle);
 
         $this->config->setReleaseStage('development');
         $this->config->setAppVersion('1.3.1');
 
-        $this->client->build('baz', 'foo', 'github', 'me', 'bugsnag-test');
-    }
-
-    public function testBuildAutoDetectsProviderGithub()
-    {
-        $this->guzzle->expects($this->once())->method('post')->with($this->equalTo('https://build.bugsnag.com'), $this->equalTo(['json' => ['sourceControl' => ['repository' => 'http://test.github.com', 'provider' => 'github'], 'releaseStage' => 'development', 'appVersion' => '1.3.1', 'apiKey' => 'example-api-key', 'buildTool' => 'bugsnag-php']]));
-
-        $this->client = new Client($this->config = new Configuration('example-api-key'), null, $this->guzzle);
-
-        $this->config->setReleaseStage('development');
-        $this->config->setAppVersion('1.3.1');
-
-        $this->client->build('http://test.github.com');
-    }
-
-    public function testBuildAutoDetectsProviderGitlab()
-    {
-        $this->guzzle->expects($this->once())->method('post')->with($this->equalTo('https://build.bugsnag.com'), $this->equalTo(['json' => ['sourceControl' => ['repository' => 'http://test.gitlab.com', 'provider' => 'gitlab'], 'releaseStage' => 'development', 'appVersion' => '1.3.1', 'apiKey' => 'example-api-key', 'buildTool' => 'bugsnag-php']]));
-
-        $this->client = new Client($this->config = new Configuration('example-api-key'), null, $this->guzzle);
-
-        $this->config->setReleaseStage('development');
-        $this->config->setAppVersion('1.3.1');
-
-        $this->client->build('http://test.gitlab.com');
-    }
-
-    public function testBuildAutoDetectsProviderBitbucket()
-    {
-        $this->guzzle->expects($this->once())->method('post')->with($this->equalTo('https://build.bugsnag.com'), $this->equalTo(['json' => ['sourceControl' => ['repository' => 'http://test.bitbucket.com', 'provider' => 'bitbucket'], 'releaseStage' => 'development', 'appVersion' => '1.3.1', 'apiKey' => 'example-api-key', 'buildTool' => 'bugsnag-php']]));
-
-        $this->client = new Client($this->config = new Configuration('example-api-key'), null, $this->guzzle);
-
-        $this->config->setReleaseStage('development');
-        $this->config->setAppVersion('1.3.1');
-
-        $this->client->build('http://test.bitbucket.com');
+        $this->client->build('baz', 'foo', 'github', 'me');
     }
 
     public function testSeverityReasonUnmodified()

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -376,7 +376,7 @@ class ClientTest extends TestCase
 
     public function testDeployWorksOutOfTheBox()
     {
-        $this->guzzle->expects($this->once())->method('post')->with($this->equalTo('deploy'), $this->equalTo(['json' => ['releaseStage' => 'production', 'apiKey' => 'example-api-key']]));
+        $this->guzzle->expects($this->once())->method('post')->with($this->equalTo('https://build.bugsnag.com'), $this->equalTo(['json' => ['releaseStage' => 'production', 'apiKey' => 'example-api-key']]));
 
         $this->client = new Client($this->config = new Configuration('example-api-key'), null, $this->guzzle);
 
@@ -385,7 +385,7 @@ class ClientTest extends TestCase
 
     public function testDeployWorksWithgReleaseStage()
     {
-        $this->guzzle->expects($this->once())->method('post')->with($this->equalTo('deploy'), $this->equalTo(['json' => ['releaseStage' => 'staging', 'apiKey' => 'example-api-key']]));
+        $this->guzzle->expects($this->once())->method('post')->with($this->equalTo('https://build.bugsnag.com'), $this->equalTo(['json' => ['releaseStage' => 'staging', 'apiKey' => 'example-api-key']]));
 
         $this->client = new Client($this->config = new Configuration('example-api-key'), null, $this->guzzle);
 
@@ -396,7 +396,7 @@ class ClientTest extends TestCase
 
     public function testDeployWorksWithAppVersion()
     {
-        $this->guzzle->expects($this->once())->method('post')->with($this->equalTo('deploy'), $this->equalTo(['json' => ['releaseStage' => 'production', 'appVersion' => '1.1.0', 'apiKey' => 'example-api-key']]));
+        $this->guzzle->expects($this->once())->method('post')->with($this->equalTo('https://build.bugsnag.com'), $this->equalTo(['json' => ['releaseStage' => 'production', 'appVersion' => '1.1.0', 'apiKey' => 'example-api-key']]));
 
         $this->client = new Client($this->config = new Configuration('example-api-key'), null, $this->guzzle);
 
@@ -407,7 +407,7 @@ class ClientTest extends TestCase
 
     public function testDeployWorksWithRepository()
     {
-        $this->guzzle->expects($this->once())->method('post')->with($this->equalTo('deploy'), $this->equalTo(['json' => ['repository' => 'foo', 'releaseStage' => 'production', 'apiKey' => 'example-api-key']]));
+        $this->guzzle->expects($this->once())->method('post')->with($this->equalTo('https://build.bugsnag.com'), $this->equalTo(['json' => ['sourceControl' => ['repository' => 'foo'], 'releaseStage' => 'production', 'apiKey' => 'example-api-key']]));
 
         $this->client = new Client($this->config = new Configuration('example-api-key'), null, $this->guzzle);
 
@@ -416,7 +416,7 @@ class ClientTest extends TestCase
 
     public function testDeployWorksWithBranch()
     {
-        $this->guzzle->expects($this->once())->method('post')->with($this->equalTo('deploy'), $this->equalTo(['json' => ['branch' => 'master', 'releaseStage' => 'production', 'apiKey' => 'example-api-key']]));
+        $this->guzzle->expects($this->once())->method('post')->with($this->equalTo('https://build.bugsnag.com'), $this->equalTo(['json' => ['releaseStage' => 'production', 'apiKey' => 'example-api-key']]));
 
         $this->client = new Client($this->config = new Configuration('example-api-key'), null, $this->guzzle);
 
@@ -425,7 +425,7 @@ class ClientTest extends TestCase
 
     public function testDeployWorksWithRevision()
     {
-        $this->guzzle->expects($this->once())->method('post')->with($this->equalTo('deploy'), $this->equalTo(['json' => ['revision' => 'bar', 'releaseStage' => 'production', 'apiKey' => 'example-api-key']]));
+        $this->guzzle->expects($this->once())->method('post')->with($this->equalTo('https://build.bugsnag.com'), $this->equalTo(['json' => ['sourceControl' => ['revision' => 'bar'], 'releaseStage' => 'production', 'apiKey' => 'example-api-key']]));
 
         $this->client = new Client($this->config = new Configuration('example-api-key'), null, $this->guzzle);
 
@@ -434,7 +434,7 @@ class ClientTest extends TestCase
 
     public function testDeployWorksWithEverything()
     {
-        $this->guzzle->expects($this->once())->method('post')->with($this->equalTo('deploy'), $this->equalTo(['json' => ['repository' => 'baz', 'branch' => 'develop', 'revision' => 'foo', 'releaseStage' => 'development', 'appVersion' => '1.3.1', 'apiKey' => 'example-api-key']]));
+        $this->guzzle->expects($this->once())->method('post')->with($this->equalTo('https://build.bugsnag.com'), $this->equalTo(['json' => ['sourceControl' => ['repository' => 'baz', 'revision' => 'foo'], 'releaseStage' => 'development', 'appVersion' => '1.3.1', 'apiKey' => 'example-api-key']]));
 
         $this->client = new Client($this->config = new Configuration('example-api-key'), null, $this->guzzle);
 
@@ -442,6 +442,88 @@ class ClientTest extends TestCase
         $this->config->setAppVersion('1.3.1');
 
         $this->client->deploy('baz', 'develop', 'foo');
+    }
+
+    public function testBuildWorksOutOfTheBox()
+    {
+        $this->guzzle->expects($this->once())->method('post')->with($this->equalTo('https://build.bugsnag.com'), $this->equalTo(['json' => ['releaseStage' => 'production', 'apiKey' => 'example-api-key']]));
+
+        $this->client = new Client($this->config = new Configuration('example-api-key'), null, $this->guzzle);
+
+        $this->client->build();
+    }
+
+    public function testBuildWorksWithgReleaseStage()
+    {
+        $this->guzzle->expects($this->once())->method('post')->with($this->equalTo('https://build.bugsnag.com'), $this->equalTo(['json' => ['releaseStage' => 'staging', 'apiKey' => 'example-api-key']]));
+
+        $this->client = new Client($this->config = new Configuration('example-api-key'), null, $this->guzzle);
+
+        $this->config->setReleaseStage('staging');
+
+        $this->client->build();
+    }
+
+    public function testBuildWorksWithAppVersion()
+    {
+        $this->guzzle->expects($this->once())->method('post')->with($this->equalTo('https://build.bugsnag.com'), $this->equalTo(['json' => ['releaseStage' => 'production', 'appVersion' => '1.1.0', 'apiKey' => 'example-api-key']]));
+
+        $this->client = new Client($this->config = new Configuration('example-api-key'), null, $this->guzzle);
+
+        $this->config->setAppVersion('1.1.0');
+
+        $this->client->build();
+    }
+
+    public function testBuildWorksWithRepository()
+    {
+        $this->guzzle->expects($this->once())->method('post')->with($this->equalTo('https://build.bugsnag.com'), $this->equalTo(['json' => ['sourceControl' => ['repository' => 'foo'], 'releaseStage' => 'production', 'apiKey' => 'example-api-key']]));
+
+        $this->client = new Client($this->config = new Configuration('example-api-key'), null, $this->guzzle);
+
+        $this->client->build('foo');
+    }
+
+    public function testBuildWorksWithProvider()
+    {
+        $this->guzzle->expects($this->once())->method('post')->with($this->equalTo('https://build.bugsnag.com'), $this->equalTo(['json' => ['sourceControl' => ['provider' => 'github'], 'releaseStage' => 'production', 'apiKey' => 'example-api-key']]));
+
+        $this->client = new Client($this->config = new Configuration('example-api-key'), null, $this->guzzle);
+
+        $this->client->build(null, null, 'github');
+    }
+
+    public function testBuildWorksWithRevision()
+    {
+        $this->guzzle->expects($this->once())->method('post')->with($this->equalTo('https://build.bugsnag.com'), $this->equalTo(['json' => ['sourceControl' => ['revision' => 'bar'], 'releaseStage' => 'production', 'apiKey' => 'example-api-key']]));
+
+        $this->client = new Client($this->config = new Configuration('example-api-key'), null, $this->guzzle);
+
+        $this->client->build(null, 'bar');
+    }
+
+    public function testBuildWorksWithEverything()
+    {
+        $this->guzzle->expects($this->once())->method('post')->with($this->equalTo('https://build.bugsnag.com'), $this->equalTo(['json' => ['sourceControl' => ['repository' => 'baz', 'revision' => 'foo', 'provider' => 'github'], 'releaseStage' => 'development', 'appVersion' => '1.3.1', 'apiKey' => 'example-api-key']]));
+
+        $this->client = new Client($this->config = new Configuration('example-api-key'), null, $this->guzzle);
+
+        $this->config->setReleaseStage('development');
+        $this->config->setAppVersion('1.3.1');
+
+        $this->client->build('baz', 'foo', 'github');
+    }
+
+    public function testBuildAutoDetectsProvider()
+    {
+        $this->guzzle->expects($this->once())->method('post')->with($this->equalTo('https://build.bugsnag.com'), $this->equalTo(['json' => ['sourceControl' => ['repository' => 'http://test.gitlab.com', 'provider' => 'gitlab'], 'releaseStage' => 'development', 'appVersion' => '1.3.1', 'apiKey' => 'example-api-key']]));
+
+        $this->client = new Client($this->config = new Configuration('example-api-key'), null, $this->guzzle);
+
+        $this->config->setReleaseStage('development');
+        $this->config->setAppVersion('1.3.1');
+
+        $this->client->build('http://test.gitlab.com');
     }
 
     public function testSeverityReasonUnmodified()

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -376,7 +376,7 @@ class ClientTest extends TestCase
 
     public function testDeployWorksOutOfTheBox()
     {
-        $this->guzzle->expects($this->once())->method('post')->with($this->equalTo('https://build.bugsnag.com'), $this->equalTo(['json' => ['releaseStage' => 'production', 'apiKey' => 'example-api-key']]));
+        $this->guzzle->expects($this->once())->method('post')->with($this->equalTo('https://build.bugsnag.com'), $this->equalTo(['json' => ['releaseStage' => 'production', 'apiKey' => 'example-api-key', 'buildTool' => 'bugsnag-php']]));
 
         $this->client = new Client($this->config = new Configuration('example-api-key'), null, $this->guzzle);
 
@@ -385,7 +385,7 @@ class ClientTest extends TestCase
 
     public function testDeployWorksWithgReleaseStage()
     {
-        $this->guzzle->expects($this->once())->method('post')->with($this->equalTo('https://build.bugsnag.com'), $this->equalTo(['json' => ['releaseStage' => 'staging', 'apiKey' => 'example-api-key']]));
+        $this->guzzle->expects($this->once())->method('post')->with($this->equalTo('https://build.bugsnag.com'), $this->equalTo(['json' => ['releaseStage' => 'staging', 'apiKey' => 'example-api-key', 'buildTool' => 'bugsnag-php']]));
 
         $this->client = new Client($this->config = new Configuration('example-api-key'), null, $this->guzzle);
 
@@ -396,7 +396,7 @@ class ClientTest extends TestCase
 
     public function testDeployWorksWithAppVersion()
     {
-        $this->guzzle->expects($this->once())->method('post')->with($this->equalTo('https://build.bugsnag.com'), $this->equalTo(['json' => ['releaseStage' => 'production', 'appVersion' => '1.1.0', 'apiKey' => 'example-api-key']]));
+        $this->guzzle->expects($this->once())->method('post')->with($this->equalTo('https://build.bugsnag.com'), $this->equalTo(['json' => ['releaseStage' => 'production', 'appVersion' => '1.1.0', 'apiKey' => 'example-api-key', 'buildTool' => 'bugsnag-php']]));
 
         $this->client = new Client($this->config = new Configuration('example-api-key'), null, $this->guzzle);
 
@@ -407,7 +407,7 @@ class ClientTest extends TestCase
 
     public function testDeployWorksWithRepository()
     {
-        $this->guzzle->expects($this->once())->method('post')->with($this->equalTo('https://build.bugsnag.com'), $this->equalTo(['json' => ['sourceControl' => ['repository' => 'foo'], 'releaseStage' => 'production', 'apiKey' => 'example-api-key']]));
+        $this->guzzle->expects($this->once())->method('post')->with($this->equalTo('https://build.bugsnag.com'), $this->equalTo(['json' => ['sourceControl' => ['repository' => 'foo'], 'releaseStage' => 'production', 'apiKey' => 'example-api-key', 'buildTool' => 'bugsnag-php']]));
 
         $this->client = new Client($this->config = new Configuration('example-api-key'), null, $this->guzzle);
 
@@ -416,7 +416,7 @@ class ClientTest extends TestCase
 
     public function testDeployWorksWithBranch()
     {
-        $this->guzzle->expects($this->once())->method('post')->with($this->equalTo('https://build.bugsnag.com'), $this->equalTo(['json' => ['releaseStage' => 'production', 'apiKey' => 'example-api-key']]));
+        $this->guzzle->expects($this->once())->method('post')->with($this->equalTo('https://build.bugsnag.com'), $this->equalTo(['json' => ['releaseStage' => 'production', 'apiKey' => 'example-api-key', 'buildTool' => 'bugsnag-php']]));
 
         $this->client = new Client($this->config = new Configuration('example-api-key'), null, $this->guzzle);
 
@@ -425,7 +425,7 @@ class ClientTest extends TestCase
 
     public function testDeployWorksWithRevision()
     {
-        $this->guzzle->expects($this->once())->method('post')->with($this->equalTo('https://build.bugsnag.com'), $this->equalTo(['json' => ['sourceControl' => ['revision' => 'bar'], 'releaseStage' => 'production', 'apiKey' => 'example-api-key']]));
+        $this->guzzle->expects($this->once())->method('post')->with($this->equalTo('https://build.bugsnag.com'), $this->equalTo(['json' => ['sourceControl' => ['revision' => 'bar'], 'releaseStage' => 'production', 'apiKey' => 'example-api-key', 'buildTool' => 'bugsnag-php']]));
 
         $this->client = new Client($this->config = new Configuration('example-api-key'), null, $this->guzzle);
 
@@ -434,7 +434,7 @@ class ClientTest extends TestCase
 
     public function testDeployWorksWithEverything()
     {
-        $this->guzzle->expects($this->once())->method('post')->with($this->equalTo('https://build.bugsnag.com'), $this->equalTo(['json' => ['sourceControl' => ['repository' => 'baz', 'revision' => 'foo'], 'releaseStage' => 'development', 'appVersion' => '1.3.1', 'apiKey' => 'example-api-key']]));
+        $this->guzzle->expects($this->once())->method('post')->with($this->equalTo('https://build.bugsnag.com'), $this->equalTo(['json' => ['sourceControl' => ['repository' => 'baz', 'revision' => 'foo'], 'releaseStage' => 'development', 'appVersion' => '1.3.1', 'apiKey' => 'example-api-key', 'buildTool' => 'bugsnag-php']]));
 
         $this->client = new Client($this->config = new Configuration('example-api-key'), null, $this->guzzle);
 
@@ -446,7 +446,7 @@ class ClientTest extends TestCase
 
     public function testBuildWorksOutOfTheBox()
     {
-        $this->guzzle->expects($this->once())->method('post')->with($this->equalTo('https://build.bugsnag.com'), $this->equalTo(['json' => ['releaseStage' => 'production', 'apiKey' => 'example-api-key']]));
+        $this->guzzle->expects($this->once())->method('post')->with($this->equalTo('https://build.bugsnag.com'), $this->equalTo(['json' => ['releaseStage' => 'production', 'apiKey' => 'example-api-key', 'buildTool' => 'bugsnag-php']]));
 
         $this->client = new Client($this->config = new Configuration('example-api-key'), null, $this->guzzle);
 
@@ -455,7 +455,7 @@ class ClientTest extends TestCase
 
     public function testBuildWorksWithgReleaseStage()
     {
-        $this->guzzle->expects($this->once())->method('post')->with($this->equalTo('https://build.bugsnag.com'), $this->equalTo(['json' => ['releaseStage' => 'staging', 'apiKey' => 'example-api-key']]));
+        $this->guzzle->expects($this->once())->method('post')->with($this->equalTo('https://build.bugsnag.com'), $this->equalTo(['json' => ['releaseStage' => 'staging', 'apiKey' => 'example-api-key', 'buildTool' => 'bugsnag-php']]));
 
         $this->client = new Client($this->config = new Configuration('example-api-key'), null, $this->guzzle);
 
@@ -466,7 +466,7 @@ class ClientTest extends TestCase
 
     public function testBuildWorksWithAppVersion()
     {
-        $this->guzzle->expects($this->once())->method('post')->with($this->equalTo('https://build.bugsnag.com'), $this->equalTo(['json' => ['releaseStage' => 'production', 'appVersion' => '1.1.0', 'apiKey' => 'example-api-key']]));
+        $this->guzzle->expects($this->once())->method('post')->with($this->equalTo('https://build.bugsnag.com'), $this->equalTo(['json' => ['releaseStage' => 'production', 'appVersion' => '1.1.0', 'apiKey' => 'example-api-key', 'buildTool' => 'bugsnag-php']]));
 
         $this->client = new Client($this->config = new Configuration('example-api-key'), null, $this->guzzle);
 
@@ -477,7 +477,7 @@ class ClientTest extends TestCase
 
     public function testBuildWorksWithRepository()
     {
-        $this->guzzle->expects($this->once())->method('post')->with($this->equalTo('https://build.bugsnag.com'), $this->equalTo(['json' => ['sourceControl' => ['repository' => 'foo'], 'releaseStage' => 'production', 'apiKey' => 'example-api-key']]));
+        $this->guzzle->expects($this->once())->method('post')->with($this->equalTo('https://build.bugsnag.com'), $this->equalTo(['json' => ['sourceControl' => ['repository' => 'foo'], 'releaseStage' => 'production', 'apiKey' => 'example-api-key', 'buildTool' => 'bugsnag-php']]));
 
         $this->client = new Client($this->config = new Configuration('example-api-key'), null, $this->guzzle);
 
@@ -486,7 +486,7 @@ class ClientTest extends TestCase
 
     public function testBuildWorksWithProvider()
     {
-        $this->guzzle->expects($this->once())->method('post')->with($this->equalTo('https://build.bugsnag.com'), $this->equalTo(['json' => ['sourceControl' => ['provider' => 'github'], 'releaseStage' => 'production', 'apiKey' => 'example-api-key']]));
+        $this->guzzle->expects($this->once())->method('post')->with($this->equalTo('https://build.bugsnag.com'), $this->equalTo(['json' => ['sourceControl' => ['provider' => 'github'], 'releaseStage' => 'production', 'apiKey' => 'example-api-key', 'buildTool' => 'bugsnag-php']]));
 
         $this->client = new Client($this->config = new Configuration('example-api-key'), null, $this->guzzle);
 
@@ -495,7 +495,7 @@ class ClientTest extends TestCase
 
     public function testBuildWorksWithRevision()
     {
-        $this->guzzle->expects($this->once())->method('post')->with($this->equalTo('https://build.bugsnag.com'), $this->equalTo(['json' => ['sourceControl' => ['revision' => 'bar'], 'releaseStage' => 'production', 'apiKey' => 'example-api-key']]));
+        $this->guzzle->expects($this->once())->method('post')->with($this->equalTo('https://build.bugsnag.com'), $this->equalTo(['json' => ['sourceControl' => ['revision' => 'bar'], 'releaseStage' => 'production', 'apiKey' => 'example-api-key', 'buildTool' => 'bugsnag-php']]));
 
         $this->client = new Client($this->config = new Configuration('example-api-key'), null, $this->guzzle);
 
@@ -504,28 +504,37 @@ class ClientTest extends TestCase
 
     public function testBuildWorksWithBuilderName()
     {
-        $this->guzzle->expects($this->once())->method('post')->with($this->equalTo('https://build.bugsnag.com'), $this->equalTo(['json' => ['builderName' => 'me', 'releaseStage' => 'production', 'apiKey' => 'example-api-key']]));
+        $this->guzzle->expects($this->once())->method('post')->with($this->equalTo('https://build.bugsnag.com'), $this->equalTo(['json' => ['builderName' => 'me', 'releaseStage' => 'production', 'apiKey' => 'example-api-key', 'buildTool' => 'bugsnag-php']]));
 
         $this->client = new Client($this->config = new Configuration('example-api-key'), null, $this->guzzle);
 
         $this->client->build(null, null, null, 'me');
     }
 
+    public function testBuildWorksWithBuildTool()
+    {
+        $this->guzzle->expects($this->once())->method('post')->with($this->equalTo('https://build.bugsnag.com'), $this->equalTo(['json' => ['releaseStage' => 'production', 'apiKey' => 'example-api-key', 'buildTool' => 'bugsnag-test']]));
+
+        $this->client = new Client($this->config = new Configuration('example-api-key'), null, $this->guzzle);
+
+        $this->client->build(null, null, null, null, 'bugsnag-test');
+    }
+
     public function testBuildWorksWithEverything()
     {
-        $this->guzzle->expects($this->once())->method('post')->with($this->equalTo('https://build.bugsnag.com'), $this->equalTo(['json' => ['builderName' => 'me', 'sourceControl' => ['repository' => 'baz', 'revision' => 'foo', 'provider' => 'github'], 'releaseStage' => 'development', 'appVersion' => '1.3.1', 'apiKey' => 'example-api-key']]));
+        $this->guzzle->expects($this->once())->method('post')->with($this->equalTo('https://build.bugsnag.com'), $this->equalTo(['json' => ['builderName' => 'me', 'sourceControl' => ['repository' => 'baz', 'revision' => 'foo', 'provider' => 'github'], 'releaseStage' => 'development', 'appVersion' => '1.3.1', 'apiKey' => 'example-api-key', 'buildTool' => 'bugsnag-test']]));
 
         $this->client = new Client($this->config = new Configuration('example-api-key'), null, $this->guzzle);
 
         $this->config->setReleaseStage('development');
         $this->config->setAppVersion('1.3.1');
 
-        $this->client->build('baz', 'foo', 'github', 'me');
+        $this->client->build('baz', 'foo', 'github', 'me', 'bugsnag-test');
     }
 
     public function testBuildAutoDetectsProviderGithub()
     {
-        $this->guzzle->expects($this->once())->method('post')->with($this->equalTo('https://build.bugsnag.com'), $this->equalTo(['json' => ['sourceControl' => ['repository' => 'http://test.github.com', 'provider' => 'github'], 'releaseStage' => 'development', 'appVersion' => '1.3.1', 'apiKey' => 'example-api-key']]));
+        $this->guzzle->expects($this->once())->method('post')->with($this->equalTo('https://build.bugsnag.com'), $this->equalTo(['json' => ['sourceControl' => ['repository' => 'http://test.github.com', 'provider' => 'github'], 'releaseStage' => 'development', 'appVersion' => '1.3.1', 'apiKey' => 'example-api-key', 'buildTool' => 'bugsnag-php']]));
 
         $this->client = new Client($this->config = new Configuration('example-api-key'), null, $this->guzzle);
 
@@ -537,7 +546,7 @@ class ClientTest extends TestCase
 
     public function testBuildAutoDetectsProviderGitlab()
     {
-        $this->guzzle->expects($this->once())->method('post')->with($this->equalTo('https://build.bugsnag.com'), $this->equalTo(['json' => ['sourceControl' => ['repository' => 'http://test.gitlab.com', 'provider' => 'gitlab'], 'releaseStage' => 'development', 'appVersion' => '1.3.1', 'apiKey' => 'example-api-key']]));
+        $this->guzzle->expects($this->once())->method('post')->with($this->equalTo('https://build.bugsnag.com'), $this->equalTo(['json' => ['sourceControl' => ['repository' => 'http://test.gitlab.com', 'provider' => 'gitlab'], 'releaseStage' => 'development', 'appVersion' => '1.3.1', 'apiKey' => 'example-api-key', 'buildTool' => 'bugsnag-php']]));
 
         $this->client = new Client($this->config = new Configuration('example-api-key'), null, $this->guzzle);
 
@@ -549,7 +558,7 @@ class ClientTest extends TestCase
 
     public function testBuildAutoDetectsProviderBitbucket()
     {
-        $this->guzzle->expects($this->once())->method('post')->with($this->equalTo('https://build.bugsnag.com'), $this->equalTo(['json' => ['sourceControl' => ['repository' => 'http://test.bitbucket.com', 'provider' => 'bitbucket'], 'releaseStage' => 'development', 'appVersion' => '1.3.1', 'apiKey' => 'example-api-key']]));
+        $this->guzzle->expects($this->once())->method('post')->with($this->equalTo('https://build.bugsnag.com'), $this->equalTo(['json' => ['sourceControl' => ['repository' => 'http://test.bitbucket.com', 'provider' => 'bitbucket'], 'releaseStage' => 'development', 'appVersion' => '1.3.1', 'apiKey' => 'example-api-key', 'buildTool' => 'bugsnag-php']]));
 
         $this->client = new Client($this->config = new Configuration('example-api-key'), null, $this->guzzle);
 

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -502,16 +502,25 @@ class ClientTest extends TestCase
         $this->client->build(null, 'bar');
     }
 
+    public function testBuildWorksWithBuilderName()
+    {
+        $this->guzzle->expects($this->once())->method('post')->with($this->equalTo('https://build.bugsnag.com'), $this->equalTo(['json' => ['builderName' => 'me', 'releaseStage' => 'production', 'apiKey' => 'example-api-key']]));
+
+        $this->client = new Client($this->config = new Configuration('example-api-key'), null, $this->guzzle);
+
+        $this->client->build(null, null, null, 'me');
+    }
+
     public function testBuildWorksWithEverything()
     {
-        $this->guzzle->expects($this->once())->method('post')->with($this->equalTo('https://build.bugsnag.com'), $this->equalTo(['json' => ['sourceControl' => ['repository' => 'baz', 'revision' => 'foo', 'provider' => 'github'], 'releaseStage' => 'development', 'appVersion' => '1.3.1', 'apiKey' => 'example-api-key']]));
+        $this->guzzle->expects($this->once())->method('post')->with($this->equalTo('https://build.bugsnag.com'), $this->equalTo(['json' => ['builderName' => 'me', 'sourceControl' => ['repository' => 'baz', 'revision' => 'foo', 'provider' => 'github'], 'releaseStage' => 'development', 'appVersion' => '1.3.1', 'apiKey' => 'example-api-key']]));
 
         $this->client = new Client($this->config = new Configuration('example-api-key'), null, $this->guzzle);
 
         $this->config->setReleaseStage('development');
         $this->config->setAppVersion('1.3.1');
 
-        $this->client->build('baz', 'foo', 'github');
+        $this->client->build('baz', 'foo', 'github', 'me');
     }
 
     public function testBuildAutoDetectsProvider()


### PR DESCRIPTION
Updates to the new Bugsnag build API.
- Adds `build` method to client to send build information off to bugsnag
- Points clients `deploy` method to `build` method
- Maintains old `deploy` method in HTTP client unchanged
- Adds new `sendBuildReport` to HTTP client to handle new API calls.
- Adds `setBuildEndpoint` and `getBuildEndpoint` to configuration, with a default.