### PR TITLE
Re-add apiKey in payload

### DIFF
--- a/src/HttpClient.php
+++ b/src/HttpClient.php
@@ -181,6 +181,7 @@ class HttpClient
         }
 
         return [
+            'apiKey' => $this->config->getApiKey(),
             'notifier' => $this->config->getNotifier(),
             'events' => $events,
         ];

--- a/tests/HttpClientTest.php
+++ b/tests/HttpClientTest.php
@@ -47,6 +47,7 @@ class HttpClientTest extends TestCase
         $this->assertInternalType('array', $params[1]['json']['events']);
         $this->assertSame([], $params[1]['json']['events'][0]['user']);
         $this->assertSame(['foo' => 'bar'], $params[1]['json']['events'][0]['metaData']);
+        $this->assertSame('6015a72ff14038114c3d12623dfb018f', $params[1]['json']['apiKey']);
 
         $headers = $params[1]['headers'];
         $this->assertSame('6015a72ff14038114c3d12623dfb018f', $headers['Bugsnag-Api-Key']);
@@ -89,6 +90,7 @@ class HttpClientTest extends TestCase
         $this->assertInternalType('array', $params[1]['json']['events']);
         $this->assertSame([], $params[1]['json']['events'][0]['user']);
         $this->assertArrayNotHasKey('metaData', $params[1]['json']['events'][0]);
+        $this->assertSame('6015a72ff14038114c3d12623dfb018f', $params[1]['json']['apiKey']);
 
         $headers = $params[1]['headers'];
         $this->assertSame('6015a72ff14038114c3d12623dfb018f', $headers['Bugsnag-Api-Key']);
@@ -135,6 +137,7 @@ class HttpClientTest extends TestCase
         $this->assertInternalType('array', $params[1]['json']['events']);
         $this->assertSame(['foo' => 'bar'], $params[1]['json']['events'][0]['user']);
         $this->assertSame([], $params[1]['json']['events'][0]['metaData']);
+        $this->assertSame('6015a72ff14038114c3d12623dfb018f', $params[1]['json']['apiKey']);
 
         $headers = $params[1]['headers'];
         $this->assertSame('6015a72ff14038114c3d12623dfb018f', $headers['Bugsnag-Api-Key']);


### PR DESCRIPTION
Re-adds apiKey into payload for older on-premise versions.