### PR TITLE
Reject empty build version

### DIFF
--- a/src/HttpClient.php
+++ b/src/HttpClient.php
@@ -106,6 +106,14 @@ class HttpClient
 
         $data = [];
         $sourceControl = [];
+
+        if (isset($app['version'])) {
+            $data['appVersion'] = $app['version'];
+        } else {
+            error_log('Bugsnag Warning: App version is not set. Unable to send build report.');
+            return;
+        }
+
         if (isset($buildInfo['repository'])) {
             $sourceControl['repository'] = $buildInfo['repository'];
         }
@@ -135,10 +143,6 @@ class HttpClient
         }
 
         $data['releaseStage'] = $app['releaseStage'];
-
-        if (isset($app['version'])) {
-            $data['appVersion'] = $app['version'];
-        }
 
         $data['apiKey'] = $this->config->getApiKey();
 

--- a/src/HttpClient.php
+++ b/src/HttpClient.php
@@ -111,6 +111,7 @@ class HttpClient
             $data['appVersion'] = $app['version'];
         } else {
             error_log('Bugsnag Warning: App version is not set. Unable to send build report.');
+
             return;
         }
 

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -376,18 +376,20 @@ class ClientTest extends TestCase
 
     public function testDeployWorksOutOfTheBox()
     {
-        $this->guzzle->expects($this->once())->method('post')->with($this->equalTo('https://build.bugsnag.com'), $this->equalTo(['json' => ['releaseStage' => 'production', 'apiKey' => 'example-api-key', 'buildTool' => 'bugsnag-php', 'builderName' => exec('whoami')]]));
+        $this->guzzle->expects($this->once())->method('post')->with($this->equalTo('https://build.bugsnag.com'), $this->equalTo(['json' => ['releaseStage' => 'production', 'apiKey' => 'example-api-key', 'buildTool' => 'bugsnag-php', 'builderName' => exec('whoami'), 'appVersion' => '1.3.1']]));
 
         $this->client = new Client($this->config = new Configuration('example-api-key'), null, $this->guzzle);
+        $this->config->setAppVersion('1.3.1');
 
         $this->client->deploy();
     }
 
     public function testDeployWorksWithReleaseStage()
     {
-        $this->guzzle->expects($this->once())->method('post')->with($this->equalTo('https://build.bugsnag.com'), $this->equalTo(['json' => ['releaseStage' => 'staging', 'apiKey' => 'example-api-key', 'buildTool' => 'bugsnag-php', 'builderName' => exec('whoami')]]));
+        $this->guzzle->expects($this->once())->method('post')->with($this->equalTo('https://build.bugsnag.com'), $this->equalTo(['json' => ['releaseStage' => 'staging', 'apiKey' => 'example-api-key', 'buildTool' => 'bugsnag-php', 'builderName' => exec('whoami'), 'appVersion' => '1.3.1']]));
 
         $this->client = new Client($this->config = new Configuration('example-api-key'), null, $this->guzzle);
+        $this->config->setAppVersion('1.3.1');
 
         $this->config->setReleaseStage('staging');
 
@@ -396,45 +398,47 @@ class ClientTest extends TestCase
 
     public function testDeployWorksWithAppVersion()
     {
-        $this->guzzle->expects($this->once())->method('post')->with($this->equalTo('https://build.bugsnag.com'), $this->equalTo(['json' => ['releaseStage' => 'production', 'appVersion' => '1.1.0', 'apiKey' => 'example-api-key', 'buildTool' => 'bugsnag-php', 'builderName' => exec('whoami')]]));
+        $this->guzzle->expects($this->once())->method('post')->with($this->equalTo('https://build.bugsnag.com'), $this->equalTo(['json' => ['releaseStage' => 'production', 'appVersion' => '1.1.0', 'apiKey' => 'example-api-key', 'buildTool' => 'bugsnag-php', 'builderName' => exec('whoami'), 'appVersion' => '1.3.1']]));
 
         $this->client = new Client($this->config = new Configuration('example-api-key'), null, $this->guzzle);
-
-        $this->config->setAppVersion('1.1.0');
+        $this->config->setAppVersion('1.3.1');
 
         $this->client->deploy();
     }
 
     public function testDeployWorksWithRepository()
     {
-        $this->guzzle->expects($this->once())->method('post')->with($this->equalTo('https://build.bugsnag.com'), $this->equalTo(['json' => ['sourceControl' => ['repository' => 'foo'], 'releaseStage' => 'production', 'apiKey' => 'example-api-key', 'buildTool' => 'bugsnag-php', 'builderName' => exec('whoami')]]));
+        $this->guzzle->expects($this->once())->method('post')->with($this->equalTo('https://build.bugsnag.com'), $this->equalTo(['json' => ['sourceControl' => ['repository' => 'foo'], 'releaseStage' => 'production', 'apiKey' => 'example-api-key', 'buildTool' => 'bugsnag-php', 'builderName' => exec('whoami'), 'appVersion' => '1.3.1']]));
 
         $this->client = new Client($this->config = new Configuration('example-api-key'), null, $this->guzzle);
+        $this->config->setAppVersion('1.3.1');
 
         $this->client->deploy('foo');
     }
 
     public function testDeployWorksWithBranch()
     {
-        $this->guzzle->expects($this->once())->method('post')->with($this->equalTo('https://build.bugsnag.com'), $this->equalTo(['json' => ['releaseStage' => 'production', 'apiKey' => 'example-api-key', 'buildTool' => 'bugsnag-php', 'builderName' => exec('whoami')]]));
+        $this->guzzle->expects($this->once())->method('post')->with($this->equalTo('https://build.bugsnag.com'), $this->equalTo(['json' => ['releaseStage' => 'production', 'apiKey' => 'example-api-key', 'buildTool' => 'bugsnag-php', 'builderName' => exec('whoami'), 'appVersion' => '1.3.1']]));
 
         $this->client = new Client($this->config = new Configuration('example-api-key'), null, $this->guzzle);
+        $this->config->setAppVersion('1.3.1');
 
         $this->client->deploy(null, 'master');
     }
 
     public function testDeployWorksWithRevision()
     {
-        $this->guzzle->expects($this->once())->method('post')->with($this->equalTo('https://build.bugsnag.com'), $this->equalTo(['json' => ['sourceControl' => ['revision' => 'bar'], 'releaseStage' => 'production', 'apiKey' => 'example-api-key', 'buildTool' => 'bugsnag-php', 'builderName' => exec('whoami')]]));
+        $this->guzzle->expects($this->once())->method('post')->with($this->equalTo('https://build.bugsnag.com'), $this->equalTo(['json' => ['sourceControl' => ['revision' => 'bar'], 'releaseStage' => 'production', 'apiKey' => 'example-api-key', 'buildTool' => 'bugsnag-php', 'builderName' => exec('whoami'), 'appVersion' => '1.3.1']]));
 
         $this->client = new Client($this->config = new Configuration('example-api-key'), null, $this->guzzle);
+        $this->config->setAppVersion('1.3.1');
 
         $this->client->deploy(null, null, 'bar');
     }
 
     public function testDeployWorksWithEverything()
     {
-        $this->guzzle->expects($this->once())->method('post')->with($this->equalTo('https://build.bugsnag.com'), $this->equalTo(['json' => ['sourceControl' => ['repository' => 'baz', 'revision' => 'foo'], 'releaseStage' => 'development', 'appVersion' => '1.3.1', 'apiKey' => 'example-api-key', 'buildTool' => 'bugsnag-php', 'builderName' => exec('whoami')]]));
+        $this->guzzle->expects($this->once())->method('post')->with($this->equalTo('https://build.bugsnag.com'), $this->equalTo(['json' => ['sourceControl' => ['repository' => 'baz', 'revision' => 'foo'], 'releaseStage' => 'development', 'appVersion' => '1.3.1', 'apiKey' => 'example-api-key', 'buildTool' => 'bugsnag-php', 'builderName' => exec('whoami'), 'appVersion' => '1.3.1']]));
 
         $this->client = new Client($this->config = new Configuration('example-api-key'), null, $this->guzzle);
 
@@ -446,76 +450,72 @@ class ClientTest extends TestCase
 
     public function testBuildWorksOutOfTheBox()
     {
-        $this->guzzle->expects($this->once())->method('post')->with($this->equalTo('https://build.bugsnag.com'), $this->equalTo(['json' => ['releaseStage' => 'production', 'apiKey' => 'example-api-key', 'buildTool' => 'bugsnag-php', 'builderName' => exec('whoami')]]));
+        $this->guzzle->expects($this->once())->method('post')->with($this->equalTo('https://build.bugsnag.com'), $this->equalTo(['json' => ['releaseStage' => 'production', 'apiKey' => 'example-api-key', 'buildTool' => 'bugsnag-php', 'builderName' => exec('whoami'), 'appVersion' => '1.3.1']]));
 
         $this->client = new Client($this->config = new Configuration('example-api-key'), null, $this->guzzle);
+        $this->config->setAppVersion('1.3.1');
 
         $this->client->build();
     }
 
     public function testBuildWorksWithReleaseStage()
     {
-        $this->guzzle->expects($this->once())->method('post')->with($this->equalTo('https://build.bugsnag.com'), $this->equalTo(['json' => ['releaseStage' => 'staging', 'apiKey' => 'example-api-key', 'buildTool' => 'bugsnag-php', 'builderName' => exec('whoami')]]));
+        $this->guzzle->expects($this->once())->method('post')->with($this->equalTo('https://build.bugsnag.com'), $this->equalTo(['json' => ['releaseStage' => 'staging', 'apiKey' => 'example-api-key', 'buildTool' => 'bugsnag-php', 'builderName' => exec('whoami'), 'appVersion' => '1.3.1']]));
 
         $this->client = new Client($this->config = new Configuration('example-api-key'), null, $this->guzzle);
 
+        $this->config->setAppVersion('1.3.1');
         $this->config->setReleaseStage('staging');
-
-        $this->client->build();
-    }
-
-    public function testBuildWorksWithAppVersion()
-    {
-        $this->guzzle->expects($this->once())->method('post')->with($this->equalTo('https://build.bugsnag.com'), $this->equalTo(['json' => ['releaseStage' => 'production', 'appVersion' => '1.1.0', 'apiKey' => 'example-api-key', 'buildTool' => 'bugsnag-php', 'builderName' => exec('whoami')]]));
-
-        $this->client = new Client($this->config = new Configuration('example-api-key'), null, $this->guzzle);
-
-        $this->config->setAppVersion('1.1.0');
 
         $this->client->build();
     }
 
     public function testBuildWorksWithRepository()
     {
-        $this->guzzle->expects($this->once())->method('post')->with($this->equalTo('https://build.bugsnag.com'), $this->equalTo(['json' => ['sourceControl' => ['repository' => 'foo'], 'releaseStage' => 'production', 'apiKey' => 'example-api-key', 'buildTool' => 'bugsnag-php', 'builderName' => exec('whoami')]]));
+        $this->guzzle->expects($this->once())->method('post')->with($this->equalTo('https://build.bugsnag.com'), $this->equalTo(['json' => ['sourceControl' => ['repository' => 'foo'], 'releaseStage' => 'production', 'apiKey' => 'example-api-key', 'buildTool' => 'bugsnag-php', 'builderName' => exec('whoami'), 'appVersion' => '1.3.1']]));
 
         $this->client = new Client($this->config = new Configuration('example-api-key'), null, $this->guzzle);
+        $this->config->setAppVersion('1.3.1');
 
         $this->client->build('foo');
     }
 
     public function testBuildWorksWithProvider()
     {
-        $this->guzzle->expects($this->once())->method('post')->with($this->equalTo('https://build.bugsnag.com'), $this->equalTo(['json' => ['sourceControl' => ['provider' => 'github'], 'releaseStage' => 'production', 'apiKey' => 'example-api-key', 'buildTool' => 'bugsnag-php', 'builderName' => exec('whoami')]]));
+        $this->guzzle->expects($this->once())->method('post')->with($this->equalTo('https://build.bugsnag.com'), $this->equalTo(['json' => ['sourceControl' => ['provider' => 'github'], 'releaseStage' => 'production', 'apiKey' => 'example-api-key', 'buildTool' => 'bugsnag-php', 'builderName' => exec('whoami'), 'appVersion' => '1.3.1']]));
 
         $this->client = new Client($this->config = new Configuration('example-api-key'), null, $this->guzzle);
+        $this->config->setAppVersion('1.3.1');
 
         $this->client->build(null, null, 'github');
     }
 
     public function testBuildWorksWithRevision()
     {
-        $this->guzzle->expects($this->once())->method('post')->with($this->equalTo('https://build.bugsnag.com'), $this->equalTo(['json' => ['sourceControl' => ['revision' => 'bar'], 'releaseStage' => 'production', 'apiKey' => 'example-api-key', 'buildTool' => 'bugsnag-php', 'builderName' => exec('whoami')]]));
+        $this->guzzle->expects($this->once())->method('post')->with($this->equalTo('https://build.bugsnag.com'), $this->equalTo(['json' => ['sourceControl' => ['revision' => 'bar'], 'releaseStage' => 'production', 'apiKey' => 'example-api-key', 'buildTool' => 'bugsnag-php', 'builderName' => exec('whoami'), 'appVersion' => '1.3.1']]));
 
         $this->client = new Client($this->config = new Configuration('example-api-key'), null, $this->guzzle);
+        $this->config->setAppVersion('1.3.1');
 
         $this->client->build(null, 'bar');
     }
 
     public function testBuildWorksWithBuilderName()
     {
-        $this->guzzle->expects($this->once())->method('post')->with($this->equalTo('https://build.bugsnag.com'), $this->equalTo(['json' => ['builderName' => 'me', 'releaseStage' => 'production', 'apiKey' => 'example-api-key', 'buildTool' => 'bugsnag-php']]));
+        $this->guzzle->expects($this->once())->method('post')->with($this->equalTo('https://build.bugsnag.com'), $this->equalTo(['json' => ['builderName' => 'me', 'releaseStage' => 'production', 'apiKey' => 'example-api-key', 'buildTool' => 'bugsnag-php', 'appVersion' => '1.3.1']]));
 
         $this->client = new Client($this->config = new Configuration('example-api-key'), null, $this->guzzle);
+        $this->config->setAppVersion('1.3.1');
 
         $this->client->build(null, null, null, 'me');
     }
 
     public function testBuildWorksWithBuildTool()
     {
-        $this->guzzle->expects($this->once())->method('post')->with($this->equalTo('https://build.bugsnag.com'), $this->equalTo(['json' => ['releaseStage' => 'production', 'apiKey' => 'example-api-key', 'buildTool' => 'bugsnag-php', 'builderName' => exec('whoami')]]));
+        $this->guzzle->expects($this->once())->method('post')->with($this->equalTo('https://build.bugsnag.com'), $this->equalTo(['json' => ['releaseStage' => 'production', 'apiKey' => 'example-api-key', 'buildTool' => 'bugsnag-php', 'builderName' => exec('whoami'), 'appVersion' => '1.3.1']]));
 
         $this->client = new Client($this->config = new Configuration('example-api-key'), null, $this->guzzle);
+        $this->config->setAppVersion('1.3.1');
 
         $this->client->build(null, null, null, null);
     }
@@ -530,6 +530,17 @@ class ClientTest extends TestCase
         $this->config->setAppVersion('1.3.1');
 
         $this->client->build('baz', 'foo', 'github', 'me');
+    }
+
+    public function testBuildFailsWithoutAPIKey()
+    {
+        $this->client = new Client($this->config = new Configuration('example-api-key'), null, $this->guzzle);
+
+        // Setup error_log mocking
+        $log = $this->getFunctionMock('Bugsnag', 'error_log');
+        $log->expects($this->once())->with($this->equalTo('Bugsnag Warning: App version is not set. Unable to send build report.'));
+
+        $this->client->build();
     }
 
     public function testSeverityReasonUnmodified()


### PR DESCRIPTION
Adds an error message and halts the sending of a build report if the `appVersion` is not set. 