### PR TITLE
Updates the payload body `payloadVersion`

### DIFF
--- a/src/Report.php
+++ b/src/Report.php
@@ -9,12 +9,13 @@ use Throwable;
 
 class Report
 {
+
     /**
      * The payload version.
      *
      * @var string
      */
-    const PAYLOAD_VERSION = '3';
+    const PAYLOAD_VERSION = HttpClient::PAYLOAD_VERSION;
 
     /**
      * The config object.
@@ -625,7 +626,7 @@ class Report
             'device' => array_merge(['time' => $this->time], $this->config->getDeviceData()),
             'user' => $this->getUser(),
             'context' => $this->getContext(),
-            'payloadVersion' => static::PAYLOAD_VERSION,
+            'payloadVersion' => HttpClient::PAYLOAD_VERSION,
             'severity' => $this->getSeverity(),
             'exceptions' => $this->exceptionArray(),
             'breadcrumbs' => $this->breadcrumbs,

--- a/src/Report.php
+++ b/src/Report.php
@@ -9,7 +9,6 @@ use Throwable;
 
 class Report
 {
-
     /**
      * The payload version.
      *

--- a/tests/HttpClientTest.php
+++ b/tests/HttpClientTest.php
@@ -48,6 +48,7 @@ class HttpClientTest extends TestCase
         $this->assertSame([], $params[1]['json']['events'][0]['user']);
         $this->assertSame(['foo' => 'bar'], $params[1]['json']['events'][0]['metaData']);
         $this->assertSame('6015a72ff14038114c3d12623dfb018f', $params[1]['json']['apiKey']);
+        $this->assertSame('4.0', $params[1]['json']['events'][0]['payloadVersion']);
 
         $headers = $params[1]['headers'];
         $this->assertSame('6015a72ff14038114c3d12623dfb018f', $headers['Bugsnag-Api-Key']);
@@ -91,6 +92,7 @@ class HttpClientTest extends TestCase
         $this->assertSame([], $params[1]['json']['events'][0]['user']);
         $this->assertArrayNotHasKey('metaData', $params[1]['json']['events'][0]);
         $this->assertSame('6015a72ff14038114c3d12623dfb018f', $params[1]['json']['apiKey']);
+        $this->assertSame('4.0', $params[1]['json']['events'][0]['payloadVersion']);
 
         $headers = $params[1]['headers'];
         $this->assertSame('6015a72ff14038114c3d12623dfb018f', $headers['Bugsnag-Api-Key']);
@@ -138,6 +140,7 @@ class HttpClientTest extends TestCase
         $this->assertSame(['foo' => 'bar'], $params[1]['json']['events'][0]['user']);
         $this->assertSame([], $params[1]['json']['events'][0]['metaData']);
         $this->assertSame('6015a72ff14038114c3d12623dfb018f', $params[1]['json']['apiKey']);
+        $this->assertSame('4.0', $params[1]['json']['events'][0]['payloadVersion']);
 
         $headers = $params[1]['headers'];
         $this->assertSame('6015a72ff14038114c3d12623dfb018f', $headers['Bugsnag-Api-Key']);

--- a/tests/ReportTest.php
+++ b/tests/ReportTest.php
@@ -137,7 +137,7 @@ class ReportTest extends TestCase
         $this->report->setPHPError(E_ERROR, 'Broken', 'file', 123);
 
         $event = $this->report->toArray();
-        $this->assertSame('3', $event['payloadVersion']);
+        $this->assertSame('4.0', $event['payloadVersion']);
     }
 
     public function testNoticeSeverity()


### PR DESCRIPTION
Ensures the `PAYLOAD_VERSION` static in `Report.php` is consistent with `PAYLOAD_VERSION` in `HttpClient.php`.  
Added tests to check the payload version is set correctly in both headers and body.