### PR TITLE
Ensure name represents class before reflecting

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -211,10 +211,12 @@ class Client
      */
     public function leaveBreadcrumb($name, $type = null, array $metaData = [])
     {
-        try {
-            $name = (new ReflectionClass($name))->getShortName();
-        } catch (ReflectionException $e) {
-            //
+        if (class_exists($name)) {
+            try {
+                $name = (new ReflectionClass($name))->getShortName();
+            } catch (ReflectionException $e) {
+                //
+            }
         }
 
         $name = substr((string) $name, 0, Breadcrumb::MAX_LENGTH);


### PR DESCRIPTION
Test that the breadcrumb name represents a valid class before reflecting. Without this debugging can be a nightmare due to all the unnecessary ReflectionExceptions being thrown.