### PR TITLE
fix(client): Ensure notify with callback is invoked on actual report

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 Changelog
 =========
 
+## TBD
+
+### Bug Fixes
+
+* Fix `notifyError(name, message, callback)` and `notifyException(ex, callback)`
+  to ensure that reports are sent when callback != null
+
 ## 3.14.0 (2018-0)
 
 * Added `registerMiddleware` method for external middleware additions

--- a/src/Client.php
+++ b/src/Client.php
@@ -296,7 +296,7 @@ class Client
                 $resolvedReport = null;
 
                 $bridge = new CallbackBridge($callback);
-                $bridge($report, function ($report) use ($resolvedReport) {
+                $bridge($report, function ($report) use (&$resolvedReport) {
                     $resolvedReport = $report;
                 });
                 if ($resolvedReport) {

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -4,6 +4,7 @@ namespace Bugsnag\Tests;
 
 use Bugsnag\Client;
 use Bugsnag\Configuration;
+use Bugsnag\HttpClient;
 use Bugsnag\Report;
 use Exception;
 use GuzzleHttp\Client as Guzzle;
@@ -42,9 +43,23 @@ class ClientTest extends TestCase
 
     public function testManualErrorNotificationWithSeverity()
     {
-        $this->client->expects($this->once())->method('notify');
+        $client = new Client($this->config, null, $this->guzzle);
+        $prop = (new ReflectionClass($client))->getProperty('http');
+        $prop->setAccessible(true);
 
-        $this->client->notifyError('SomeError', 'Some message', function ($report) {
+        $http = $this->getMockBuilder(HttpClient::class)
+                     ->setMethods(['queue'])
+                     ->setConstructorArgs([$this->config, $this->guzzle])
+                     ->getMock();
+        $prop->setValue($client, $http);
+
+        $http->expects($this->once())
+             ->method('queue')
+             ->with($this->callback(function ($subject) {
+                 return $subject->getSeverity() === 'info';
+             }));
+
+        $client->notifyError('SomeError', 'Some message', function ($report) {
             $report->setSeverity('info');
         });
     }


### PR DESCRIPTION
## Goal

Without dereferencing the report, $resolvedReport is always null and
nothing is delivered to Bugsnag when callback != null


## Tests

Updated existing tests for calling `notify` to check that the callback change is applied

## Linked issues

Fixes bugsnag/bugsnag-laravel#310

## Review

For the submitter, initial self-review:

- [x] Commented on code changes inline explain the reasoning behind the approach
- [x] Reviewed the test cases added for completeness and possible points for discussion
- [x] A changelog entry was added for the goal of this pull request
- [x] Check the scope of the changeset - is everything in the diff required for the pull request?
- This pull request is ready for:
  - [x] Initial review of the intended approach, not yet feature complete
  - [x] Structural review of the classes, functions, and properties modified
  - [x] Final review

For the pull request reviewer(s), this changeset has been reviewed for:

- [ ] Consistency across platforms for structures or concepts added or modified
- [ ] Consistency between the changeset and the goal stated above
- [ ] Internal consistency with the rest of the library - is there any overlap between existing interfaces and any which have been added?
- [ ] Usage friction - is the proposed change in usage cumbersome or complicated?
- [ ] Performance and complexity - are there any cases of unexpected O(n^3) when iterating, recursing, flat mapping, etc?
- [ ] Concurrency concerns - if components are accessed asynchronously, what issues will arise
- [ ] Thoroughness of added tests and any missing edge cases
- [ ] Idiomatic use of the language
