### PR TITLE
Fixed recursion on payload too large

### DIFF
--- a/src/Exception/PayloadTooLargeException.php
+++ b/src/Exception/PayloadTooLargeException.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Bugsnag\Exception;
+
+class PayloadTooLargeException extends \RuntimeException {
+
+    private $payload;
+
+    public function __construct(array $payload) {
+        parent::__construct('Payload too large', 0, null);
+
+        $this->payload = $payload;
+    }
+
+    /**
+     * @return array
+     */
+    public function getPayload() {
+        return $this->payload;
+    }
+
+
+}


### PR DESCRIPTION
## Goal

Fixed the endless recursion when the payload to submit is too large. The PHP max function nesting will be reached.

## Review

For the submitter, initial self-review:

- [x] Commented on code changes inline explain the reasoning behind the approach
- [x] Reviewed the test cases added for completeness and possible points for discussion
- [x] A changelog entry was added for the goal of this pull request
- [x] Check the scope of the changeset - is everything in the diff required for the pull request?
- This pull request is ready for:
  - [x] Initial review of the intended approach, not yet feature complete
  - [x] Structural review of the classes, functions, and properties modified
  - [x] Final review

For the pull request reviewer(s), this changeset has been reviewed for:

- [ ] Consistency across platforms for structures or concepts added or modified
- [ ] Consistency between the changeset and the goal stated above
- [ ] Internal consistency with the rest of the library - is there any overlap between existing interfaces and any which have been added?
- [ ] Usage friction - is the proposed change in usage cumbersome or complicated?
- [ ] Performance and complexity - are there any cases of unexpected O(n^3) when iterating, recursing, flat mapping, etc?
- [ ] Concurrency concerns - if components are accessed asynchronously, what issues will arise
- [ ] Thoroughness of added tests and any missing edge cases
- [ ] Idiomatic use of the language
