### PR TITLE
Fix Mockery: Fix mockery to v1.1 for HHVM 3.9 compatability

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
     },
     "require-dev": {
         "graham-campbell/testbench-core": "^1.1",
-        "mockery/mockery": "^0.9.4|^1.0",
+        "mockery/mockery": "^0.9.4|~1.1.0",
         "mtdowling/burgomaster": "dev-master#72151eddf5f0cf101502b94bf5031f9c53501a04",
         "phpunit/phpunit": "^4.8|^5.0",
         "php-mock/php-mock-phpunit": "^1.1"


### PR DESCRIPTION
## Goal
Since the 1.2 release mockery has been failing on HHVM 3.9.  I've raised the issue [here](https://github.com/mockery/mockery/issues/922).  In the meantime we should lock the mockery version to `1.1`.

## Changeset
- Changed upper mockery version from `^1.0` to `~1.1.0`.