### PR TITLE
Allow configuring project root path by using a regular expression

### DIFF
--- a/src/Configuration.php
+++ b/src/Configuration.php
@@ -269,6 +269,22 @@ class Configuration
     }
 
     /**
+     * Set the project root regex.
+     *
+     * @param string|null $projectRootRegex the project root path
+     *
+     * @return void
+     */
+    public function setProjectRootRegex($projectRootRegex)
+    {
+        if (@preg_match($projectRootRegex, null) === false) {
+            throw new InvalidArgumentException('Invalid project root regex: '.$projectRootRegex);
+        }
+
+        $this->projectRootRegex = $projectRootRegex;
+    }
+
+    /**
      * Is the given file in the project?
      *
      * @param string $file

--- a/tests/ConfigurationTest.php
+++ b/tests/ConfigurationTest.php
@@ -74,6 +74,27 @@ class ConfigurationTest extends TestCase
         $this->assertFalse($this->config->isInProject('/base/root/dir/afile.php'));
     }
 
+    public function testRootPathRegex()
+    {
+        $this->assertFalse($this->config->isInProject('/root/dir/app/afile.php'));
+
+        $this->config->setProjectRootRegex("/^(".preg_quote("/root/dir/app", '/')."|".preg_quote("/root/dir/lib", '/').")[\\/]?/i");
+
+        $this->assertTrue($this->config->isInProject('/root/dir/app/afile.php'));
+        $this->assertTrue($this->config->isInProject('/root/dir/lib/afile.php'));
+        $this->assertFalse($this->config->isInProject('/root'));
+        $this->assertFalse($this->config->isInProject('/root/dir/other-directory/afile.php'));
+        $this->assertFalse($this->config->isInProject('/base/root/dir/app/afile.php'));
+
+        $this->config->setProjectRootRegex("/^(".preg_quote("/root/dir/app/", '/')."|".preg_quote("/root/dir/lib/", '/').")[\\/]?/i");
+
+        $this->assertTrue($this->config->isInProject('/root/dir/app/afile.php'));
+        $this->assertTrue($this->config->isInProject('/root/dir/lib/afile.php'));
+        $this->assertFalse($this->config->isInProject('/root'));
+        $this->assertFalse($this->config->isInProject('/root/dir/other-directory/afile.php'));
+        $this->assertFalse($this->config->isInProject('/base/root/dir/afile.php'));
+    }
+
     public function testAppData()
     {
         $this->assertSame(['type' => 'cli', 'releaseStage' => 'production'], $this->config->getAppData());

--- a/tests/ConfigurationTest.php
+++ b/tests/ConfigurationTest.php
@@ -78,7 +78,7 @@ class ConfigurationTest extends TestCase
     {
         $this->assertFalse($this->config->isInProject('/root/dir/app/afile.php'));
 
-        $this->config->setProjectRootRegex("/^(".preg_quote("/root/dir/app", '/')."|".preg_quote("/root/dir/lib", '/').")[\\/]?/i");
+        $this->config->setProjectRootRegex('/^('.preg_quote('/root/dir/app', '/').'|'.preg_quote('/root/dir/lib', '/').')[\\/]?/i');
 
         $this->assertTrue($this->config->isInProject('/root/dir/app/afile.php'));
         $this->assertTrue($this->config->isInProject('/root/dir/lib/afile.php'));
@@ -86,7 +86,7 @@ class ConfigurationTest extends TestCase
         $this->assertFalse($this->config->isInProject('/root/dir/other-directory/afile.php'));
         $this->assertFalse($this->config->isInProject('/base/root/dir/app/afile.php'));
 
-        $this->config->setProjectRootRegex("/^(".preg_quote("/root/dir/app/", '/')."|".preg_quote("/root/dir/lib/", '/').")[\\/]?/i");
+        $this->config->setProjectRootRegex('/^('.preg_quote('/root/dir/app/', '/').'|'.preg_quote('/root/dir/lib/', '/').')[\\/]?/i');
 
         $this->assertTrue($this->config->isInProject('/root/dir/app/afile.php'));
         $this->assertTrue($this->config->isInProject('/root/dir/lib/afile.php'));


### PR DESCRIPTION
## Goal

Allow configuring project root by using regular expressions to support more complex codebase structures. 

## Design

In our case, we have different folders for each domain. All of them outside of the app directory, which we use only for application scope. So, errors from different sources get grouped when there are completely different errors. 

For example, we have a method "dispatchNow" (into the app folder) to handle jobs in the way application needs. That method is called from other domains, which Bugsnag doesn't recognize as we can only define one directory as project root. So, every codebase invoking dispachNow from other folders than app get grouped together being different errors.

## Discussion
I've seen version 2.x had this method. But, I don't know why it was removed in version 3. Maybe there are some corner case or question to be considered to add this feature.

Let me know what do you think ;)

Cheers!