### PR TITLE
ci: Remove hhvm test target

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,29 +28,8 @@ matrix:
       env: GUZZLE_VERSION=^5.3
     - php: 7.2
       env: GUZZLE_VERSION=^6.0
-    - php: hhvm-3.6
-      env: GUZZLE_VERSION=^5.3
-    - php: hhvm-3.6
-      env: GUZZLE_VERSION=^6.0
-    - php: hhvm-3.9
-      env: GUZZLE_VERSION=^5.3
-    - php: hhvm-3.9
-      env: GUZZLE_VERSION=^6.0
-    - php: hhvm-3.12
-      env: GUZZLE_VERSION=^5.3
-    - php: hhvm-3.12
-      env: GUZZLE_VERSION=^6.0
-    - php: hhvm-3.15
-      env: GUZZLE_VERSION=^5.3
-    - php: hhvm-3.15
-      env: GUZZLE_VERSION=^6.0
-    - php: hhvm-3.18
-      env: GUZZLE_VERSION=^5.3
-    - php: hhvm-3.18
-      env: GUZZLE_VERSION=^6.0
 
 before_install:
-  - if [[ $TRAVIS_PHP_VERSION =~ ^hhvm ]]; then echo 'hhvm.jit = false' >> /etc/hhvm/php.ini ; fi
   - composer require "guzzlehttp/guzzle:${GUZZLE_VERSION}" --no-update
 
 install:


### PR DESCRIPTION
HHVM has gone its own way from the true path of PHP 7

Ref: https://hhvm.com/blog/2017/09/18/the-future-of-hhvm.html