### PR TITLE
fix: Allow modification of stack values by using references

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 Changelog
 =========
 
+## TBD
+
+### Bug Fixes
+
+* Allow modifying stack frame values by reference
+
 ## 3.15.0 (2018-11-1)
 
 ### Enhancements

--- a/src/Stacktrace.php
+++ b/src/Stacktrace.php
@@ -137,7 +137,7 @@ class Stacktrace
      *
      * @return array[]
      */
-    public function toArray()
+    public function &toArray()
     {
         return $this->frames;
     }
@@ -149,7 +149,7 @@ class Stacktrace
      *
      * @return array[]
      */
-    public function getFrames()
+    public function &getFrames()
     {
         return $this->frames;
     }

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -167,18 +167,18 @@ class ClientTest extends TestCase
 
         $this->client->notify($report = Report::fromNamedError($this->config, 'Magic', 'oh no'));
 
-        $this->assertFalse($report->getStacktrace()->getFrames()[0]["inProject"]);
+        $this->assertFalse($report->getStacktrace()->getFrames()[0]['inProject']);
 
         $this->client->registerCallback(function (Report $report) {
             $frames = &$report->getStacktrace()->getFrames();
-            $frames[0]["inProject"] = true;
+            $frames[0]['inProject'] = true;
 
             return true;
         });
 
         $this->client->notify($report = Report::fromNamedError($this->config, 'Magic', 'oh no'));
 
-        $this->assertTrue($report->getStacktrace()->getFrames()[0]["inProject"]);
+        $this->assertTrue($report->getStacktrace()->getFrames()[0]['inProject']);
     }
 
     public function testDirectCallbackSkipsError()

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -159,6 +159,28 @@ class ClientTest extends TestCase
         $this->client->notify(Report::fromNamedError($this->config, 'SkipMe', 'Message'));
     }
 
+    public function testBeforeNotifyCanModifyReportFrames()
+    {
+        $this->client = new Client($this->config = new Configuration('example-api-key'), null, $this->guzzle);
+
+        $this->client->setBatchSending(false);
+
+        $this->client->notify($report = Report::fromNamedError($this->config, 'Magic', 'oh no'));
+
+        $this->assertFalse($report->getStacktrace()->getFrames()[0]["inProject"]);
+
+        $this->client->registerCallback(function (Report $report) {
+            $frames = &$report->getStacktrace()->getFrames();
+            $frames[0]["inProject"] = true;
+
+            return true;
+        });
+
+        $this->client->notify($report = Report::fromNamedError($this->config, 'Magic', 'oh no'));
+
+        $this->assertTrue($report->getStacktrace()->getFrames()[0]["inProject"]);
+    }
+
     public function testDirectCallbackSkipsError()
     {
         $this->client = new Client($this->config = new Configuration('example-api-key'), null, $this->guzzle);


### PR DESCRIPTION
Makes it possible to modify stack frame values without having to
completely reconstruct the stack from modified frames.

For example, this now works:

```php
\Bugsnag::registerCallback(function ($report) {
    $frames = &$report->getStacktrace()->getFrames();
    foreach ($frames as &$frame) {
        $frame["inProject"] = true;
    }
});
```

## Changeset

Added reference indicators to `toArray()` and `getFrames()`

## Tests

* Added a new callback test which changes a frame value by reference

## Review

- This pull request is ready for:
  - [ ] Initial review of the intended approach, not yet feature complete
  - [ ] Structural review of the classes, functions, and properties modified
  - [x] Final review

For the pull request reviewer(s), this changeset has been reviewed for:

- [ ] Usage friction - is the proposed change in usage cumbersome or complicated?
- [ ] Thoroughness of added tests and any missing edge cases
- [ ] Idiomatic use of the language