### PR TITLE
perf: Expand reflected calls into Client methods

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -405,26 +405,428 @@ class Client
         return $this->sessionTracker;
     }
 
+    // Forward calls to Configuration:
+
     /**
-     * Dynamically pass calls to the configuration.
+     * Get the Bugsnag API Key.
      *
-     * @param string $method
-     * @param array  $parameters
-     *
-     * @throws \BadMethodCallException
-     *
-     * @return mixed
+     * @var string
      */
-    public function __call($method, $parameters)
+    public function getApiKey()
     {
-        $callable = [$this->config, $method];
+        return $this->config->getApiKey();
+    }
 
-        if (!is_callable($callable)) {
-            throw new BadMethodCallException("The method '{$method}' does not exist.");
-        }
+    /**
+     * Sets whether errors should be batched together and send at the end of each request.
+     *
+     * @param bool $batchSending whether to batch together errors
+     *
+     * @return $this
+     */
+    public function setBatchSending($batchSending)
+    {
+        $this->config->setBatchSending($batchSending);
 
-        $value = call_user_func_array($callable, $parameters);
+        return $this;
+    }
 
-        return stripos($method, 'set') === 0 ? $this : $value;
+    /**
+     * Is batch sending is enabled?
+     *
+     * @return bool
+     */
+    public function isBatchSending()
+    {
+        return $this->config->isBatchSending();
+    }
+
+    /**
+     * Set which release stages should be allowed to notify Bugsnag.
+     *
+     * Eg ['production', 'development'].
+     *
+     * @param string[]|null $notifyReleaseStages array of release stages to notify for
+     *
+     * @return $this
+     */
+    public function setNotifyReleaseStages(array $notifyReleaseStages = null)
+    {
+        $this->config->setNotifyReleaseStages($notifyReleaseStages);
+
+        return $this;
+    }
+
+    /**
+     * Should we notify Bugsnag based on the current release stage?
+     *
+     * @return bool
+     */
+    public function shouldNotify()
+    {
+        return $this->config->shouldNotify();
+    }
+
+    /**
+     * Set the strings to filter out from metaData arrays before sending then.
+     *
+     * Eg. ['password', 'credit_card'].
+     *
+     * @param string[] $filters an array of metaData filters
+     *
+     * @return $this
+     */
+    public function setFilters(array $filters)
+    {
+        $this->config->setFilters($filters);
+
+        return $this;
+    }
+
+    /**
+     * Get the array of metaData filters.
+     *
+     * @var string
+     */
+    public function getFilters()
+    {
+        return $this->config->getFilters();
+    }
+
+    /**
+     * Set the project root.
+     *
+     * @param string|null $projectRoot the project root path
+     *
+     * @return void
+     */
+    public function setProjectRoot($projectRoot)
+    {
+        $this->config->setProjectRoot($projectRoot);
+    }
+
+    /**
+     * Is the given file in the project?
+     *
+     * @param string $file
+     *
+     * @return string
+     */
+    public function isInProject($file)
+    {
+        return $this->config->isInProject($file);
+    }
+
+    /**
+     * Set the strip path.
+     *
+     * @param string|null $stripPath the absolute strip path
+     *
+     * @return void
+     */
+    public function setStripPath($stripPath)
+    {
+        $this->config->setStripPath($stripPath);
+    }
+
+    /**
+     * Set the regular expression used to strip paths from stacktraces.
+     *
+     * @param string|null $stripPathRegex
+     *
+     * @return void
+     */
+    public function setStripPathRegex($stripPathRegex)
+    {
+        $this->config->setStripPathRegex($stripPathRegex);
+    }
+
+    /**
+     * Get the stripped file path.
+     *
+     * @param string $file
+     *
+     * @return string
+     */
+    public function getStrippedFilePath($file)
+    {
+        return $this->config->getStrippedFilePath($file);
+    }
+
+    /**
+     * Set if we should we send a small snippet of the code that crashed.
+     *
+     * This can help you diagnose even faster from within your dashboard.
+     *
+     * @param bool $sendCode whether to send code to Bugsnag
+     *
+     * @return $this
+     */
+    public function setSendCode($sendCode)
+    {
+        $this->config->setSendCode($sendCode);
+
+        return $this;
+    }
+
+    /**
+     * Should we send a small snippet of the code that crashed?
+     *
+     * @return bool
+     */
+    public function shouldSendCode()
+    {
+        return $this->config->shouldSendCode();
+    }
+
+    /**
+     * Sets the notifier to report as to Bugsnag.
+     *
+     * This should only be set by other notifier libraries.
+     *
+     * @param string[] $notifier an array of name, version, url.
+     *
+     * @return $this
+     */
+    public function setNotifier(array $notifier)
+    {
+        $this->config->setNotifier($notifier);
+
+        return $this;
+    }
+
+    /**
+     * Get the notifier to report as to Bugsnag.
+     *
+     * @var string[]
+     */
+    public function getNotifier()
+    {
+        return $this->config->getNotifier();
+    }
+
+    /**
+     * Set your app's semantic version, eg "1.2.3".
+     *
+     * @param string|null $appVersion the app's version
+     *
+     * @return $this
+     */
+    public function setAppVersion($appVersion)
+    {
+        $this->config->setAppVersion($appVersion);
+
+        return $this;
+    }
+
+    /**
+     * Set your release stage, eg "production" or "development".
+     *
+     * @param string|null $releaseStage the app's current release stage
+     *
+     * @return $this
+     */
+    public function setReleaseStage($releaseStage)
+    {
+        $this->config->setReleaseStage($releaseStage);
+
+        return $this;
+    }
+
+    /**
+     * Set the type of application executing the code.
+     *
+     * This is usually used to represent if you are running plain PHP code
+     * "php", via a framework, eg "laravel", or executing through delayed
+     * worker code, eg "resque".
+     *
+     * @param string|null $type the current type
+     *
+     * @return $this
+     */
+    public function setAppType($type)
+    {
+        $this->config->setAppType($type);
+
+        return $this;
+    }
+
+    /**
+     * Set the fallback application type.
+     *
+     * This is should be used only by libraries to set an fallback app type.
+     *
+     * @param string|null $type the fallback type
+     *
+     * @return $this
+     */
+    public function setFallbackType($type)
+    {
+        $this->config->setFallbackType($type);
+
+        return $this;
+    }
+
+    /**
+     * Get the application data.
+     *
+     * @return array
+     */
+    public function getAppData()
+    {
+        return $this->config->getAppData();
+    }
+
+    /**
+     * Set the hostname.
+     *
+     * @param string|null $hostname the hostname
+     *
+     * @return $this
+     */
+    public function setHostname($hostname)
+    {
+        $this->config->setHostname($hostname);
+
+        return $this;
+    }
+
+    /**
+     * Get the device data.
+     *
+     * @return array
+     */
+    public function getDeviceData()
+    {
+        return $this->config->getDeviceData();
+    }
+
+    /**
+     * Set custom metadata to send to Bugsnag.
+     *
+     * You can use this to add custom tabs of data to each error on your
+     * Bugsnag dashboard.
+     *
+     * @param array[] $metaData an array of arrays of custom data
+     * @param bool    $merge    should we merge the meta data
+     *
+     * @return $this
+     */
+    public function setMetaData(array $metaData, $merge = true)
+    {
+        $this->config->setMetaData($metaData, $merge);
+
+        return $this;
+    }
+
+    /**
+     * Get the custom metadata to send to Bugsnag.
+     *
+     * @return array[]
+     */
+    public function getMetaData()
+    {
+        return $this->config->getMetaData();
+    }
+
+    /**
+     * Set Bugsnag's error reporting level.
+     *
+     * If this is not set, we'll use your current PHP error_reporting value
+     * from your ini file or error_reporting(...) calls.
+     *
+     * @param int|null $errorReportingLevel the error reporting level integer
+     *
+     * @return $this
+     */
+    public function setErrorReportingLevel($errorReportingLevel)
+    {
+        $this->config->setErrorReportingLevel($errorReportingLevel);
+
+        return $this;
+    }
+
+    /**
+     * Should we ignore the given error code?
+     *
+     * @param int $code the error code
+     *
+     * @return bool
+     */
+    public function shouldIgnoreErrorCode($code)
+    {
+        return $this->config->shouldIgnoreErrorCode($code);
+    }
+
+    /**
+     * Set session tracking state and pass in optional guzzle.
+     *
+     * @param bool $track whether to track sessions
+     *
+     * @return $this
+     */
+    public function setAutoCaptureSessions($track)
+    {
+        $this->config->setAutoCaptureSessions($track);
+
+        return $this;
+    }
+
+    /**
+     * Set session delivery endpoint.
+     *
+     * @param string $endpoint the session endpoint
+     *
+     * @return $this
+     */
+    public function setSessionEndpoint($endpoint)
+    {
+        $this->config->setSessionEndpoint($endpoint);
+
+        return $this;
+    }
+
+    /**
+     * Get the session client.
+     *
+     * @return \Guzzle\ClientInterface
+     */
+    public function getSessionClient()
+    {
+        return $this->config->getSessionClient();
+    }
+
+    /**
+     * Whether should be auto-capturing sessions.
+     *
+     * @return bool
+     */
+    public function shouldCaptureSessions()
+    {
+        return $this->config->shouldCaptureSessions();
+    }
+
+    /**
+     * Sets the build endpoint.
+     *
+     * @param string $endpoint the build endpoint
+     *
+     * @return $this
+     */
+    public function setBuildEndpoint($endpoint)
+    {
+        $this->config->setBuildEndpoint($endpoint);
+
+        return $this;
+    }
+
+    /**
+     * Returns the build endpoint.
+     *
+     * @return string
+     */
+    public function getBuildEndpoint()
+    {
+        return $this->config->getBuildEndpoint();
     }
 }

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -131,17 +131,6 @@ class ClientTest extends TestCase
         }
     }
 
-    public function testDynamicConfigSetting()
-    {
-        $client = Client::make('foo');
-
-        $this->assertTrue($client->isBatchSending());
-
-        $this->assertSame($client, $client->setBatchSending(false));
-
-        $this->assertFalse($client->isBatchSending());
-    }
-
     public function testBeforeNotifySkipsError()
     {
         $this->client = new Client($this->config = new Configuration('example-api-key'), null, $this->guzzle);
@@ -479,16 +468,6 @@ class ClientTest extends TestCase
         $this->assertArrayNotHasKey('Environment', $report->getMetaData());
     }
 
-    /**
-     * @expectedException \BadMethodCallException
-     */
-    public function testBadMethodCall()
-    {
-        $this->client = new Client($this->config = new Configuration('example-api-key'), null, $this->guzzle);
-
-        $this->client->foo();
-    }
-
     public function testBatchingDoesNotFlush()
     {
         $this->client = $this->getMockBuilder(Client::class)
@@ -759,5 +738,156 @@ class ClientTest extends TestCase
         });
 
         $this->assertSame('REDACTED', $report->getMetaData()['request']['url']);
+    }
+
+    public function testBatchSending()
+    {
+        $client = Client::make('foo');
+
+        $this->assertTrue($client->isBatchSending());
+
+        $this->assertSame($client, $client->setBatchSending(false));
+
+        $this->assertFalse($client->isBatchSending());
+    }
+
+    public function testGetApiKey()
+    {
+        $client = Client::make('foo');
+        $this->assertSame('foo', $client->getApiKey());
+    }
+
+    public function testNotifyReleaseStages()
+    {
+        $client = Client::make('foo');
+        $this->assertSame($client, $client->setNotifyReleaseStages(null));
+        $this->assertSame($client, $client->setReleaseStage('beta'));
+        $this->assertTrue($client->shouldNotify());
+        $this->assertSame($client, $client->setNotifyReleaseStages(['prod']));
+        $this->assertFalse($client->shouldNotify());
+        $this->assertSame($client, $client->setNotifyReleaseStages(['prod', 'beta']));
+        $this->assertTrue($client->shouldNotify());
+    }
+
+    public function testFilters()
+    {
+        $client = Client::make('foo');
+        $this->assertSame($client, $client->setFilters(['pass']));
+        $this->assertSame(['pass'], $client->getFilters());
+    }
+
+    public function testSetProjectRoot()
+    {
+        $client = Client::make('foo');
+        $client->setProjectRoot('/foo/bar');
+        $this->assertTrue($client->isInProject('/foo/bar/z'));
+        $this->assertFalse($client->isInProject('/foo/baz'));
+        $this->assertFalse($client->isInProject('/foo'));
+    }
+
+    public function testSetStripPath()
+    {
+        $client = Client::make('foo');
+        $client->setStripPath('/foo/bar/');
+        $this->assertSame('src/thing.php', $client->getStrippedFilePath('/foo/bar/src/thing.php'));
+        $this->assertSame('/foo/src/thing.php', $client->getStrippedFilePath('/foo/src/thing.php'));
+        $this->assertSame('x/src/thing.php', $client->getStrippedFilePath('x/src/thing.php'));
+    }
+
+    public function testSetStripPathRegex()
+    {
+        $client = Client::make('foo');
+        $client->setStripPathRegex('/^\\/(foo|bar)\\//');
+        $this->assertSame('src/thing.php', $client->getStrippedFilePath('/foo/src/thing.php'));
+        $this->assertSame('src/thing.php', $client->getStrippedFilePath('/bar/src/thing.php'));
+        $this->assertSame('/baz/src/thing.php', $client->getStrippedFilePath('/baz/src/thing.php'));
+        $this->assertSame('x/foo/thing.php', $client->getStrippedFilePath('x/foo/thing.php'));
+    }
+
+    public function testSendCode()
+    {
+        $client = Client::make('foo');
+        $this->assertTrue($client->shouldSendCode());
+        $this->assertSame($client, $client->setSendCode(true));
+        $this->assertTrue($client->shouldSendCode());
+        $this->assertSame($client, $client->setSendCode(false));
+        $this->assertFalse($client->shouldSendCode());
+    }
+
+    public function testBuildEndpoint()
+    {
+        $client = Client::make('foo');
+        $this->assertSame($client, $client->setBuildEndpoint('https://example'));
+        $this->assertSame('https://example', $client->getBuildEndpoint());
+    }
+
+    public function testSessionClient()
+    {
+        $client = Client::make('foo');
+        $this->assertSame($client, $client->setSessionEndpoint('https://example'));
+        $sessionClient = $client->getSessionClient();
+        $this->assertSame(Guzzle::class, get_class($sessionClient));
+
+        if (substr(ClientInterface::VERSION, 0, 1) == '5') {
+            $clientUri = $sessionClient->getBaseUrl();
+        } else {
+            $baseUri = $sessionClient->getConfig('base_uri');
+            $clientUri = $baseUri->getScheme().'://'.$baseUri->getHost();
+        }
+
+        $this->assertSame('https://example', $clientUri);
+    }
+
+    public function testSetAutoCaptureSessions()
+    {
+        $client = Client::make('foo');
+        $this->assertSame($client, $client->setAutoCaptureSessions(false));
+        $this->assertFalse($client->shouldCaptureSessions());
+        $this->assertSame($client, $client->setAutoCaptureSessions(true));
+        $this->assertTrue($client->shouldCaptureSessions());
+    }
+
+    public function testErrorReportingLevel()
+    {
+        $client = Client::make('foo');
+        $this->assertSame($client, $client->setErrorReportingLevel(E_ALL));
+        $this->assertFalse($client->shouldIgnoreErrorCode(E_NOTICE));
+        $this->assertSame($client, $client->setErrorReportingLevel(E_ALL && ~E_NOTICE));
+        $this->assertTrue($client->shouldIgnoreErrorCode(E_NOTICE));
+    }
+
+    public function testMetaData()
+    {
+        $client = Client::make('foo');
+        $this->assertSame($client, $client->setMetaData(['foo' => ['bar' => 'baz']]));
+        $this->assertSame(['foo' => ['bar' => 'baz']], $client->getMetaData());
+        $this->assertSame($client, $client->setMetaData(['foo' => ['bear' => 4]]));
+        $this->assertSame(['foo' => ['bar' => 'baz', 'bear' => 4]], $client->getMetaData());
+        $this->assertSame($client, $client->setMetaData(['baz' => ['bar' => 9]], false));
+        $this->assertSame(['baz' => ['bar' => 9]], $client->getMetaData());
+    }
+
+    public function testDeviceData()
+    {
+        $client = Client::make('foo');
+        $this->assertSame($client, $client->setHostname('web1.example.com'));
+        $this->assertSame('web1.example.com', $client->getDeviceData()['hostname']);
+    }
+
+    public function testAppData()
+    {
+        $client = Client::make('foo');
+        $this->assertSame($client, $client->setAppVersion('34.2.1-beta2'));
+        $data = $client->getAppData();
+        $this->assertSame('34.2.1-beta2', $client->getAppData()['version']);
+        $client->setFallbackType('foo-app');
+        $this->assertSame('foo-app', $client->getAppData()['type']);
+    }
+
+    public function testNotifier()
+    {
+        $client = Client::make('foo');
+        $this->assertSame($client, $client->setNotifier(['foo' => 'bar']));
+        $this->assertSame(['foo' => 'bar'], $client->getNotifier());
     }
 }


### PR DESCRIPTION
## Goal

Improve performance and shrink callstacks by removing the reflection calls from `Client` to `Configuration`. Also beef up test coverage for config options!

Related to #476 

## Changeset

Removed the `__call` method from `Client`, replacing it with the instance methods from `Configuration`.

## Tests

Added new unit tests for the return values and behaviors of `Client` to ensure that:

* The setters which return the instance still return the right thing
* The getters return the same object as before

The tests pass before and after the change.