### PR TITLE
Restrict input file reads to PUT requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 Changelog
 =========
 
+## 3.15.2 (TBA)
+
+### Bug Fixes
+
+* Prevent automatic collection of POST form data
+  [#]()
+
 ## 3.15.1 (2018-12-19)
 
 ### Bug Fixes

--- a/src/Request/BasicResolver.php
+++ b/src/Request/BasicResolver.php
@@ -125,7 +125,9 @@ class BasicResolver implements ResolverInterface
 
         if (isset($server['CONTENT_TYPE']) && stripos($server['CONTENT_TYPE'], 'application/json') === 0) {
             return (array) json_decode($input, true) ?: null;
-        } else {
+        }
+
+        if (strtoupper($server['REQUEST_METHOD']) === 'PUT') {
             parse_str($input, $params);
 
             return (array) $params ?: null;

--- a/tests/RequestTest.php
+++ b/tests/RequestTest.php
@@ -150,6 +150,22 @@ class RequestTest extends TestCase
         $this->assertSame(['request' => $data], $this->resolver->resolve()->getMetaData());
     }
 
+    public function testGetMetaDataWithPostFormInput()
+    {
+        $_SERVER['REQUEST_METHOD'] = 'POST';
+
+        $data = [
+            'url' => 'http://example.com/blah/blah.php?some=param',
+            'httpMethod' => 'POST',
+            'params' => null,
+            'clientIp' => '123.45.67.8',
+            'userAgent' => 'Example Browser 1.2.3',
+            'headers' => ['Host' => 'example.com', 'User-Agent' => 'Example Browser 1.2.3'],
+        ];
+
+        $this->assertSame(['request' => $data], $this->resolver->resolve()->getMetaData());
+    }
+
     public function testGetMetaDataWithGetInput()
     {
         $_SERVER['REQUEST_METHOD'] = 'GET';

--- a/tests/RequestTest.php
+++ b/tests/RequestTest.php
@@ -138,6 +138,8 @@ class RequestTest extends TestCase
 
     public function testGetMetaDataWithPutInput()
     {
+        $_SERVER['REQUEST_METHOD'] = 'PUT';
+
         $data = [
             'url' => 'http://example.com/blah/blah.php?some=param',
             'httpMethod' => 'PUT',


### PR DESCRIPTION
## Goal

Reverts the change added in [this commit](https://github.com/bugsnag/bugsnag-php/pull/472/files#diff-9d96f78d5d8866b276c422dbe1bcfac3R95) that enables the `input://` file to be read in non-PUT requests.

## Tests
Added a test ensuring that the input file isn't read in a `POST` non-JSON scenario.