### PR TITLE
Add setProjectRootRegex method

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -506,6 +506,18 @@ class Client
     }
 
     /**
+     * Set the project root regex.
+     *
+     * @param string|null $projectRootRegex the project root path
+     *
+     * @return void
+     */
+    public function setProjectRootRegex($projectRootRegex)
+    {
+        $this->config->setProjectRootRegex($projectRootRegex);
+    }
+
+    /**
      * Is the given file in the project?
      *
      * @param string $file

--- a/src/Configuration.php
+++ b/src/Configuration.php
@@ -282,6 +282,7 @@ class Configuration
         }
 
         $this->projectRootRegex = $projectRootRegex;
+        $this->setStripPathRegex($projectRootRegex);
     }
 
     /**

--- a/src/Configuration.php
+++ b/src/Configuration.php
@@ -261,7 +261,8 @@ class Configuration
      */
     public function setProjectRoot($projectRoot)
     {
-        $this->setProjectRootRegex('/^'.preg_quote($projectRoot, '/').'[\\/]?/i');
+        $projectRootRegex = $projectRoot ? '/^'.preg_quote($projectRoot, '/').'[\\/]?/i' : null;
+        $this->setProjectRootRegex($projectRootRegex);
     }
 
     /**
@@ -273,7 +274,7 @@ class Configuration
      */
     public function setProjectRootRegex($projectRootRegex)
     {
-        if (@preg_match($projectRootRegex, null) === false) {
+        if ($projectRootRegex && @preg_match($projectRootRegex, null) === false) {
             throw new InvalidArgumentException('Invalid project root regex: '.$projectRootRegex);
         }
 
@@ -302,7 +303,8 @@ class Configuration
      */
     public function setStripPath($stripPath)
     {
-        $this->setStripPathRegex('/^'.preg_quote($stripPath, '/').'[\\/]?/i');
+        $stripPathRegex = $stripPath ? '/^'.preg_quote($stripPath, '/').'[\\/]?/i' : null;
+        $this->setStripPathRegex($stripPathRegex);
     }
 
     /**
@@ -314,7 +316,7 @@ class Configuration
      */
     public function setStripPathRegex($stripPathRegex)
     {
-        if (@preg_match($stripPathRegex, null) === false) {
+        if ($stripPathRegex && @preg_match($stripPathRegex, null) === false) {
             throw new InvalidArgumentException('Invalid strip path regex: '.$stripPathRegex);
         }
 

--- a/src/Configuration.php
+++ b/src/Configuration.php
@@ -269,6 +269,22 @@ class Configuration
     }
 
     /**
+     * Set the project root regex.
+     *
+     * @param string|null $projectRootRegex the project root path
+     *
+     * @return void
+     */
+    public function setProjectRootRegex($projectRootRegex)
+    {
+        if (@preg_match($projectRootRegex, null) === false) {
+            throw new InvalidArgumentException('Invalid project root regex: '.$projectRootRegex);
+        }
+
+        $this->projectRootRegex = $projectRootRegex;
+    }
+
+    /**
      * Is the given file in the project?
      *
      * @param string $file

--- a/src/Configuration.php
+++ b/src/Configuration.php
@@ -261,11 +261,7 @@ class Configuration
      */
     public function setProjectRoot($projectRoot)
     {
-        $this->projectRootRegex = $projectRoot ? '/^'.preg_quote($projectRoot, '/').'[\\/]?/i' : null;
-
-        if ($projectRoot && !$this->stripPathRegex) {
-            $this->setStripPath($projectRoot);
-        }
+        $this->setProjectRootRegex('/^'.preg_quote($projectRoot, '/').'[\\/]?/i');
     }
 
     /**
@@ -306,7 +302,7 @@ class Configuration
      */
     public function setStripPath($stripPath)
     {
-        $this->stripPathRegex = $stripPath ? '/^'.preg_quote($stripPath, '/').'[\\/]?/i' : null;
+        $this->setStripPathRegex('/^'.preg_quote($stripPath, '/').'[\\/]?/i');
     }
 
     /**

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -785,6 +785,15 @@ class ClientTest extends TestCase
         $this->assertFalse($client->isInProject('/foo'));
     }
 
+    public function testSetProjectRootRegex()
+    {
+        $client = Client::make('foo');
+        $client->setProjectRootRegex('/^\/foo\/bar/i');
+        $this->assertTrue($client->isInProject('/foo/bar/z'));
+        $this->assertFalse($client->isInProject('/foo/baz'));
+        $this->assertFalse($client->isInProject('/foo'));
+    }
+
     public function testSetStripPath()
     {
         $client = Client::make('foo');

--- a/tests/ConfigurationTest.php
+++ b/tests/ConfigurationTest.php
@@ -74,6 +74,15 @@ class ConfigurationTest extends TestCase
         $this->assertFalse($this->config->isInProject('/base/root/dir/afile.php'));
     }
 
+    public function testRootPathSetsStripPath()
+    {
+        $this->config->setProjectRoot('/foo/bar');
+
+        $this->assertSame('src/thing.php', $this->config->getStrippedFilePath('/foo/bar/src/thing.php'));
+        $this->assertSame('/foo/src/thing.php', $this->config->getStrippedFilePath('/foo/src/thing.php'));
+        $this->assertSame('x/src/thing.php', $this->config->getStrippedFilePath('x/src/thing.php'));
+    }
+
     public function testRootPathRegex()
     {
         $this->assertFalse($this->config->isInProject('/root/dir/app/afile.php'));
@@ -93,6 +102,35 @@ class ConfigurationTest extends TestCase
         $this->assertFalse($this->config->isInProject('/root'));
         $this->assertFalse($this->config->isInProject('/root/dir/other-directory/afile.php'));
         $this->assertFalse($this->config->isInProject('/base/root/dir/afile.php'));
+    }
+
+    public function testRootPathRegexSetsStripPathRegex()
+    {
+        $this->config->setProjectRootRegex('/^\\/(foo|bar)\\//');
+
+        $this->assertSame('src/thing.php', $this->config->getStrippedFilePath('/foo/src/thing.php'));
+        $this->assertSame('src/thing.php', $this->config->getStrippedFilePath('/bar/src/thing.php'));
+        $this->assertSame('/baz/src/thing.php', $this->config->getStrippedFilePath('/baz/src/thing.php'));
+        $this->assertSame('x/foo/thing.php', $this->config->getStrippedFilePath('x/foo/thing.php'));
+    }
+
+    public function testStripPath()
+    {
+        $this->config->setStripPath('/foo/bar');
+
+        $this->assertSame('src/thing.php', $this->config->getStrippedFilePath('/foo/bar/src/thing.php'));
+        $this->assertSame('/foo/src/thing.php', $this->config->getStrippedFilePath('/foo/src/thing.php'));
+        $this->assertSame('x/src/thing.php', $this->config->getStrippedFilePath('x/src/thing.php'));
+    }
+
+    public function testStripPathRegex()
+    {
+        $this->config->setStripPathRegex('/^\\/(foo|bar)\\//');
+
+        $this->assertSame('src/thing.php', $this->config->getStrippedFilePath('/foo/src/thing.php'));
+        $this->assertSame('src/thing.php', $this->config->getStrippedFilePath('/bar/src/thing.php'));
+        $this->assertSame('/baz/src/thing.php', $this->config->getStrippedFilePath('/baz/src/thing.php'));
+        $this->assertSame('x/foo/thing.php', $this->config->getStrippedFilePath('x/foo/thing.php'));
     }
 
     /**

--- a/tests/ConfigurationTest.php
+++ b/tests/ConfigurationTest.php
@@ -74,6 +74,27 @@ class ConfigurationTest extends TestCase
         $this->assertFalse($this->config->isInProject('/base/root/dir/afile.php'));
     }
 
+    public function testRootPathRegex()
+    {
+        $this->assertFalse($this->config->isInProject('/root/dir/app/afile.php'));
+
+        $this->config->setProjectRootRegex("/^(".preg_quote("/root/dir/app", '/')."|".preg_quote("/root/dir/lib", '/').")[\\/]?/i");
+
+        $this->assertTrue($this->config->isInProject('/root/dir/app/afile.php'));
+        $this->assertTrue($this->config->isInProject('/root/dir/lib/afile.php'));
+        $this->assertFalse($this->config->isInProject('/root'));
+        $this->assertFalse($this->config->isInProject('/root/dir/other-directory/afile.php'));
+        $this->assertFalse($this->config->isInProject('/base/root/dir/app/afile.php'));
+
+        $this->config->setProjectRootRegex("/^(".preg_quote("/root/dir/app/", '/')."|".preg_quote("/root/dir/lib/", '/').")[\\/]?/i");
+
+        $this->assertTrue($this->config->isInProject('/root/dir/app/afile.php'));
+        $this->assertTrue($this->config->isInProject('/root/dir/lib/afile.php'));
+        $this->assertFalse($this->config->isInProject('/root'));
+        $this->assertFalse($this->config->isInProject('/root/dir/other-directory/afile.php'));
+        $this->assertFalse($this->config->isInProject('/base/root/dir/afile.php'));
+    }
+
     public function testAppData()
     {
         $this->assertSame(['type' => 'cli', 'releaseStage' => 'production'], $this->config->getAppData());

--- a/tests/ConfigurationTest.php
+++ b/tests/ConfigurationTest.php
@@ -74,6 +74,16 @@ class ConfigurationTest extends TestCase
         $this->assertFalse($this->config->isInProject('/base/root/dir/afile.php'));
     }
 
+    public function testRootPathNull()
+    {
+        $this->config->setProjectRoot('/root/dir');
+        $this->config->setProjectRoot(null);
+
+        $this->assertFalse($this->config->isInProject('/root/dir/afile.php'));
+        $this->assertFalse($this->config->isInProject('/root'));
+        $this->assertFalse($this->config->isInProject('/base/root/dir/afile.php'));
+    }
+
     public function testRootPathSetsStripPath()
     {
         $this->config->setProjectRoot('/foo/bar');
@@ -104,6 +114,18 @@ class ConfigurationTest extends TestCase
         $this->assertFalse($this->config->isInProject('/base/root/dir/afile.php'));
     }
 
+    public function testRootPathRegexNull()
+    {
+        $this->config->setProjectRootRegex('/^('.preg_quote('/root/dir/app', '/').'|'.preg_quote('/root/dir/lib', '/').')[\\/]?/i');
+        $this->config->setProjectRootRegex(null);
+
+        $this->assertFalse($this->config->isInProject('/root/dir/app/afile.php'));
+        $this->assertFalse($this->config->isInProject('/root/dir/lib/afile.php'));
+        $this->assertFalse($this->config->isInProject('/root'));
+        $this->assertFalse($this->config->isInProject('/root/dir/other-directory/afile.php'));
+        $this->assertFalse($this->config->isInProject('/base/root/dir/app/afile.php'));
+    }
+
     public function testRootPathRegexSetsStripPathRegex()
     {
         $this->config->setProjectRootRegex('/^\\/(foo|bar)\\//');
@@ -123,12 +145,33 @@ class ConfigurationTest extends TestCase
         $this->assertSame('x/src/thing.php', $this->config->getStrippedFilePath('x/src/thing.php'));
     }
 
+    public function testStripPathNull()
+    {
+        $this->config->setStripPath('/foo/bar');
+        $this->config->setStripPath(null);
+
+        $this->assertSame('/foo/bar/src/thing.php', $this->config->getStrippedFilePath('/foo/bar/src/thing.php'));
+        $this->assertSame('/foo/src/thing.php', $this->config->getStrippedFilePath('/foo/src/thing.php'));
+        $this->assertSame('x/src/thing.php', $this->config->getStrippedFilePath('x/src/thing.php'));
+    }
+
     public function testStripPathRegex()
     {
         $this->config->setStripPathRegex('/^\\/(foo|bar)\\//');
 
         $this->assertSame('src/thing.php', $this->config->getStrippedFilePath('/foo/src/thing.php'));
         $this->assertSame('src/thing.php', $this->config->getStrippedFilePath('/bar/src/thing.php'));
+        $this->assertSame('/baz/src/thing.php', $this->config->getStrippedFilePath('/baz/src/thing.php'));
+        $this->assertSame('x/foo/thing.php', $this->config->getStrippedFilePath('x/foo/thing.php'));
+    }
+
+    public function testStripPathRegexNull()
+    {
+        $this->config->setStripPathRegex('/^\\/(foo|bar)\\//');
+        $this->config->setStripPathRegex(null);
+
+        $this->assertSame('/foo/src/thing.php', $this->config->getStrippedFilePath('/foo/src/thing.php'));
+        $this->assertSame('/bar/src/thing.php', $this->config->getStrippedFilePath('/bar/src/thing.php'));
         $this->assertSame('/baz/src/thing.php', $this->config->getStrippedFilePath('/baz/src/thing.php'));
         $this->assertSame('x/foo/thing.php', $this->config->getStrippedFilePath('x/foo/thing.php'));
     }

--- a/tests/ConfigurationTest.php
+++ b/tests/ConfigurationTest.php
@@ -95,6 +95,15 @@ class ConfigurationTest extends TestCase
         $this->assertFalse($this->config->isInProject('/base/root/dir/afile.php'));
     }
 
+    /**
+     * @expectedException \InvalidArgumentException
+     * @expectedExpcetionMessage Invalid project root regex: [thisisnotavalidregex
+     */
+    public function testInvalidRootPathRegexThrows()
+    {
+        $this->config->setProjectRootRegex('[thisisnotavalidregex');
+    }
+
     public function testAppData()
     {
         $this->assertSame(['type' => 'cli', 'releaseStage' => 'production'], $this->config->getAppData());

--- a/tests/ConfigurationTest.php
+++ b/tests/ConfigurationTest.php
@@ -78,7 +78,7 @@ class ConfigurationTest extends TestCase
     {
         $this->assertFalse($this->config->isInProject('/root/dir/app/afile.php'));
 
-        $this->config->setProjectRootRegex("/^(".preg_quote("/root/dir/app", '/')."|".preg_quote("/root/dir/lib", '/').")[\\/]?/i");
+        $this->config->setProjectRootRegex('/^('.preg_quote('/root/dir/app', '/').'|'.preg_quote('/root/dir/lib', '/').')[\\/]?/i');
 
         $this->assertTrue($this->config->isInProject('/root/dir/app/afile.php'));
         $this->assertTrue($this->config->isInProject('/root/dir/lib/afile.php'));
@@ -86,7 +86,7 @@ class ConfigurationTest extends TestCase
         $this->assertFalse($this->config->isInProject('/root/dir/other-directory/afile.php'));
         $this->assertFalse($this->config->isInProject('/base/root/dir/app/afile.php'));
 
-        $this->config->setProjectRootRegex("/^(".preg_quote("/root/dir/app/", '/')."|".preg_quote("/root/dir/lib/", '/').")[\\/]?/i");
+        $this->config->setProjectRootRegex('/^('.preg_quote('/root/dir/app/', '/').'|'.preg_quote('/root/dir/lib/', '/').')[\\/]?/i');
 
         $this->assertTrue($this->config->isInProject('/root/dir/app/afile.php'));
         $this->assertTrue($this->config->isInProject('/root/dir/lib/afile.php'));


### PR DESCRIPTION
## Goal
Adds `setProjectRootRegex` to the `Configuration` class, allowing the `projectRoot` regex to be set directly.

Based on #501 by @jpcid, this adds additional tests and a dedicated method in the Client class to allow calling the added `setProjectRootRegex` method in the Configuration.