### PR TITLE
Auto on session tracking

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -785,27 +785,73 @@ class Client
     }
 
     /**
-     * Set session delivery endpoint.
+     * Sets the notify and session endpoints
      *
-     * @param string $endpoint the session endpoint
+     * @param string $notifyEndpoint the notify endpoint
+     * @param string $sessionEndpoint the session endpoint
      *
      * @return $this
      */
-    public function setSessionEndpoint($endpoint)
+    public function setEndpoints($notifyEndpoint, $sessionEndpoint)
     {
-        $this->config->setSessionEndpoint($endpoint);
+        $this->config->setEndpoints($notifyEndpoint, $sessionEndpoint);
 
         return $this;
     }
 
     /**
-     * Get the session client.
+     * Gets the notify endpoint
      *
-     * @return \Guzzle\ClientInterface
+     * @return string
      */
-    public function getSessionClient()
+    public function getNotifyEndpoint()
     {
-        return $this->config->getSessionClient();
+        return $this->config->getNotifyEndpoint();
+    }
+
+    /**
+     * Gets the session endpoint
+     *
+     * @return string
+     */
+    public function getSessionEndpoint()
+    {
+        return $this->config->getSessionEndpoint();
+    }
+
+    /**
+     * Gets the current guzzle client.
+     *
+     * @return GuzzleHttp\ClientInterface
+     */
+    public function getGuzzleClient()
+    {
+        return $this->config->getGuzzleClient();
+    }
+
+    /**
+     * Sets the guzzle client
+     *
+     * Delivery URLs should be set using the "setEndpoints" method
+     *
+     * @param GuzzleHttp\ClientInterface $guzzleClient the new guzzle client
+     *
+     * @return $this
+     */
+    public function setGuzzleClient($guzzleClient)
+    {
+        $this->config->setGuzzleClient($guzzleClient);
+        return $this;
+    }
+
+    /**
+     * Whether any sessions are enabled.
+     *
+     * @return bool
+     */
+    public function sessionsEnabled()
+    {
+        return $this->config->sessionsEnabled();
     }
 
     /**
@@ -813,9 +859,9 @@ class Client
      *
      * @return bool
      */
-    public function shouldCaptureSessions()
+    public function shouldAutoCaptureSessions()
     {
-        return $this->config->shouldCaptureSessions();
+        return $this->config->shouldAutoCaptureSessions();
     }
 
     /**

--- a/src/Configuration.php
+++ b/src/Configuration.php
@@ -3,6 +3,7 @@
 namespace Bugsnag;
 
 use InvalidArgumentException;
+use Bugsnag\Utils;
 
 class Configuration
 {
@@ -688,7 +689,7 @@ class Configuration
     public function getGuzzleClient()
     {
         if (!$this->guzzleClient) {
-            $this->guzzleClient = Client::makeGuzzle();
+            $this->guzzleClient = Utils::makeGuzzle();
         }
         return $this->guzzleClient;
     }

--- a/src/SessionTracker.php
+++ b/src/SessionTracker.php
@@ -285,7 +285,7 @@ class SessionTracker
         if (count($sessions) == 0) {
             return;
         }
-        $http = $this->config->getSessionClient();
+        $guzzle = $this->config->getGuzzleClient();
         $payload = $this->constructPayload($sessions);
         $headers = [
             'Bugsnag-Api-Key' => $this->config->getApiKey(),
@@ -295,7 +295,7 @@ class SessionTracker
         $this->setLastSent();
 
         try {
-            $http->post('', [
+            $guzzle->post($this->config->getSessionEndpoint(), [
                 'json' => $payload,
                 'headers' => $headers,
             ]);

--- a/src/Utils.php
+++ b/src/Utils.php
@@ -2,6 +2,9 @@
 
 namespace Bugsnag;
 
+use Composer\CaBundle\CaBundle;
+use GuzzleHttp\Client as Guzzle;
+
 class Utils
 {
     /**
@@ -39,5 +42,35 @@ class Utils
         }
 
         return $builderName;
+    }
+
+    /**
+     * Make a new guzzle client instance.
+     *
+     * @param array       $options
+     *
+     * @return \GuzzleHttp\ClientInterface
+     */
+    public static function makeGuzzle(array $options = [])
+    {
+        if ($path = static::getCaBundlePath()) {
+            $options['verify'] = $path;
+        }
+
+        return new Guzzle($options);
+    }
+
+    /**
+     * Get the ca bundle path if one exists.
+     *
+     * @return string|false
+     */
+    protected static function getCaBundlePath()
+    {
+        if (!class_exists(CaBundle::class)) {
+            return false;
+        }
+
+        return realpath(CaBundle::getSystemCaRootBundlePath());
     }
 }

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -30,7 +30,7 @@ class ClientTest extends TestCase
 
         $this->client = $this->getMockBuilder(Client::class)
                              ->setMethods(['notify'])
-                             ->setConstructorArgs([$this->config = new Configuration('example-api-key'), null, $this->guzzle])
+                             ->setConstructorArgs([$this->config = new Configuration('example-api-key'), null])
                              ->getMock();
     }
 
@@ -43,13 +43,13 @@ class ClientTest extends TestCase
 
     public function testManualErrorNotificationWithSeverity()
     {
-        $client = new Client($this->config, null, $this->guzzle);
+        $client = new Client($this->config, null);
         $prop = (new ReflectionClass($client))->getProperty('http');
         $prop->setAccessible(true);
 
         $http = $this->getMockBuilder(HttpClient::class)
                      ->setMethods(['queue'])
-                     ->setConstructorArgs([$this->config, $this->guzzle])
+                     ->setConstructorArgs([$this->config])
                      ->getMock();
         $prop->setValue($client, $http);
 
@@ -102,7 +102,8 @@ class ClientTest extends TestCase
 
     public function testBeforeNotifySkipsError()
     {
-        $this->client = new Client($this->config = new Configuration('example-api-key'), null, $this->guzzle);
+        $this->client = new Client($this->config = new Configuration('example-api-key'), null);
+        $this->config->setGuzzleClient($this->guzzle);
 
         $this->client->setBatchSending(false);
 
@@ -119,8 +120,8 @@ class ClientTest extends TestCase
 
     public function testBeforeNotifyCanModifyReportFrames()
     {
-        $this->client = new Client($this->config = new Configuration('example-api-key'), null, $this->guzzle);
-
+        $this->client = new Client($this->config = new Configuration('example-api-key'), null);
+        $this->config->setGuzzleClient($this->guzzle);
         $this->client->setBatchSending(false);
 
         $this->client->notify($report = Report::fromNamedError($this->config, 'Magic', 'oh no'));
@@ -141,7 +142,8 @@ class ClientTest extends TestCase
 
     public function testDirectCallbackSkipsError()
     {
-        $this->client = new Client($this->config = new Configuration('example-api-key'), null, $this->guzzle);
+        $this->client = new Client($this->config = new Configuration('example-api-key'), null);
+        $this->config->setGuzzleClient($this->guzzle);
 
         $this->client->setBatchSending(false);
 
@@ -156,7 +158,8 @@ class ClientTest extends TestCase
 
     public function testMetaDataWorks()
     {
-        $this->client = new Client($this->config = new Configuration('example-api-key'), null, $this->guzzle);
+        $this->client = new Client($this->config = new Configuration('example-api-key'), null);
+        $this->config->setGuzzleClient($this->guzzle);
 
         $this->client->notify($report = Report::fromNamedError($this->config, 'Name'), function ($report) {
             $report->setMetaData(['foo' => 'baz']);
@@ -167,7 +170,8 @@ class ClientTest extends TestCase
 
     public function testCustomMiddlewareWorks()
     {
-        $this->client = new Client($this->config = new Configuration('example-api-key'), null, $this->guzzle);
+        $this->client = new Client($this->config = new Configuration('example-api-key'), null);
+        $this->config->setGuzzleClient($this->guzzle);
 
         $this->client->registerMiddleware(function ($report, callable $next) {
             $report->setMetaData(['middleware' => 'registered']);
@@ -181,7 +185,8 @@ class ClientTest extends TestCase
 
     public function testMiddlewareCanModifySeverity()
     {
-        $this->client = new Client($this->config = new Configuration('example-api-key'), null, $this->guzzle);
+        $this->client = new Client($this->config = new Configuration('example-api-key'), null);
+        $this->config->setGuzzleClient($this->guzzle);
 
         $this->client->registerMiddleware(function ($report, callable $next) {
             $report->setSeverity('info');
@@ -198,7 +203,8 @@ class ClientTest extends TestCase
 
     public function testMiddlewareCanModifyUnhandled()
     {
-        $this->client = new Client($this->config = new Configuration('example-api-key'), null, $this->guzzle);
+        $this->client = new Client($this->config = new Configuration('example-api-key'), null);
+        $this->config->setGuzzleClient($this->guzzle);
 
         $this->client->registerMiddleware(function ($report, callable $next) {
             $report->setUnhandled(true);
@@ -215,7 +221,8 @@ class ClientTest extends TestCase
 
     public function testMiddlewareCanModifySeverityReason()
     {
-        $this->client = new Client($this->config = new Configuration('example-api-key'), null, $this->guzzle);
+        $this->client = new Client($this->config = new Configuration('example-api-key'), null);
+        $this->config->setGuzzleClient($this->guzzle);
 
         $this->client->registerMiddleware(function ($report, callable $next) {
             $report->setSeverityReason([
@@ -236,7 +243,8 @@ class ClientTest extends TestCase
 
     public function testNotOverriddenByCallbacks()
     {
-        $this->client = new Client($this->config = new Configuration('example-api-key'), null, $this->guzzle);
+        $this->client = new Client($this->config = new Configuration('example-api-key'), null);
+        $this->config->setGuzzleClient($this->guzzle);
 
         $this->client->registerMiddleware(function ($report, callable $next) {
             $report->setUnhandled(true);
@@ -284,7 +292,8 @@ class ClientTest extends TestCase
 
     public function testBreadcrumbsFallback()
     {
-        $this->client = new Client($this->config = new Configuration('example-api-key'), null, $this->guzzle);
+        $this->client = new Client($this->config = new Configuration('example-api-key'), null);
+        $this->config->setGuzzleClient($this->guzzle);
 
         $this->client->leaveBreadcrumb('Foo Bar Baz', 'bla');
 
@@ -303,7 +312,8 @@ class ClientTest extends TestCase
 
     public function testBreadcrumbsNoName()
     {
-        $this->client = new Client($this->config = new Configuration('example-api-key'), null, $this->guzzle);
+        $this->client = new Client($this->config = new Configuration('example-api-key'), null);
+        $this->config->setGuzzleClient($this->guzzle);
 
         // notify with an empty report name
         $this->client->notify(Report::fromNamedError($this->config, ''));
@@ -324,7 +334,8 @@ class ClientTest extends TestCase
 
     public function testBreadcrumbsGetShortNameClass()
     {
-        $this->client = new Client($this->config = new Configuration('example-api-key'), null, $this->guzzle);
+        $this->config->setGuzzleClient($this->guzzle);
+        $this->client = new Client($this->config = new Configuration('example-api-key'), null);
 
         $this->client->leaveBreadcrumb(Client::class, 'state');
 
@@ -343,7 +354,8 @@ class ClientTest extends TestCase
 
     public function testBreadcrumbsLong()
     {
-        $this->client = new Client($this->config = new Configuration('example-api-key'), null, $this->guzzle);
+        $this->client = new Client($this->config = new Configuration('example-api-key'), null);
+        $this->config->setGuzzleClient($this->guzzle);
 
         $this->client->leaveBreadcrumb('This error name is far too long to be allowed through.', 'user', ['foo' => 'bar']);
 
@@ -362,7 +374,8 @@ class ClientTest extends TestCase
 
     public function testBreadcrumbsLarge()
     {
-        $this->client = new Client($this->config = new Configuration('example-api-key'), null, $this->guzzle);
+        $this->client = new Client($this->config = new Configuration('example-api-key'), null);
+        $this->config->setGuzzleClient($this->guzzle);
 
         $this->client->leaveBreadcrumb('Test', 'user', ['foo' => str_repeat('A', 5000)]);
 
@@ -381,8 +394,9 @@ class ClientTest extends TestCase
 
     public function testBreadcrumbsAgain()
     {
-        $this->client = new Client($this->config = new Configuration('example-api-key'), null, $this->guzzle);
+        $this->client = new Client($this->config = new Configuration('example-api-key'), null);
 
+        $this->config->setGuzzleClient($this->guzzle);
         $this->client->leaveBreadcrumb('Test', 'user', ['foo' => 'bar']);
 
         $this->client->notify($report = Report::fromNamedError($this->config, 'Name'));
@@ -428,7 +442,8 @@ class ClientTest extends TestCase
     {
         $_ENV['SOMETHING'] = 'blah';
 
-        $this->client = new Client($this->config = new Configuration('example-api-key'), null, $this->guzzle);
+        $this->client = new Client($this->config = new Configuration('example-api-key'), null);
+        $this->config->setGuzzleClient($this->guzzle);
 
         $this->client->registerDefaultCallbacks();
 
@@ -441,8 +456,10 @@ class ClientTest extends TestCase
     {
         $this->client = $this->getMockBuilder(Client::class)
                              ->setMethods(['flush'])
-                             ->setConstructorArgs([$this->config, null, $this->guzzle])
+                             ->setConstructorArgs([$this->config, null])
                              ->getMock();
+
+        $this->config->setGuzzleClient($this->guzzle);
 
         $this->client->expects($this->never())->method('flush');
 
@@ -453,8 +470,10 @@ class ClientTest extends TestCase
     {
         $this->client = $this->getMockBuilder(Client::class)
                              ->setMethods(['flush'])
-                             ->setConstructorArgs([$this->config, null, $this->guzzle])
+                             ->setConstructorArgs([$this->config, null])
                              ->getMock();
+
+        $this->config->setGuzzleClient($this->guzzle);
 
         $this->client->expects($this->once())->method('flush');
 

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -830,30 +830,13 @@ class ClientTest extends TestCase
         $this->assertSame('https://example', $client->getBuildEndpoint());
     }
 
-    public function testSessionClient()
-    {
-        $client = Client::make('foo');
-        $this->assertSame($client, $client->setSessionEndpoint('https://example'));
-        $sessionClient = $client->getSessionClient();
-        $this->assertSame(Guzzle::class, get_class($sessionClient));
-
-        if (substr(ClientInterface::VERSION, 0, 1) == '5') {
-            $clientUri = $sessionClient->getBaseUrl();
-        } else {
-            $baseUri = $sessionClient->getConfig('base_uri');
-            $clientUri = $baseUri->getScheme().'://'.$baseUri->getHost();
-        }
-
-        $this->assertSame('https://example', $clientUri);
-    }
-
     public function testSetAutoCaptureSessions()
     {
         $client = Client::make('foo');
         $this->assertSame($client, $client->setAutoCaptureSessions(false));
-        $this->assertFalse($client->shouldCaptureSessions());
+        $this->assertFalse($client->shouldAutoCaptureSessions());
         $this->assertSame($client, $client->setAutoCaptureSessions(true));
-        $this->assertTrue($client->shouldCaptureSessions());
+        $this->assertTrue($client->shouldAutoCaptureSessions());
     }
 
     public function testErrorReportingLevel()
@@ -898,5 +881,40 @@ class ClientTest extends TestCase
         $client = Client::make('foo');
         $this->assertSame($client, $client->setNotifier(['foo' => 'bar']));
         $this->assertSame(['foo' => 'bar'], $client->getNotifier());
+    }
+
+    public function testSetEndpoints()
+    {
+        $client = Client::make('foo');
+        $this->assertSame(\Bugsnag\Configuration::DEFAULT_NOTIFY_ENDPOINT, $client->getNotifyEndpoint());
+        $this->assertSame(\Bugsnag\Configuration::DEFAULT_SESSION_ENDPOINT, $client->getSessionEndpoint());
+
+        $notify = "notify";
+        $session = "session";
+        $this->assertSame($client, $client->setEndpoints($notify, $session));
+
+        $this->assertSame($notify, $client->getNotifyEndpoint());
+        $this->assertSame($session, $client->getSessionEndpoint());
+    }
+
+    public function testSessionsEnabled()
+    {
+        $client = Client::make('foo');
+        $this->assertTrue($client->sessionsEnabled());
+
+        $client->setEndpoints("notify", null);
+
+        $this->assertFalse($client->sessionsEnabled());
+        $this->assertFalse($client->shouldAutoCaptureSessions());
+    }
+
+    public function testSetGuzzleClient()
+    {
+        $client = Client::make('foo');
+        $this->assertInstanceOf(Guzzle::class, $client->getGuzzleClient());
+
+        $guzzle = new Guzzle();
+        $this->assertSame($client, $client->setGuzzleClient($guzzle));
+        $this->assertSame($guzzle, $client->getGuzzleClient());
     }
 }

--- a/tests/ConfigurationTest.php
+++ b/tests/ConfigurationTest.php
@@ -301,7 +301,7 @@ class ConfigurationTest extends TestCase
     public function testGetGuzzleClientCreation()
     {
         $guzzle = $this->config->getGuzzleClient();
-        $this->assertInstanceOf("GuzzleHttp\Client", $guzzle);
+        $this->assertInstanceOf(GuzzleClient::class, $guzzle);
     }
 
 }

--- a/tests/HttpClientTest.php
+++ b/tests/HttpClientTest.php
@@ -56,6 +56,25 @@ class HttpClientTest extends TestCase
         $this->assertSame('4.0', $headers['Bugsnag-Payload-Version']);
     }
 
+    public function testHttpClientUsesConfigSettings()
+    {
+        $config = $this->getMockBuilder(Configuration::class)
+                       ->disableOriginalConstructor()
+                       ->setMethods(['getNotifyEndpoint', 'getGuzzleClient'])
+                       ->getMock();
+
+        // Expect Client to get the guzzleClient and endpoint from Config
+        $config->expects($this->once())->method('getGuzzleClient')->willReturn($this->guzzle);
+        $config->expects($this->once())->method('getNotifyEndpoint')->willReturn('foo');
+
+        // Expect post to be called
+        $this->guzzle->expects($this->any())->method('post');
+
+        $http = new HttpClient($config);
+        $http->queue(Report::fromNamedError($this->config, 'Name'));
+        $http->send();
+    }
+
     public function testHttpClientMultipleSend()
     {
         // Expect request to be called

--- a/tests/HttpClientTest.php
+++ b/tests/HttpClientTest.php
@@ -20,13 +20,13 @@ class HttpClientTest extends TestCase
 
     protected function setUp()
     {
-        $this->config = new Configuration('6015a72ff14038114c3d12623dfb018f');
-
         $this->guzzle = $this->getMockBuilder(Client::class)
                              ->setMethods(['post'])
                              ->getMock();
+        $this->config = new Configuration('6015a72ff14038114c3d12623dfb018f');
+        $this->config->setGuzzleClient($this->guzzle);
 
-        $this->http = new HttpClient($this->config, $this->guzzle);
+        $this->http = new HttpClient($this->config);
     }
 
     public function testHttpClient()
@@ -41,7 +41,7 @@ class HttpClientTest extends TestCase
         $this->assertCount(1, $invocations = $spy->getInvocations());
         $params = $invocations[0]->parameters;
         $this->assertCount(2, $params);
-        $this->assertSame('', $params[0]);
+        $this->assertSame(\Bugsnag\Configuration::DEFAULT_NOTIFY_ENDPOINT, $params[0]);
         $this->assertInternalType('array', $params[1]);
         $this->assertInternalType('array', $params[1]['json']['notifier']);
         $this->assertInternalType('array', $params[1]['json']['events']);
@@ -85,7 +85,7 @@ class HttpClientTest extends TestCase
         $this->assertCount(1, $invocations = $spy->getInvocations());
         $params = $invocations[0]->parameters;
         $this->assertCount(2, $params);
-        $this->assertSame('', $params[0]);
+        $this->assertSame(\Bugsnag\Configuration::DEFAULT_NOTIFY_ENDPOINT, $params[0]);
         $this->assertInternalType('array', $params[1]);
         $this->assertInternalType('array', $params[1]['json']['notifier']);
         $this->assertInternalType('array', $params[1]['json']['events']);
@@ -133,7 +133,7 @@ class HttpClientTest extends TestCase
         $this->assertCount(1, $invocations = $spy->getInvocations());
         $params = $invocations[0]->parameters;
         $this->assertCount(2, $params);
-        $this->assertSame('', $params[0]);
+        $this->assertSame(\Bugsnag\Configuration::DEFAULT_NOTIFY_ENDPOINT, $params[0]);
         $this->assertInternalType('array', $params[1]);
         $this->assertInternalType('array', $params[1]['json']['notifier']);
         $this->assertInternalType('array', $params[1]['json']['events']);


### PR DESCRIPTION
## Goal

- Allow endpoints to be set through the `Client`/`Configuration` after initialization
- Ensure only one GuzzleClient is created during each run
- Ensure GuzzleClient is only created if necessary
- Make AutoCaptureSessions `true` by default

TODO: Add SessionTracker tests