### PR TITLE
Fix/session guzzle client

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -115,7 +115,7 @@ class Client
         $this->recorder = new Recorder();
         $this->pipeline = new Pipeline();
         $this->http = new HttpClient($config, $guzzle ?: static::makeGuzzle());
-        $this->sessionTracker = new SessionTracker($config);
+        $this->sessionTracker = new SessionTracker($config, $this->http);
 
         $this->registerMiddleware(new NotificationSkipper($config));
         $this->registerMiddleware(new BreadcrumbData($this->recorder));
@@ -800,7 +800,9 @@ class Client
 
     /**
      * Get the session client.
-     *
+     * 
+     * @deprecated All deliveries are made through the HttpClient
+     * 
      * @return \Guzzle\ClientInterface
      */
     public function getSessionClient()
@@ -840,5 +842,15 @@ class Client
     public function getBuildEndpoint()
     {
         return $this->config->getBuildEndpoint();
+    }
+
+    /**
+     * Get session delivery endpoint.
+     *
+     * @return string
+     */
+    public function getSessionEndpoint()
+    {
+        return $this->config->getSessionEndpoint();
     }
 }

--- a/src/Configuration.php
+++ b/src/Configuration.php
@@ -125,6 +125,8 @@ class Configuration
     /**
      * A client to use to send sessions.
      *
+     * @deprecated No longer used
+     *
      * @var \Guzzle\ClientInterface
      */
     protected $sessionClient;
@@ -595,7 +597,19 @@ class Configuration
     }
 
     /**
+     * Get session delivery endpoint.
+     *
+     * @return string
+     */
+    public function getSessionEndpoint()
+    {
+        return $this->sessionEndpoint;
+    }
+
+    /**
      * Get the session client.
+     *
+     * @deprecated All deliveries are made through the HttpClient
      *
      * @return \Guzzle\ClientInterface
      */

--- a/src/Configuration.php
+++ b/src/Configuration.php
@@ -139,6 +139,13 @@ class Configuration
     protected $sessionEndpoint = self::SESSION_ENDPOINT;
 
     /**
+     * The endpoint to deliver event notifications to.
+     *
+     * @var string
+     */
+    protected $notifyEndpoint = Client::ENDPOINT;
+
+    /**
      * The endpoint to deliver build notifications to.
      *
      * @var string
@@ -658,5 +665,29 @@ class Configuration
         }
 
         return self::BUILD_ENDPOINT;
+    }
+
+    /**
+     * Sets the notification endpoint.
+     *
+     * @param string $endpoint the notification endpoint
+     *
+     * @return $this
+     */
+    public function setNotifyEndpoint($endpoint)
+    {
+        $this->notifyEndpoint = $endpoint;
+
+        return $this;
+    }
+
+    /**
+     * Gets the notification endpoint.
+     *
+     * @return string
+     */
+    public function getNotifyEndpoint()
+    {
+        return $this->notifyEndpoint;
     }
 }

--- a/src/HttpClient.php
+++ b/src/HttpClient.php
@@ -235,11 +235,15 @@ class HttpClient
             return;
         }
 
-        $this->deliverPayload($url, $normalized, $this->getHeaders());
+        try {
+            $this->deliverPayload($url, $normalized, $this->getHeaders());
+        } catch (Exception $e) {
+            error_log('Bugsnag Warning: Couldn\'t notify. '.$e->getMessage());
+        }
     }
 
     /**
-     * Attempts to deliver a payload via guzzle and logs any failures
+     * Attempts to deliver a payload via guzzle and allow failure to propagate to caller
      *
      * @param string $url the url to deliver to
      * @param array $payload the payload array
@@ -247,15 +251,10 @@ class HttpClient
      */
     public function deliverPayload($url, $payload, $headers)
     {
-        // Send via guzzle and log any failures
-        try {
-            $this->guzzle->post($url, [
-                'json' => $payload,
-                'headers' => $headers,
-            ]);
-        } catch (Exception $e) {
-            error_log('Bugsnag Warning: Couldn\'t deliver payload. '.$e->getMessage());
-        }
+        $this->guzzle->post($url, [
+            'json' => $payload,
+            'headers' => $headers,
+        ]);
     }
 
     /**

--- a/src/HttpClient.php
+++ b/src/HttpClient.php
@@ -235,14 +235,26 @@ class HttpClient
             return;
         }
 
+        $this->deliverPayload($url, $normalized, $this->getHeaders());
+    }
+
+    /**
+     * Attempts to deliver a payload via guzzle and logs any failures
+     *
+     * @param string $url the url to deliver to
+     * @param array $payload the payload array
+     * @param array $headers the header array
+     */
+    public function deliverPayload($url, $payload, $headers)
+    {
         // Send via guzzle and log any failures
         try {
             $this->guzzle->post($url, [
-                'json' => $normalized,
-                'headers' => $this->getHeaders(),
+                'json' => $payload,
+                'headers' => $headers,
             ]);
         } catch (Exception $e) {
-            error_log('Bugsnag Warning: Couldn\'t notify. '.$e->getMessage());
+            error_log('Bugsnag Warning: Couldn\'t deliver payload. '.$e->getMessage());
         }
     }
 

--- a/src/HttpClient.php
+++ b/src/HttpClient.php
@@ -163,7 +163,7 @@ class HttpClient
             return;
         }
 
-        $this->postJson('', $this->build());
+        $this->postJson($this->config->getNotifyEndpoint(), $this->build());
 
         $this->queue = [];
     }

--- a/src/HttpClient.php
+++ b/src/HttpClient.php
@@ -149,7 +149,7 @@ class HttpClient
 
         $endpoint = $this->config->getBuildEndpoint();
 
-        $this->guzzle->post($endpoint, ['json' => $data]);
+        $this->deliverPayload($endpoint, $data, []);
     }
 
     /**

--- a/src/SessionTracker.php
+++ b/src/SessionTracker.php
@@ -95,7 +95,7 @@ class SessionTracker
     /**
      * The HttpClient, to be used for delivery.
      *
-     * @var \Bugsnag\HttpClient
+     * @var HttpClient
      */
     protected $httpClient;
 
@@ -106,7 +106,7 @@ class SessionTracker
      *
      * @return void
      */
-    public function __construct(Configuration $config, \Bugsnag\HttpClient $httpClient)
+    public function __construct(Configuration $config, HttpClient $httpClient)
     {
         $this->config = $config;
         $this->httpClient = $httpClient;
@@ -302,7 +302,11 @@ class SessionTracker
         $this->setLastSent();
 
         try {
-            $this->httpClient->deliverPayload($this->config->getSessionEndpoint(), $payload, $headers);
+            $this->httpClient->deliverPayload(
+                $this->config->getSessionEndpoint(),
+                $payload,
+                $headers
+            );
         } catch (Exception $e) {
             error_log('Bugsnag Warning: Couldn\'t notify. '.$e->getMessage());
             if (!is_null($this->retryFunction)) {

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -845,6 +845,7 @@ class ClientTest extends TestCase
         }
 
         $this->assertSame('https://example', $clientUri);
+        $this->assertSame('https://example', $client->getSessionEndpoint());
     }
 
     public function testSetAutoCaptureSessions()

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -108,11 +108,7 @@ class ClientTest extends TestCase
 
         $this->assertInstanceOf(Client::class, $client);
 
-        if (version_compare(ClientInterface::VERSION, '6') === 1) {
-            $this->assertEquals(new Uri('https://example.com'), $this->getGuzzle($client)->getConfig('base_uri'));
-        } else {
-            $this->assertSame('https://example.com', $this->getGuzzle($client)->getBaseUrl());
-        }
+        $this->assertEquals("https://example.com", $client->getNotifyEndpoint());
     }
 
     public function testCanMakeFromEnv()
@@ -124,11 +120,17 @@ class ClientTest extends TestCase
 
         $this->assertInstanceOf(Client::class, $client);
 
-        if (version_compare(ClientInterface::VERSION, '6') === 1) {
-            $this->assertEquals(new Uri('http://foo.com'), $this->getGuzzle($client)->getConfig('base_uri'));
-        } else {
-            $this->assertSame('http://foo.com', $this->getGuzzle($client)->getBaseUrl());
-        }
+        $this->assertEquals("http://foo.com", $client->getNotifyEndpoint());
+    }
+
+    public function testCanMakeWithGuzzle()
+    {
+        $key = version_compare(ClientInterface::VERSION, '6') === 1 ? 'base_uri' : 'base_url';
+        $guzzle = new Guzzle([$key => 'https://bar.com']);
+
+        $client = new Client(new Configuration('123'), null, $guzzle);
+
+        $this->assertEquals('https://bar.com', $client->getNotifyEndpoint());
     }
 
     public function testBeforeNotifySkipsError()
@@ -899,5 +901,16 @@ class ClientTest extends TestCase
         $client = Client::make('foo');
         $this->assertSame($client, $client->setNotifier(['foo' => 'bar']));
         $this->assertSame(['foo' => 'bar'], $client->getNotifier());
+    }
+
+    public function testSetNotifyEndpoint()
+    {
+        $client = Client::make('foo');
+
+        $this->assertEquals(Client::ENDPOINT, $client->getNotifyEndpoint());
+
+        $client->setNotifyEndpoint('http://test.com');
+
+        $this->assertEquals('http://test.com', $client->getNotifyEndpoint());
     }
 }

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -80,26 +80,10 @@ class ClientTest extends TestCase
         });
     }
 
-    protected function getGuzzle(Client $client)
-    {
-        $prop = (new ReflectionClass($client))->getProperty('http');
-        $prop->setAccessible(true);
-
-        $http = $prop->getValue($client);
-
-        $prop = (new ReflectionClass($http))->getProperty('guzzle');
-        $prop->setAccessible(true);
-
-        return $prop->getValue($http);
-    }
-
     public function testDefaultSetup()
     {
-        if (version_compare(ClientInterface::VERSION, '6') === 1) {
-            $this->assertEquals(new Uri('https://notify.bugsnag.com'), $this->getGuzzle(Client::make('123'))->getConfig('base_uri'));
-        } else {
-            $this->assertSame('https://notify.bugsnag.com', $this->getGuzzle(Client::make('123'))->getBaseUrl());
-        }
+        $client = Client::make('123');
+        $this->assertEquals(Client::ENDPOINT, $client->getNotifyEndpoint());
     }
 
     public function testCanMake()

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -511,7 +511,7 @@ class ClientTest extends TestCase
 
     public function testDeployWorksOutOfTheBox()
     {
-        $this->guzzle->expects($this->once())->method('post')->with($this->equalTo('https://build.bugsnag.com'), $this->equalTo(['json' => ['releaseStage' => 'production', 'apiKey' => 'example-api-key', 'buildTool' => 'bugsnag-php', 'builderName' => exec('whoami'), 'appVersion' => '1.3.1']]));
+        $this->guzzle->expects($this->once())->method('post')->with($this->equalTo('https://build.bugsnag.com'), $this->equalTo(['json' => ['releaseStage' => 'production', 'apiKey' => 'example-api-key', 'buildTool' => 'bugsnag-php', 'builderName' => exec('whoami'), 'appVersion' => '1.3.1'], 'headers' => []]));
 
         $this->client = new Client($this->config = new Configuration('example-api-key'), null, $this->guzzle);
         $this->config->setAppVersion('1.3.1');
@@ -521,7 +521,7 @@ class ClientTest extends TestCase
 
     public function testDeployWorksWithReleaseStage()
     {
-        $this->guzzle->expects($this->once())->method('post')->with($this->equalTo('https://build.bugsnag.com'), $this->equalTo(['json' => ['releaseStage' => 'staging', 'apiKey' => 'example-api-key', 'buildTool' => 'bugsnag-php', 'builderName' => exec('whoami'), 'appVersion' => '1.3.1']]));
+        $this->guzzle->expects($this->once())->method('post')->with($this->equalTo('https://build.bugsnag.com'), $this->equalTo(['json' => ['releaseStage' => 'staging', 'apiKey' => 'example-api-key', 'buildTool' => 'bugsnag-php', 'builderName' => exec('whoami'), 'appVersion' => '1.3.1'], 'headers' => []]));
 
         $this->client = new Client($this->config = new Configuration('example-api-key'), null, $this->guzzle);
         $this->config->setAppVersion('1.3.1');
@@ -533,7 +533,7 @@ class ClientTest extends TestCase
 
     public function testDeployWorksWithAppVersion()
     {
-        $this->guzzle->expects($this->once())->method('post')->with($this->equalTo('https://build.bugsnag.com'), $this->equalTo(['json' => ['releaseStage' => 'production', 'appVersion' => '1.1.0', 'apiKey' => 'example-api-key', 'buildTool' => 'bugsnag-php', 'builderName' => exec('whoami'), 'appVersion' => '1.3.1']]));
+        $this->guzzle->expects($this->once())->method('post')->with($this->equalTo('https://build.bugsnag.com'), $this->equalTo(['json' => ['releaseStage' => 'production', 'appVersion' => '1.1.0', 'apiKey' => 'example-api-key', 'buildTool' => 'bugsnag-php', 'builderName' => exec('whoami'), 'appVersion' => '1.3.1'], 'headers' => []]));
 
         $this->client = new Client($this->config = new Configuration('example-api-key'), null, $this->guzzle);
         $this->config->setAppVersion('1.3.1');
@@ -543,7 +543,7 @@ class ClientTest extends TestCase
 
     public function testDeployWorksWithRepository()
     {
-        $this->guzzle->expects($this->once())->method('post')->with($this->equalTo('https://build.bugsnag.com'), $this->equalTo(['json' => ['sourceControl' => ['repository' => 'foo'], 'releaseStage' => 'production', 'apiKey' => 'example-api-key', 'buildTool' => 'bugsnag-php', 'builderName' => exec('whoami'), 'appVersion' => '1.3.1']]));
+        $this->guzzle->expects($this->once())->method('post')->with($this->equalTo('https://build.bugsnag.com'), $this->equalTo(['json' => ['sourceControl' => ['repository' => 'foo'], 'releaseStage' => 'production', 'apiKey' => 'example-api-key', 'buildTool' => 'bugsnag-php', 'builderName' => exec('whoami'), 'appVersion' => '1.3.1'], 'headers' => []]));
 
         $this->client = new Client($this->config = new Configuration('example-api-key'), null, $this->guzzle);
         $this->config->setAppVersion('1.3.1');
@@ -553,7 +553,7 @@ class ClientTest extends TestCase
 
     public function testDeployWorksWithBranch()
     {
-        $this->guzzle->expects($this->once())->method('post')->with($this->equalTo('https://build.bugsnag.com'), $this->equalTo(['json' => ['releaseStage' => 'production', 'apiKey' => 'example-api-key', 'buildTool' => 'bugsnag-php', 'builderName' => exec('whoami'), 'appVersion' => '1.3.1']]));
+        $this->guzzle->expects($this->once())->method('post')->with($this->equalTo('https://build.bugsnag.com'), $this->equalTo(['json' => ['releaseStage' => 'production', 'apiKey' => 'example-api-key', 'buildTool' => 'bugsnag-php', 'builderName' => exec('whoami'), 'appVersion' => '1.3.1'], 'headers' => []]));
 
         $this->client = new Client($this->config = new Configuration('example-api-key'), null, $this->guzzle);
         $this->config->setAppVersion('1.3.1');
@@ -563,7 +563,7 @@ class ClientTest extends TestCase
 
     public function testDeployWorksWithRevision()
     {
-        $this->guzzle->expects($this->once())->method('post')->with($this->equalTo('https://build.bugsnag.com'), $this->equalTo(['json' => ['sourceControl' => ['revision' => 'bar'], 'releaseStage' => 'production', 'apiKey' => 'example-api-key', 'buildTool' => 'bugsnag-php', 'builderName' => exec('whoami'), 'appVersion' => '1.3.1']]));
+        $this->guzzle->expects($this->once())->method('post')->with($this->equalTo('https://build.bugsnag.com'), $this->equalTo(['json' => ['sourceControl' => ['revision' => 'bar'], 'releaseStage' => 'production', 'apiKey' => 'example-api-key', 'buildTool' => 'bugsnag-php', 'builderName' => exec('whoami'), 'appVersion' => '1.3.1'], 'headers' => []]));
 
         $this->client = new Client($this->config = new Configuration('example-api-key'), null, $this->guzzle);
         $this->config->setAppVersion('1.3.1');
@@ -573,7 +573,7 @@ class ClientTest extends TestCase
 
     public function testDeployWorksWithEverything()
     {
-        $this->guzzle->expects($this->once())->method('post')->with($this->equalTo('https://build.bugsnag.com'), $this->equalTo(['json' => ['sourceControl' => ['repository' => 'baz', 'revision' => 'foo'], 'releaseStage' => 'development', 'appVersion' => '1.3.1', 'apiKey' => 'example-api-key', 'buildTool' => 'bugsnag-php', 'builderName' => exec('whoami'), 'appVersion' => '1.3.1']]));
+        $this->guzzle->expects($this->once())->method('post')->with($this->equalTo('https://build.bugsnag.com'), $this->equalTo(['json' => ['sourceControl' => ['repository' => 'baz', 'revision' => 'foo'], 'releaseStage' => 'development', 'appVersion' => '1.3.1', 'apiKey' => 'example-api-key', 'buildTool' => 'bugsnag-php', 'builderName' => exec('whoami'), 'appVersion' => '1.3.1'], 'headers' => []]));
 
         $this->client = new Client($this->config = new Configuration('example-api-key'), null, $this->guzzle);
 
@@ -585,7 +585,7 @@ class ClientTest extends TestCase
 
     public function testBuildWorksOutOfTheBox()
     {
-        $this->guzzle->expects($this->once())->method('post')->with($this->equalTo('https://build.bugsnag.com'), $this->equalTo(['json' => ['releaseStage' => 'production', 'apiKey' => 'example-api-key', 'buildTool' => 'bugsnag-php', 'builderName' => exec('whoami'), 'appVersion' => '1.3.1']]));
+        $this->guzzle->expects($this->once())->method('post')->with($this->equalTo('https://build.bugsnag.com'), $this->equalTo(['json' => ['releaseStage' => 'production', 'apiKey' => 'example-api-key', 'buildTool' => 'bugsnag-php', 'builderName' => exec('whoami'), 'appVersion' => '1.3.1'], 'headers' => []]));
 
         $this->client = new Client($this->config = new Configuration('example-api-key'), null, $this->guzzle);
         $this->config->setAppVersion('1.3.1');
@@ -595,7 +595,7 @@ class ClientTest extends TestCase
 
     public function testBuildWorksWithReleaseStage()
     {
-        $this->guzzle->expects($this->once())->method('post')->with($this->equalTo('https://build.bugsnag.com'), $this->equalTo(['json' => ['releaseStage' => 'staging', 'apiKey' => 'example-api-key', 'buildTool' => 'bugsnag-php', 'builderName' => exec('whoami'), 'appVersion' => '1.3.1']]));
+        $this->guzzle->expects($this->once())->method('post')->with($this->equalTo('https://build.bugsnag.com'), $this->equalTo(['json' => ['releaseStage' => 'staging', 'apiKey' => 'example-api-key', 'buildTool' => 'bugsnag-php', 'builderName' => exec('whoami'), 'appVersion' => '1.3.1'], 'headers' => []]));
 
         $this->client = new Client($this->config = new Configuration('example-api-key'), null, $this->guzzle);
 
@@ -607,7 +607,7 @@ class ClientTest extends TestCase
 
     public function testBuildWorksWithRepository()
     {
-        $this->guzzle->expects($this->once())->method('post')->with($this->equalTo('https://build.bugsnag.com'), $this->equalTo(['json' => ['sourceControl' => ['repository' => 'foo'], 'releaseStage' => 'production', 'apiKey' => 'example-api-key', 'buildTool' => 'bugsnag-php', 'builderName' => exec('whoami'), 'appVersion' => '1.3.1']]));
+        $this->guzzle->expects($this->once())->method('post')->with($this->equalTo('https://build.bugsnag.com'), $this->equalTo(['json' => ['sourceControl' => ['repository' => 'foo'], 'releaseStage' => 'production', 'apiKey' => 'example-api-key', 'buildTool' => 'bugsnag-php', 'builderName' => exec('whoami'), 'appVersion' => '1.3.1'], 'headers' => []]));
 
         $this->client = new Client($this->config = new Configuration('example-api-key'), null, $this->guzzle);
         $this->config->setAppVersion('1.3.1');
@@ -617,7 +617,7 @@ class ClientTest extends TestCase
 
     public function testBuildWorksWithProvider()
     {
-        $this->guzzle->expects($this->once())->method('post')->with($this->equalTo('https://build.bugsnag.com'), $this->equalTo(['json' => ['sourceControl' => ['provider' => 'github'], 'releaseStage' => 'production', 'apiKey' => 'example-api-key', 'buildTool' => 'bugsnag-php', 'builderName' => exec('whoami'), 'appVersion' => '1.3.1']]));
+        $this->guzzle->expects($this->once())->method('post')->with($this->equalTo('https://build.bugsnag.com'), $this->equalTo(['json' => ['sourceControl' => ['provider' => 'github'], 'releaseStage' => 'production', 'apiKey' => 'example-api-key', 'buildTool' => 'bugsnag-php', 'builderName' => exec('whoami'), 'appVersion' => '1.3.1'], 'headers' => []]));
 
         $this->client = new Client($this->config = new Configuration('example-api-key'), null, $this->guzzle);
         $this->config->setAppVersion('1.3.1');
@@ -627,7 +627,7 @@ class ClientTest extends TestCase
 
     public function testBuildWorksWithRevision()
     {
-        $this->guzzle->expects($this->once())->method('post')->with($this->equalTo('https://build.bugsnag.com'), $this->equalTo(['json' => ['sourceControl' => ['revision' => 'bar'], 'releaseStage' => 'production', 'apiKey' => 'example-api-key', 'buildTool' => 'bugsnag-php', 'builderName' => exec('whoami'), 'appVersion' => '1.3.1']]));
+        $this->guzzle->expects($this->once())->method('post')->with($this->equalTo('https://build.bugsnag.com'), $this->equalTo(['json' => ['sourceControl' => ['revision' => 'bar'], 'releaseStage' => 'production', 'apiKey' => 'example-api-key', 'buildTool' => 'bugsnag-php', 'builderName' => exec('whoami'), 'appVersion' => '1.3.1'], 'headers' => []]));
 
         $this->client = new Client($this->config = new Configuration('example-api-key'), null, $this->guzzle);
         $this->config->setAppVersion('1.3.1');
@@ -637,7 +637,7 @@ class ClientTest extends TestCase
 
     public function testBuildWorksWithBuilderName()
     {
-        $this->guzzle->expects($this->once())->method('post')->with($this->equalTo('https://build.bugsnag.com'), $this->equalTo(['json' => ['builderName' => 'me', 'releaseStage' => 'production', 'apiKey' => 'example-api-key', 'buildTool' => 'bugsnag-php', 'appVersion' => '1.3.1']]));
+        $this->guzzle->expects($this->once())->method('post')->with($this->equalTo('https://build.bugsnag.com'), $this->equalTo(['json' => ['builderName' => 'me', 'releaseStage' => 'production', 'apiKey' => 'example-api-key', 'buildTool' => 'bugsnag-php', 'appVersion' => '1.3.1'], 'headers' => []]));
 
         $this->client = new Client($this->config = new Configuration('example-api-key'), null, $this->guzzle);
         $this->config->setAppVersion('1.3.1');
@@ -647,7 +647,7 @@ class ClientTest extends TestCase
 
     public function testBuildWorksWithBuildTool()
     {
-        $this->guzzle->expects($this->once())->method('post')->with($this->equalTo('https://build.bugsnag.com'), $this->equalTo(['json' => ['releaseStage' => 'production', 'apiKey' => 'example-api-key', 'buildTool' => 'bugsnag-php', 'builderName' => exec('whoami'), 'appVersion' => '1.3.1']]));
+        $this->guzzle->expects($this->once())->method('post')->with($this->equalTo('https://build.bugsnag.com'), $this->equalTo(['json' => ['releaseStage' => 'production', 'apiKey' => 'example-api-key', 'buildTool' => 'bugsnag-php', 'builderName' => exec('whoami'), 'appVersion' => '1.3.1'], 'headers' => []]));
 
         $this->client = new Client($this->config = new Configuration('example-api-key'), null, $this->guzzle);
         $this->config->setAppVersion('1.3.1');
@@ -657,7 +657,7 @@ class ClientTest extends TestCase
 
     public function testBuildWorksWithEverything()
     {
-        $this->guzzle->expects($this->once())->method('post')->with($this->equalTo('https://build.bugsnag.com'), $this->equalTo(['json' => ['builderName' => 'me', 'sourceControl' => ['repository' => 'baz', 'revision' => 'foo', 'provider' => 'github'], 'releaseStage' => 'development', 'appVersion' => '1.3.1', 'apiKey' => 'example-api-key', 'buildTool' => 'bugsnag-php']]));
+        $this->guzzle->expects($this->once())->method('post')->with($this->equalTo('https://build.bugsnag.com'), $this->equalTo(['json' => ['builderName' => 'me', 'sourceControl' => ['repository' => 'baz', 'revision' => 'foo', 'provider' => 'github'], 'releaseStage' => 'development', 'appVersion' => '1.3.1', 'apiKey' => 'example-api-key', 'buildTool' => 'bugsnag-php'], 'headers' => []]));
 
         $this->client = new Client($this->config = new Configuration('example-api-key'), null, $this->guzzle);
 

--- a/tests/ConfigurationTest.php
+++ b/tests/ConfigurationTest.php
@@ -276,5 +276,7 @@ class ConfigurationTest extends TestCase
         }
 
         $this->assertSame($testUrl, $clientUri);
+
+        $this->assertSame($testUrl, $this->config->getSessionEndpoint());
     }
 }

--- a/tests/ConfigurationTest.php
+++ b/tests/ConfigurationTest.php
@@ -279,4 +279,11 @@ class ConfigurationTest extends TestCase
 
         $this->assertSame($testUrl, $this->config->getSessionEndpoint());
     }
+
+    public function testSetNotifyEndpoint()
+    {
+        $this->config->setNotifyEndpoint('http://test.com');
+
+        $this->assertSame('http://test.com', $this->config->getNotifyEndpoint());
+    }
 }

--- a/tests/HttpClientTest.php
+++ b/tests/HttpClientTest.php
@@ -152,7 +152,7 @@ class HttpClientTest extends TestCase
     {
         // Setup error_log mocking
         $log = $this->getFunctionMock('Bugsnag', 'error_log');
-        $log->expects($this->once())->with($this->equalTo('Bugsnag Warning: Couldn\'t deliver payload. Guzzle exception thrown!'));
+        $log->expects($this->once())->with($this->equalTo('Bugsnag Warning: Couldn\'t notify. Guzzle exception thrown!'));
 
         // Expect request to be called
         $this->guzzle->method('post')->will($this->throwException(new Exception('Guzzle exception thrown!')));

--- a/tests/HttpClientTest.php
+++ b/tests/HttpClientTest.php
@@ -152,7 +152,7 @@ class HttpClientTest extends TestCase
     {
         // Setup error_log mocking
         $log = $this->getFunctionMock('Bugsnag', 'error_log');
-        $log->expects($this->once())->with($this->equalTo('Bugsnag Warning: Couldn\'t notify. Guzzle exception thrown!'));
+        $log->expects($this->once())->with($this->equalTo('Bugsnag Warning: Couldn\'t deliver payload. Guzzle exception thrown!'));
 
         // Expect request to be called
         $this->guzzle->method('post')->will($this->throwException(new Exception('Guzzle exception thrown!')));
@@ -160,5 +160,22 @@ class HttpClientTest extends TestCase
         // Add a report to the http and deliver it
         $this->http->queue(Report::fromNamedError($this->config, 'Name')->setMetaData(['foo' => 'bar']));
         $this->http->send();
+    }
+
+    public function testDeliverPayload()
+    {
+        $url = "testUrl";
+        $payload = [
+            "foo" => 1,
+            "bar" => 2
+        ];
+        $headers = [
+            "test-header" => "set"
+        ];
+        $this->guzzle->expects($this->once())->method('post')->with($url, [
+            'json' => $payload,
+            'headers' => $headers
+        ]);
+        $this->http->deliverPayload($url, $payload, $headers);
     }
 }


### PR DESCRIPTION
## Goal

Enables using the same GuzzleHttp\Client for all HTTP requests, meaning any custom options set will be applicable across event, session, & build notifications.

## Design

- Adds a public method `deliverPayload` to the HttpClient
- Changes SessionTracker to use `deliverPayload` for session delivery
- Adds `notifyEndpoint` to configuration with appropriate getter & setters
- Deprecate `getSessionClient` method on Configuration and Client
- Extracts `base_uri`/`base_url` from passed guzzle clients and assigns the value to `notifyEndpoint` to retain existing behaviour.


## Tests

- Updates existing tests to work with any API changes:
    - Removes reflection into `HttpClient` when testing default client setup
    - Guzzle client now expects blank headers when delivery build or deploy notifications
- Adds tests and lines in existing tests referencing new behaviour.
- Includes updates for tests established in #520 , requiring that to be merged first.