### PR TITLE
Allow for optional appVersion to be passed into build function

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -349,10 +349,11 @@ class Client
      * @param string|null $revision    the source control revision you are currently deploying
      * @param string|null $provider    the provider of the source control for the build
      * @param string|null $builderName the name of who or what is making the build
+     * @param string|null $appVersion  the version for this build
      *
      * @return void
      */
-    public function build($repository = null, $revision = null, $provider = null, $builderName = null)
+    public function build($repository = null, $revision = null, $provider = null, $builderName = null, $appVersion = null)
     {
         $data = [];
 
@@ -370,6 +371,11 @@ class Client
 
         if ($builderName) {
             $data['builder'] = $builderName;
+        }
+
+        //Allowing the appVersion to be passed to the build function in the event semVer is not used(Timestamp, hash, etc.)
+        if ($appVersion) {
+            $this->getConfig()->setAppVersion($appVersion);
         }
 
         $this->http->sendBuildReport($data);

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -645,6 +645,15 @@ class ClientTest extends TestCase
         $this->client->build(null, null, null, 'me');
     }
 
+    public function testBuildWorksWithAppVersionInBuild()
+    {
+        $this->guzzle->expects($this->once())->method('post')->with($this->equalTo('https://build.bugsnag.com'), $this->equalTo(['json' => ['releaseStage' => 'production', 'apiKey' => 'example-api-key', 'buildTool' => 'bugsnag-php', 'builderName' => exec('whoami'), 'appVersion' => '1.3.1']]));
+
+        $this->client = new Client($this->config = new Configuration('example-api-key'), null, $this->guzzle);
+
+        $this->client->build(null, null, null, null, '1.3.1');
+    }
+
     public function testBuildWorksWithBuildTool()
     {
         $this->guzzle->expects($this->once())->method('post')->with($this->equalTo('https://build.bugsnag.com'), $this->equalTo(['json' => ['releaseStage' => 'production', 'apiKey' => 'example-api-key', 'buildTool' => 'bugsnag-php', 'builderName' => exec('whoami'), 'appVersion' => '1.3.1']]));
@@ -652,7 +661,7 @@ class ClientTest extends TestCase
         $this->client = new Client($this->config = new Configuration('example-api-key'), null, $this->guzzle);
         $this->config->setAppVersion('1.3.1');
 
-        $this->client->build(null, null, null, null);
+        $this->client->build(null, null, null, null, null);
     }
 
     public function testBuildWorksWithEverything()
@@ -664,7 +673,7 @@ class ClientTest extends TestCase
         $this->config->setReleaseStage('development');
         $this->config->setAppVersion('1.3.1');
 
-        $this->client->build('baz', 'foo', 'github', 'me');
+        $this->client->build('baz', 'foo', 'github', 'me', '1.3.1');
     }
 
     public function testBuildFailsWithoutAPIKey()


### PR DESCRIPTION
## Goal

Allow for `appVersion` to be specified at build time in the event a project uses hash or timestamp based versioning. 

## Changeset

### Changed

Changed the `Client.php` function declaration for `build` to allow an `appVersion` to be passed in and set in the config.

## Tests

Updated: `testBuildWorksWithBuildTool`, `testBuildWorksWithEverything`
Added: `testBuildWorksWithAppVersionInBuild` which removes the call `$this->config->setAppVersion('1.3.1');` to allow the version to be set through the build.

## Discussion

This is a proposal change, I don't know if this functionality was not added intentionally as it will overwrite any value set via config/ENV or code calling `config->setAppVersion('X.X.X');`

If this is the case, please advise what changes might be best used. 

### Alternative Approaches

<!-- What other approaches were considered or discussed? -->

### Outstanding Questions

### Linked issues

[bugsnag/bugsnag-laravel PR : Add appVersion to DeployCommand](https://github.com/bugsnag/bugsnag-laravel/pull/351)
<!--

Fixes #
Related to #

-->

## Review

<!-- When submitting for review, consider the points for self-review and the
     criteria which will be used for secondary review -->

For the submitter, initial self-review:

- [X] Commented on code changes inline explain the reasoning behind the approach
- [X] Reviewed the test cases added for completeness and possible points for discussion
- [ ] A changelog entry was added for the goal of this pull request
- [X] Check the scope of the changeset - is everything in the diff required for the pull request?
- This pull request is ready for:
  - [X] Initial review of the intended approach, not yet feature complete
  - [X] Structural review of the classes, functions, and properties modified
  - [X] Final review

For the pull request reviewer(s), this changeset has been reviewed for:

- [ ] Consistency across platforms for structures or concepts added or modified
- [ ] Consistency between the changeset and the goal stated above
- [ ] Internal consistency with the rest of the library - is there any overlap between existing interfaces and any which have been added?
- [ ] Usage friction - is the proposed change in usage cumbersome or complicated?
- [ ] Performance and complexity - are there any cases of unexpected O(n^3) when iterating, recursing, flat mapping, etc?
- [ ] Concurrency concerns - if components are accessed asynchronously, what issues will arise
- [ ] Thoroughness of added tests and any missing edge cases
- [ ] Idiomatic use of the language
