### PR TITLE
Add PHP runtime version reporting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 Changelog
 =========
 
+## TBD
+
+### Enhancements
+
+* Add PHP version string to report and session payloads (device.runtimeVersions)
+  [#525](https://github.com/bugsnag/bugsnag-php/pull/525)
+
 ## 3.16.0 (2019-01-29)
 
 ### Enhancements

--- a/src/Client.php
+++ b/src/Client.php
@@ -704,18 +704,6 @@ class Client
     }
 
     /**
-    * Adds new data fields to the device data collection.
-    *
-    * @param array $data an associative array containing the new data to be added
-    *
-    * @return this
-    */
-    public function mergeDeviceData($data)
-    {
-        return $this->config->mergeDeviceData($data);
-    }
-
-    /**
      * Get the device data.
      *
      * @return array

--- a/src/Client.php
+++ b/src/Client.php
@@ -704,6 +704,18 @@ class Client
     }
 
     /**
+    * Adds new data fields to the device data collection.
+    *
+    * @param array $data an associative array containing the new data to be added
+    *
+    * @return this
+    */
+    public function mergeDeviceData($data)
+    {
+        return $this->config->mergeDeviceData($data);
+    }
+
+    /**
      * Get the device data.
      *
      * @return array

--- a/src/Client.php
+++ b/src/Client.php
@@ -506,6 +506,18 @@ class Client
     }
 
     /**
+     * Set the project root regex.
+     *
+     * @param string|null $projectRootRegex the project root path
+     *
+     * @return void
+     */
+    public function setProjectRootRegex($projectRootRegex)
+    {
+        $this->config->setProjectRootRegex($projectRootRegex);
+    }
+
+    /**
      * Is the given file in the project?
      *
      * @param string $file

--- a/src/Configuration.php
+++ b/src/Configuration.php
@@ -160,6 +160,8 @@ class Configuration
 
         $this->apiKey = $apiKey;
         $this->fallbackType = php_sapi_name();
+
+        // Add PHP runtime version to device data
         $this->mergeDeviceData(['runtimeVersions' => ['php' => phpversion()]]);
     }
 

--- a/src/Configuration.php
+++ b/src/Configuration.php
@@ -477,15 +477,15 @@ class Configuration
     }
 
     /**
-     * Merges new data fields to the device data collection.
+     * Adds new data fields to the device data collection.
      *
-     * @param array the data to add
+     * @param array $data an associative array containing the new data to be added
      *
      * @return this
      */
-    public function mergeDeviceData($deviceData)
+    public function mergeDeviceData($data)
     {
-        $this->deviceData = array_merge_recursive($this->deviceData, $deviceData);
+        $this->deviceData = array_merge_recursive($this->deviceData, $data);
 
         return $this;
     }

--- a/src/Configuration.php
+++ b/src/Configuration.php
@@ -160,6 +160,7 @@ class Configuration
 
         $this->apiKey = $apiKey;
         $this->fallbackType = php_sapi_name();
+        $this->mergeDeviceData(['runtimeVersions' => ['php' => phpversion()]]);
     }
 
     /**
@@ -469,6 +470,20 @@ class Configuration
     public function setHostname($hostname)
     {
         $this->deviceData['hostname'] = $hostname;
+
+        return $this;
+    }
+
+    /**
+     * Merges new data fields to the device data collection.
+     *
+     * @param array the data to add
+     *
+     * @return this
+     */
+    public function mergeDeviceData($deviceData)
+    {
+        $this->deviceData = array_merge_recursive($this->deviceData, $deviceData);
 
         return $this;
     }

--- a/src/Configuration.php
+++ b/src/Configuration.php
@@ -261,11 +261,25 @@ class Configuration
      */
     public function setProjectRoot($projectRoot)
     {
-        $this->projectRootRegex = $projectRoot ? '/^'.preg_quote($projectRoot, '/').'[\\/]?/i' : null;
+        $projectRootRegex = $projectRoot ? '/^'.preg_quote($projectRoot, '/').'[\\/]?/i' : null;
+        $this->setProjectRootRegex($projectRootRegex);
+    }
 
-        if ($projectRoot && !$this->stripPathRegex) {
-            $this->setStripPath($projectRoot);
+    /**
+     * Set the project root regex.
+     *
+     * @param string|null $projectRootRegex the project root path
+     *
+     * @return void
+     */
+    public function setProjectRootRegex($projectRootRegex)
+    {
+        if ($projectRootRegex && @preg_match($projectRootRegex, null) === false) {
+            throw new InvalidArgumentException('Invalid project root regex: '.$projectRootRegex);
         }
+
+        $this->projectRootRegex = $projectRootRegex;
+        $this->setStripPathRegex($projectRootRegex);
     }
 
     /**
@@ -289,7 +303,8 @@ class Configuration
      */
     public function setStripPath($stripPath)
     {
-        $this->stripPathRegex = $stripPath ? '/^'.preg_quote($stripPath, '/').'[\\/]?/i' : null;
+        $stripPathRegex = $stripPath ? '/^'.preg_quote($stripPath, '/').'[\\/]?/i' : null;
+        $this->setStripPathRegex($stripPathRegex);
     }
 
     /**
@@ -301,7 +316,7 @@ class Configuration
      */
     public function setStripPathRegex($stripPathRegex)
     {
-        if (@preg_match($stripPathRegex, null) === false) {
+        if ($stripPathRegex && @preg_match($stripPathRegex, null) === false) {
             throw new InvalidArgumentException('Invalid strip path regex: '.$stripPathRegex);
         }
 

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -880,8 +880,6 @@ class ClientTest extends TestCase
     {
         $client = Client::make('foo');
         $this->assertSame($client, $client->setHostname('web1.example.com'));
-        $this->assertSame('web1.example.com', $client->getDeviceData()['hostname']);
-        $this->assertSame(phpversion(), $client->getDeviceData()['runtimeVersions']['php']);
     }
 
     public function testAppData()

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -785,6 +785,15 @@ class ClientTest extends TestCase
         $this->assertFalse($client->isInProject('/foo'));
     }
 
+    public function testSetProjectRootRegex()
+    {
+        $client = Client::make('foo');
+        $client->setProjectRootRegex('/^\/foo\/bar/i');
+        $this->assertTrue($client->isInProject('/foo/bar/z'));
+        $this->assertFalse($client->isInProject('/foo/baz'));
+        $this->assertFalse($client->isInProject('/foo'));
+    }
+
     public function testSetStripPath()
     {
         $client = Client::make('foo');

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -881,6 +881,7 @@ class ClientTest extends TestCase
         $client = Client::make('foo');
         $this->assertSame($client, $client->setHostname('web1.example.com'));
         $this->assertSame('web1.example.com', $client->getDeviceData()['hostname']);
+        $this->assertSame(phpversion(), $client->getDeviceData()['runtimeVersions']['php']);
     }
 
     public function testAppData()

--- a/tests/ConfigurationTest.php
+++ b/tests/ConfigurationTest.php
@@ -74,6 +74,117 @@ class ConfigurationTest extends TestCase
         $this->assertFalse($this->config->isInProject('/base/root/dir/afile.php'));
     }
 
+    public function testRootPathNull()
+    {
+        $this->config->setProjectRoot('/root/dir');
+        $this->config->setProjectRoot(null);
+
+        $this->assertFalse($this->config->isInProject('/root/dir/afile.php'));
+        $this->assertFalse($this->config->isInProject('/root'));
+        $this->assertFalse($this->config->isInProject('/base/root/dir/afile.php'));
+    }
+
+    public function testRootPathSetsStripPath()
+    {
+        $this->config->setProjectRoot('/foo/bar');
+
+        $this->assertSame('src/thing.php', $this->config->getStrippedFilePath('/foo/bar/src/thing.php'));
+        $this->assertSame('/foo/src/thing.php', $this->config->getStrippedFilePath('/foo/src/thing.php'));
+        $this->assertSame('x/src/thing.php', $this->config->getStrippedFilePath('x/src/thing.php'));
+    }
+
+    public function testRootPathRegex()
+    {
+        $this->assertFalse($this->config->isInProject('/root/dir/app/afile.php'));
+
+        $this->config->setProjectRootRegex('/^('.preg_quote('/root/dir/app', '/').'|'.preg_quote('/root/dir/lib', '/').')[\\/]?/i');
+
+        $this->assertTrue($this->config->isInProject('/root/dir/app/afile.php'));
+        $this->assertTrue($this->config->isInProject('/root/dir/lib/afile.php'));
+        $this->assertFalse($this->config->isInProject('/root'));
+        $this->assertFalse($this->config->isInProject('/root/dir/other-directory/afile.php'));
+        $this->assertFalse($this->config->isInProject('/base/root/dir/app/afile.php'));
+
+        $this->config->setProjectRootRegex('/^('.preg_quote('/root/dir/app/', '/').'|'.preg_quote('/root/dir/lib/', '/').')[\\/]?/i');
+
+        $this->assertTrue($this->config->isInProject('/root/dir/app/afile.php'));
+        $this->assertTrue($this->config->isInProject('/root/dir/lib/afile.php'));
+        $this->assertFalse($this->config->isInProject('/root'));
+        $this->assertFalse($this->config->isInProject('/root/dir/other-directory/afile.php'));
+        $this->assertFalse($this->config->isInProject('/base/root/dir/afile.php'));
+    }
+
+    public function testRootPathRegexNull()
+    {
+        $this->config->setProjectRootRegex('/^('.preg_quote('/root/dir/app', '/').'|'.preg_quote('/root/dir/lib', '/').')[\\/]?/i');
+        $this->config->setProjectRootRegex(null);
+
+        $this->assertFalse($this->config->isInProject('/root/dir/app/afile.php'));
+        $this->assertFalse($this->config->isInProject('/root/dir/lib/afile.php'));
+        $this->assertFalse($this->config->isInProject('/root'));
+        $this->assertFalse($this->config->isInProject('/root/dir/other-directory/afile.php'));
+        $this->assertFalse($this->config->isInProject('/base/root/dir/app/afile.php'));
+    }
+
+    public function testRootPathRegexSetsStripPathRegex()
+    {
+        $this->config->setProjectRootRegex('/^\\/(foo|bar)\\//');
+
+        $this->assertSame('src/thing.php', $this->config->getStrippedFilePath('/foo/src/thing.php'));
+        $this->assertSame('src/thing.php', $this->config->getStrippedFilePath('/bar/src/thing.php'));
+        $this->assertSame('/baz/src/thing.php', $this->config->getStrippedFilePath('/baz/src/thing.php'));
+        $this->assertSame('x/foo/thing.php', $this->config->getStrippedFilePath('x/foo/thing.php'));
+    }
+
+    public function testStripPath()
+    {
+        $this->config->setStripPath('/foo/bar');
+
+        $this->assertSame('src/thing.php', $this->config->getStrippedFilePath('/foo/bar/src/thing.php'));
+        $this->assertSame('/foo/src/thing.php', $this->config->getStrippedFilePath('/foo/src/thing.php'));
+        $this->assertSame('x/src/thing.php', $this->config->getStrippedFilePath('x/src/thing.php'));
+    }
+
+    public function testStripPathNull()
+    {
+        $this->config->setStripPath('/foo/bar');
+        $this->config->setStripPath(null);
+
+        $this->assertSame('/foo/bar/src/thing.php', $this->config->getStrippedFilePath('/foo/bar/src/thing.php'));
+        $this->assertSame('/foo/src/thing.php', $this->config->getStrippedFilePath('/foo/src/thing.php'));
+        $this->assertSame('x/src/thing.php', $this->config->getStrippedFilePath('x/src/thing.php'));
+    }
+
+    public function testStripPathRegex()
+    {
+        $this->config->setStripPathRegex('/^\\/(foo|bar)\\//');
+
+        $this->assertSame('src/thing.php', $this->config->getStrippedFilePath('/foo/src/thing.php'));
+        $this->assertSame('src/thing.php', $this->config->getStrippedFilePath('/bar/src/thing.php'));
+        $this->assertSame('/baz/src/thing.php', $this->config->getStrippedFilePath('/baz/src/thing.php'));
+        $this->assertSame('x/foo/thing.php', $this->config->getStrippedFilePath('x/foo/thing.php'));
+    }
+
+    public function testStripPathRegexNull()
+    {
+        $this->config->setStripPathRegex('/^\\/(foo|bar)\\//');
+        $this->config->setStripPathRegex(null);
+
+        $this->assertSame('/foo/src/thing.php', $this->config->getStrippedFilePath('/foo/src/thing.php'));
+        $this->assertSame('/bar/src/thing.php', $this->config->getStrippedFilePath('/bar/src/thing.php'));
+        $this->assertSame('/baz/src/thing.php', $this->config->getStrippedFilePath('/baz/src/thing.php'));
+        $this->assertSame('x/foo/thing.php', $this->config->getStrippedFilePath('x/foo/thing.php'));
+    }
+
+    /**
+     * @expectedException \InvalidArgumentException
+     * @expectedExpcetionMessage Invalid project root regex: [thisisnotavalidregex
+     */
+    public function testInvalidRootPathRegexThrows()
+    {
+        $this->config->setProjectRootRegex('[thisisnotavalidregex');
+    }
+
     public function testAppData()
     {
         $this->assertSame(['type' => 'cli', 'releaseStage' => 'production'], $this->config->getAppData());

--- a/tests/ConfigurationTest.php
+++ b/tests/ConfigurationTest.php
@@ -218,11 +218,64 @@ class ConfigurationTest extends TestCase
 
     public function testDeviceData()
     {
-        $this->assertSame(['hostname' => php_uname('n')], $this->config->getDeviceData());
+        $this->assertEquals(2, count($this->config->getDeviceData()));
+        $this->assertSame(php_uname('n'), $this->config->getDeviceData()['hostname']);
+        $this->assertSame(phpversion(), $this->config->getDeviceData()['runtimeVersions']['php']);
 
         $this->config->setHostname('web1.example.com');
 
-        $this->assertSame(['hostname' => 'web1.example.com'], $this->config->getDeviceData());
+        $this->assertEquals(2, count($this->config->getDeviceData()));
+        $this->assertSame('web1.example.com', $this->config->getDeviceData()['hostname']);
+        $this->assertSame(phpversion(), $this->config->getDeviceData()['runtimeVersions']['php']);
+    }
+
+    public function testMergeDeviceDataEmptyArray()
+    {
+        $newData = [];
+
+        $this->config->mergeDeviceData($newData);
+
+        $this->assertEquals(2, count($this->config->getDeviceData()));
+        $this->assertSame(php_uname('n'), $this->config->getDeviceData()['hostname']);
+        $this->assertSame(phpversion(), $this->config->getDeviceData()['runtimeVersions']['php']);
+    }
+
+    public function testMergeDeviceDataSingleValue()
+    {
+        $newData = ['field1' => 'value'];
+
+        $this->config->mergeDeviceData($newData);
+
+        $this->assertEquals(3, count($this->config->getDeviceData()));
+        $this->assertSame(php_uname('n'), $this->config->getDeviceData()['hostname']);
+        $this->assertSame(phpversion(), $this->config->getDeviceData()['runtimeVersions']['php']);
+        $this->assertSame('value', $this->config->getDeviceData()['field1']);
+    }
+
+    public function testMergeDeviceDataMultiValues()
+    {
+        $newData = ['field1' => 'value', 'field2' => 2];
+
+        $this->config->mergeDeviceData($newData);
+
+        $this->assertEquals(4, count($this->config->getDeviceData()));
+        $this->assertSame(php_uname('n'), $this->config->getDeviceData()['hostname']);
+        $this->assertSame(phpversion(), $this->config->getDeviceData()['runtimeVersions']['php']);
+        $this->assertSame('value', $this->config->getDeviceData()['field1']);
+        $this->assertSame(2, $this->config->getDeviceData()['field2']);
+    }
+
+    public function testMergeDeviceDataComplexValues()
+    {
+        $newData = ['array_field' => [0, 1, 2], 'assoc_array_field' => ['f1' => 1]];
+
+        $this->config->mergeDeviceData($newData);
+
+        $this->assertEquals(4, count($this->config->getDeviceData()));
+        $this->assertSame(php_uname('n'), $this->config->getDeviceData()['hostname']);
+        $this->assertSame(phpversion(), $this->config->getDeviceData()['runtimeVersions']['php']);
+        $this->assertSame([0, 1, 2], $this->config->getDeviceData()['array_field']);
+        $this->assertSame(['f1' => 1], $this->config->getDeviceData()['assoc_array_field']);
     }
 
     public function testSessionTrackingDefaults()

--- a/tests/ReportTest.php
+++ b/tests/ReportTest.php
@@ -26,9 +26,10 @@ class ReportTest extends TestCase
     {
         $data = $this->report->toArray();
 
-        $this->assertCount(2, $data['device']);
+        $this->assertCount(3, $data['device']);
         $this->assertInternalType('string', $data['device']['time']);
         $this->assertSame(php_uname('n'), $data['device']['hostname']);
+        $this->assertSame(phpversion(), $data['device']['runtimeVersions']['php']);
     }
 
     public function testMetaData()


### PR DESCRIPTION
## Goal

Augments reporting with the version of PHP in use when an event occurred in case of issues in a specific version of PHP.

## Design

Added data to device.runtimeVersions.php as per other notifiers.

## Changeset

### Changed

* Configuration.php - added the data during initialisation;
* Configuration.php - added mergeDeviceData method for use by other PHP notifiers.

## Tests

* Added testMergeDeviceData* unit tests
* Amended assertion structure of testDeviceData
* End-to-end test run against live project ([event here](https://app.bugsnag.com/bugsnag-test-projects/php/errors/5ce408ae0b9f150019679df1?event_id=5ce40cbc003a00195b430000))

## Review

<!-- When submitting for review, consider the points for self-review and the
     criteria which will be used for secondary review -->

For the submitter, initial self-review:

- [x] Commented on code changes inline explain the reasoning behind the approach
- [x] Reviewed the test cases added for completeness and possible points for discussion
- [x] A changelog entry was added for the goal of this pull request
- [x] Check the scope of the changeset - is everything in the diff required for the pull request?
- This pull request is ready for:
  - [ ] Initial review of the intended approach, not yet feature complete
  - [ ] Structural review of the classes, functions, and properties modified
  - [x] Final review

For the pull request reviewer(s), this changeset has been reviewed for:

- [x] Consistency across platforms for structures or concepts added or modified
- [x] Consistency between the changeset and the goal stated above
- [x] Internal consistency with the rest of the library - is there any overlap between existing interfaces and any which have been added?
- [x] Usage friction - is the proposed change in usage cumbersome or complicated?
- [x] Performance and complexity - are there any cases of unexpected O(n^3) when iterating, recursing, flat mapping, etc?
- [x] Concurrency concerns - if components are accessed asynchronously, what issues will arise
- [x] Thoroughness of added tests and any missing edge cases
- [x] Idiomatic use of the language
