### PR TITLE
More robust environment variable fetching

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -9,9 +9,12 @@ This document is one of a series describing the layout of the individual Bugsnag
 
 ## Dependencies
 - [composer/ca-bundle](https://github.com/composer/ca-bundle)
-- [guzzlehttp/guzzler](https://github.com/guzzle/guzzle)
+- [guzzlehttp/guzzle](https://github.com/guzzle/guzzle)
+- [vlucas/phpdotenv](https://github.com/vlucas/phpdotenv)
 
 ## Dev Dependencies
+- [graham-campbell/testbench-core](https://github.com/GrahamCampbell/Laravel-TestBench-Core)
+- [mockery/mockery](https://github.com/mockery/mockery)
 - [mtdowling/burgomaster](https://github.com/mtdowling/Burgomaster)
 - [phpunit/phpunit](https://github.com/sebastianbergmann/phpunit)
 - [php-mock/php-mock-phpunit](https://github.com/php-mock/php-mock-phpunit)
@@ -152,4 +155,4 @@ Standard default callbacks are registered along with an additional callback to d
 The Silex framework requires manual registering of error and exception handlers, which requires the user add a `notifyException` call into an error handler registered to the app container's `error` function.
 
 ## [Bugsnag-Magento](https://github.com/bugsnag/bugsnag-magento)
-THe Bugsnag-Magento module enables Bugsnag functionality through the Magento admin panel.  It uses an older version of the Bugsnag-PHP library packaged with the module and so some of the methods and features will likely have been refactored by later versions.
+The Bugsnag-Magento module enables Bugsnag functionality through the Magento admin panel.  It uses an older version of the Bugsnag-PHP library packaged with the module and so some of the methods and features will likely have been refactored by later versions.

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,8 @@
     "require": {
         "php": ">=5.5",
         "composer/ca-bundle": "^1.0",
-        "guzzlehttp/guzzle": "^5.0|^6.0"
+        "guzzlehttp/guzzle": "^5.0|^6.0",
+        "vlucas/phpdotenv": "^3.0"
     },
     "require-dev": {
         "graham-campbell/testbench-core": "^1.1",

--- a/src/Client.php
+++ b/src/Client.php
@@ -18,6 +18,7 @@ use Bugsnag\Middleware\SessionData;
 use Bugsnag\Request\BasicResolver;
 use Bugsnag\Request\ResolverInterface;
 use Composer\CaBundle\CaBundle;
+use Dotenv\Environment\DotenvFactory;
 use GuzzleHttp\Client as Guzzle;
 use GuzzleHttp\ClientInterface;
 use ReflectionClass;
@@ -87,8 +88,10 @@ class Client
      */
     public static function make($apiKey = null, $endpoint = null, $defaults = true)
     {
-        $config = new Configuration($apiKey ?: getenv('BUGSNAG_API_KEY'));
-        $guzzle = static::makeGuzzle($endpoint ?: getenv('BUGSNAG_ENDPOINT'));
+        $env = (new DotenvFactory())->create();
+
+        $config = new Configuration($apiKey ?: $env->get('BUGSNAG_API_KEY'));
+        $guzzle = static::makeGuzzle($endpoint ?: $env->get('BUGSNAG_ENDPOINT'));
 
         $client = new static($config, null, $guzzle);
 


### PR DESCRIPTION
## Goal

The `getenv` and `putenv` functions in PHP are not threadsafe. For this reason, sometimes people choose not to call them when loading any environment variables in a scripted fashion, for example, from a ruby-style `.env` file, using some custom software.

Thus, we may need to check beyond `getenv` to find the environment variable the user has set. Fortunately, there is a mature package for doing this (and for loading `.env` files... it is actually exactly the package that ships with Laravel): vlucas/phpdotenv.

## Design

We replace the calls to `getenv` with checking all of the possible sources environment variables could be in: `$_SERVER[...]`, `$_ENV[...]`, `getenv(...)`, `apache_getenv(...)` (where available).

## Changeset

There area no API changes.

## Tests

An additional test has been added, demonstrating that loading the api key and server url into the env superglobal can now be detected by the client on instantiation.

## Review

For the pull request reviewer(s), this changeset has been reviewed for:

- [ ] Consistency across platforms for structures or concepts added or modified
- [ ] Consistency between the changeset and the goal stated above
- [ ] Internal consistency with the rest of the library - is there any overlap between existing interfaces and any which have been added?
- [ ] Usage friction - is the proposed change in usage cumbersome or complicated?
- [ ] Performance and complexity - are there any cases of unexpected O(n^3) when iterating, recursing, flat mapping, etc?
- [ ] Concurrency concerns - if components are accessed asynchronously, what issues will arise
- [ ] Thoroughness of added tests and any missing edge cases
- [ ] Idiomatic use of the language
