### PR TITLE
Compatibility with phpdotenv v2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
         "php": ">=5.5",
         "composer/ca-bundle": "^1.0",
         "guzzlehttp/guzzle": "^5.0|^6.0",
-        "vlucas/phpdotenv": "^3.0"
+        "vlucas/phpdotenv": "^2.0|^3.0"
     },
     "require-dev": {
         "graham-campbell/testbench-core": "^1.1",

--- a/src/Client.php
+++ b/src/Client.php
@@ -17,7 +17,6 @@ use Bugsnag\Middleware\SessionData;
 use Bugsnag\Request\BasicResolver;
 use Bugsnag\Request\ResolverInterface;
 use Composer\CaBundle\CaBundle;
-use Dotenv\Environment\DotenvFactory;
 use GuzzleHttp\Client as Guzzle;
 use GuzzleHttp\ClientInterface;
 use ReflectionClass;
@@ -87,10 +86,8 @@ class Client
      */
     public static function make($apiKey = null, $endpoint = null, $defaults = true)
     {
-        $env = (new DotenvFactory())->create();
-
-        $config = new Configuration($apiKey ?: $env->get('BUGSNAG_API_KEY'));
-        $guzzle = static::makeGuzzle($endpoint ?: $env->get('BUGSNAG_ENDPOINT'));
+        $config = new Configuration($apiKey ?: Env::get('BUGSNAG_API_KEY'));
+        $guzzle = static::makeGuzzle($endpoint ?: Env::get('BUGSNAG_ENDPOINT'));
 
         $client = new static($config, null, $guzzle);
 

--- a/src/Env.php
+++ b/src/Env.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace Bugsnag;
+
+use Dotenv\Environment\DotenvFactory;
+use Dotenv\Loader;
+
+class Env
+{
+    /**
+     * Get an environment variable.
+     *
+     * @param string $name
+     *
+     * @return string|null
+     */
+    public static function get($name)
+    {
+        return class_exists(DotenvFactory::class) ? self::getV3($name) : self::getV2($name);
+    }
+
+    /**
+     * Get an environment variable using dotenv v3.
+     *
+     * @param string $name
+     *
+     * @return string|null
+     */
+    private static function getV3($name)
+    {
+        static $env;
+
+        if ($env === null) {
+            $env = (new DotenvFactory())->create();
+        }
+
+        return $env->get($name);
+    }
+
+    /**
+     * Get an environment variable using dotenv v2.
+     *
+     * @param string $name
+     *
+     * @return string|null
+     */
+    private static function getV2($name)
+    {
+        static $loader;
+
+        if ($loader === null) {
+            $loader = new Loader('');
+        }
+
+        return $loader->getEnvironmentVariable($name);
+    }
+}


### PR DESCRIPTION
We should probably not insist on v3, to allow the latest version of the bugsnag php library to be installed in every application.