### PR TITLE
Default PHP exception handler will now fire

### DIFF
--- a/tests/HandlerTest.php
+++ b/tests/HandlerTest.php
@@ -82,6 +82,15 @@ namespace Bugsnag\Tests {
             $this->assertSame($e_to_throw, $previous_exception_handler_arg);
         }
 
+        public function testExceptionHandlerWithPreviousWhenNoPrevious()
+        {
+            $exceptionCode = 20190902;
+            $this->expectExceptionCode($exceptionCode);
+            $e = new Exception('No previous handler!', $exceptionCode);
+
+            Handler::registerWithPrevious($this->client)->exceptionHandler($e);
+        }
+
         public function testExceptionHandlerWithoutPrevious()
         {
             $previous_exception_handler_called = false;


### PR DESCRIPTION
This is a PR for [issue 523](https://github.com/bugsnag/bugsnag-php/issues/523) (And accidentally fixes [issue 475](https://github.com/bugsnag/bugsnag-php/issues/475))

In both cases, the root cause is that BugSnag **does** change default PHP behaviour with regard to exception handling and `registerWithPrevious` when no previous exception handler has been set.

It is more obvious in the CLI context, where the exit status from a script encountering an unhandled exception is incorrectly 0 ([issue 523](https://github.com/bugsnag/bugsnag-php/issues/523)). Without BugSnag enabled, the default PHP behaviour would be to generate a fatal error (`E_ERROR`) and the CLI script would exit with 255.

In a SAPI context, this is less obvious. Assuming `display_errors = off` and no content has been sent to the browser (ie output buffering is enabled), PHP default behaviour is to show a white screen of death with an HTTP status code of **500**. With BugSnag enabled via `registerWithPrevious`, the behaviour is to display a white screen of death with an HTTP status code of **200**. This is effectively the same thing as the CLI bug, but it's rarely noticeable unless something (a proxy or upstream server like Apache) interrogates the HTTP status code.

The additional effect that @thedotedge reported in [issue 475](https://github.com/bugsnag/bugsnag-php/issues/475) is that the default behaviour produces a fatal error that can be "trapped" (ish) within the shutdown function. When BugSnag is enabled via `registerWithPrevious` this error is never created and his switch statement fails (he makes a legitimate point that this is a bug).

In summary, if no previous exception handler exists, and the user invokes BugSnag via `registerWithPrevious`, then BugSnag should trigger the default exception handler in PHP. 

Note: a side effect to this is that BugSnag will now report on two events, the unhandled exception and the resulting fatal error. Perhaps the `E_ERROR` is something that could be filtered on the reporting side of things (the timestamp looks like it's the same for both events?)
<img width="1196" alt="Screenshot 2019-09-02 at 22 04 01" src="https://user-images.githubusercontent.com/43520/64133420-d2321c80-cdcd-11e9-8752-cb4f61218d8e.png">

