### PR TITLE
Make session delivery obey the release stage rules used by notify

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 Changelog
 =========
 
+## TBC
+
+* Make session delivery obey the release stage rules used by notify
+  [#542](https://github.com/bugsnag/bugsnag-php/pull/542)
+
 ## 3.18.0 (2019-08-28)
 
 ### Enhancements

--- a/src/SessionTracker.php
+++ b/src/SessionTracker.php
@@ -285,6 +285,9 @@ class SessionTracker
         if (count($sessions) == 0) {
             return;
         }
+        if (!$this->config->shouldNotify()) {
+            return;
+        }
         $http = $this->config->getSessionClient();
         $payload = $this->constructPayload($sessions);
         $headers = [

--- a/tests/SessionTrackerTest.php
+++ b/tests/SessionTrackerTest.php
@@ -2,10 +2,8 @@
 
 namespace Bugsnag\Tests;
 
-use Bugsnag\Client;
 use Bugsnag\Configuration;
 use Bugsnag\SessionTracker;
-use GuzzleHttp\Client as Guzzle;
 use phpmock\phpunit\PHPMock;
 use PHPUnit_Framework_TestCase as TestCase;
 
@@ -61,7 +59,7 @@ class SessionTrackerTest extends TestCase
         $this->config->expects($this->once())->method('getApiKey')->willReturn('example-api-key');
         $this->sessionTracker->expects($this->once())->method('setLastSent');
 
-        $this->http->expects($this->once())->method('post')->with($this->equalTo(''), $this->callback(function($sessionPayload) {
+        $this->http->expects($this->once())->method('post')->with($this->equalTo(''), $this->callback(function ($sessionPayload) {
             return count($sessionPayload) == 2
                    && $sessionPayload['json']['notifier'] == 'test_notifier'
                    && $sessionPayload['json']['device'] == 'device_data'
@@ -71,8 +69,7 @@ class SessionTrackerTest extends TestCase
                    && $sessionPayload['json']['sessionCounts'][0]['sessionsStarted'] == 1
                    && $sessionPayload['headers']['Bugsnag-Api-Key'] == 'example-api-key'
                    && preg_match('/(\d+\.)+/', $sessionPayload['headers']['Bugsnag-Payload-Version'])
-                   && preg_match('/\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}/', $sessionPayload['headers']['Bugsnag-Sent-At'])
-                   ;
+                   && preg_match('/\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}/', $sessionPayload['headers']['Bugsnag-Sent-At']);
         }));
 
         $this->sessionTracker->sendSessions();

--- a/tests/SessionTrackerTest.php
+++ b/tests/SessionTrackerTest.php
@@ -1,0 +1,80 @@
+<?php
+
+namespace Bugsnag\Tests;
+
+use Bugsnag\Client;
+use Bugsnag\Configuration;
+use Bugsnag\SessionTracker;
+use GuzzleHttp\Client as Guzzle;
+use phpmock\phpunit\PHPMock;
+use PHPUnit_Framework_TestCase as TestCase;
+
+class SessionTrackerTest extends TestCase
+{
+    use PHPMock;
+
+    protected $sessionTracker;
+    protected $config;
+    protected $http;
+
+    protected function setUp()
+    {
+        $this->config = $this->getMockBuilder(Configuration::class)
+                            ->setConstructorArgs(['example-api-key'])
+                            ->getMock();
+        $this->sessionTracker = $this->getMockBuilder(SessionTracker::class)
+                             ->setMethods(['getSessionCounts', 'setLastSent'])
+                             ->setConstructorArgs([$this->config])
+                             ->getMock();
+        $this->http = $this->getMockBuilder(HttpClient::class)
+                            ->setMethods(['post'])
+                            ->getMock();
+    }
+
+    public function testSendSessionsEmpty()
+    {
+        $this->sessionTracker->expects($this->once())->method('getSessionCounts')->willReturn([]);
+        $this->config->expects($this->never())->method('getSessionClient');
+        $this->http->expects($this->never())->method('post');
+
+        $this->sessionTracker->sendSessions();
+    }
+
+    public function testSendSessionsShouldNotNotify()
+    {
+        $this->sessionTracker->expects($this->once())->method('getSessionCounts')->willReturn(['2000-01-01T00:00:00' => 1]);
+        $this->config->expects($this->once())->method('shouldNotify')->willReturn(false);
+        $this->config->expects($this->never())->method('getSessionClient');
+        $this->http->expects($this->never())->method('post');
+
+        $this->sessionTracker->sendSessions();
+    }
+
+    public function testSendSessions()
+    {
+        $this->sessionTracker->expects($this->once())->method('getSessionCounts')->willReturn(['2000-01-01T00:00:00' => 1]);
+        $this->config->expects($this->once())->method('shouldNotify')->willReturn(true);
+        $this->config->expects($this->once())->method('getSessionClient')->willReturn($this->http);
+        $this->config->expects($this->once())->method('getNotifier')->willReturn('test_notifier');
+        $this->config->expects($this->once())->method('getDeviceData')->willReturn('device_data');
+        $this->config->expects($this->once())->method('getAppData')->willReturn('app_data');
+        $this->config->expects($this->once())->method('getApiKey')->willReturn('example-api-key');
+        $this->sessionTracker->expects($this->once())->method('setLastSent');
+
+        $this->http->expects($this->once())->method('post')->with($this->equalTo(''), $this->callback(function($sessionPayload) {
+            return count($sessionPayload) == 2
+                   && $sessionPayload['json']['notifier'] == 'test_notifier'
+                   && $sessionPayload['json']['device'] == 'device_data'
+                   && $sessionPayload['json']['app'] == 'app_data'
+                   && count($sessionPayload['json']['sessionCounts']) == 1
+                   && $sessionPayload['json']['sessionCounts'][0]['startedAt'] == '2000-01-01T00:00:00'
+                   && $sessionPayload['json']['sessionCounts'][0]['sessionsStarted'] == 1
+                   && $sessionPayload['headers']['Bugsnag-Api-Key'] == 'example-api-key'
+                   && preg_match('/(\d+\.)+/', $sessionPayload['headers']['Bugsnag-Payload-Version'])
+                   && preg_match('/\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}/', $sessionPayload['headers']['Bugsnag-Sent-At'])
+                   ;
+        }));
+
+        $this->sessionTracker->sendSessions();
+    }
+}


### PR DESCRIPTION
## Goal

Unlike other notifiers, `bugsnag-php` does not check `Configuration::shouldNotify` when delivering session payloads.

## Changeset

### Changed

* `SessionTracker` - added extra check on `deliverSessions`

## Tests

* Added new 'SessionTrackerTest` class as this doesn't seem to be covered at this level

### Linked issues

Fixes bugsnag/bugsnag-laravel#362

## Review

<!-- When submitting for review, consider the points for self-review and the
     criteria which will be used for secondary review -->

For the submitter, initial self-review:

- [x] Commented on code changes inline explain the reasoning behind the approach
- [x] Reviewed the test cases added for completeness and possible points for discussion
- [x] A changelog entry was added for the goal of this pull request
- [x] Check the scope of the changeset - is everything in the diff required for the pull request?
- This pull request is ready for:
  - [ ] Initial review of the intended approach, not yet feature complete
  - [ ] Structural review of the classes, functions, and properties modified
  - [x] Final review

For the pull request reviewer(s), this changeset has been reviewed for:

- [ ] Consistency across platforms for structures or concepts added or modified
- [ ] Consistency between the changeset and the goal stated above
- [ ] Internal consistency with the rest of the library - is there any overlap between existing interfaces and any which have been added?
- [ ] Usage friction - is the proposed change in usage cumbersome or complicated?
- [ ] Performance and complexity - are there any cases of unexpected O(n^3) when iterating, recursing, flat mapping, etc?
- [ ] Concurrency concerns - if components are accessed asynchronously, what issues will arise
- [ ] Thoroughness of added tests and any missing edge cases
- [ ] Idiomatic use of the language
