### PR TITLE
Support PHP 7.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,36 +1,54 @@
 language: php
-dist: trusty
-sudo: false
 
 matrix:
   include:
     - php: 5.5.9
+      dist: trusty
       env: GUZZLE_VERSION=^5.3
     - php: 5.5.9
+      dist: trusty
       env: GUZZLE_VERSION=^6.0
     - php: 5.5
+      dist: trusty
       env: GUZZLE_VERSION=^5.3
     - php: 5.5
+      dist: trusty
       env: GUZZLE_VERSION=^6.0
     - php: 5.6
+      dist: xenial
       env: GUZZLE_VERSION=^5.3
     - php: 5.6
+      dist: xenial
       env: GUZZLE_VERSION=^6.0
     - php: 7.0
+      dist: xenial
       env: GUZZLE_VERSION=^5.3
     - php: 7.0
+      dist: xenial
       env: GUZZLE_VERSION=^6.0
     - php: 7.1
+      dist: bionic
       env: GUZZLE_VERSION=^5.3
     - php: 7.1
+      dist: bionic
       env: GUZZLE_VERSION=^6.0
     - php: 7.2
+      dist: bionic
       env: GUZZLE_VERSION=^5.3
     - php: 7.2
+      dist: bionic
       env: GUZZLE_VERSION=^6.0
     - php: 7.3
+      dist: bionic
       env: GUZZLE_VERSION=^5.3
     - php: 7.3
+      dist: bionic
+      env: GUZZLE_VERSION=^6.0
+    - php: 7.4
+      dist: bionic
+      env: GUZZLE_VERSION=^5.3
+    - php: 7.4
+      dist: bionic
       env: GUZZLE_VERSION=^6.0
 
 before_install:

--- a/composer.json
+++ b/composer.json
@@ -17,9 +17,9 @@
     },
     "require-dev": {
         "graham-campbell/testbench-core": "^1.1",
-        "mockery/mockery": "^0.9.4|^1.3",
+        "mockery/mockery": "^0.9.4|^1.3.1",
         "mtdowling/burgomaster": "dev-master#72151eddf5f0cf101502b94bf5031f9c53501a04",
-        "phpunit/phpunit": "^4.8.36|^7.0",
+        "phpunit/phpunit": "^4.8.36|^7.5.15",
         "php-mock/php-mock-phpunit": "^1.1|^2.1"
     },
     "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -17,10 +17,10 @@
     },
     "require-dev": {
         "graham-campbell/testbench-core": "^1.1",
-        "mockery/mockery": "^0.9.4|~1.1.0",
+        "mockery/mockery": "^0.9.4|^1.3",
         "mtdowling/burgomaster": "dev-master#72151eddf5f0cf101502b94bf5031f9c53501a04",
-        "phpunit/phpunit": "^4.8|^5.0",
-        "php-mock/php-mock-phpunit": "^1.1"
+        "phpunit/phpunit": "^4.8.36|^7.0",
+        "php-mock/php-mock-phpunit": "^1.1|^2.1"
     },
     "autoload": {
         "psr-4" : {

--- a/tests/Breadcrumbs/BreadcrumbTest.php
+++ b/tests/Breadcrumbs/BreadcrumbTest.php
@@ -3,7 +3,7 @@
 namespace Bugsnag\Tests\Breadcrumbs;
 
 use Bugsnag\Breadcrumbs\Breadcrumb;
-use PHPUnit_Framework_TestCase as TestCase;
+use Bugsnag\Tests\TestCase;
 
 class BreadcrumbTest extends TestCase
 {
@@ -35,12 +35,13 @@ class BreadcrumbTest extends TestCase
         $this->assertSame('Good name!', $breadcrumb->toArray()['name']);
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     * @expectedExceptionMessage The breadcrumb type must be one of the set of 8 standard types.
-     */
     public function testBadType()
     {
+        $this->expectedException(
+            \InvalidArgumentException::class,
+            'The breadcrumb type must be one of the set of 8 standard types.'
+        );
+
         new Breadcrumb('Foo', 'bar');
     }
 

--- a/tests/Breadcrumbs/RecorderTest.php
+++ b/tests/Breadcrumbs/RecorderTest.php
@@ -4,8 +4,8 @@ namespace Bugsnag\Tests\Breadcrumbs;
 
 use Bugsnag\Breadcrumbs\Breadcrumb;
 use Bugsnag\Breadcrumbs\Recorder;
+use Bugsnag\Tests\TestCase;
 use Iterator;
-use PHPUnit_Framework_TestCase as TestCase;
 
 class RecorderTest extends TestCase
 {

--- a/tests/Callbacks/CustomUserTest.php
+++ b/tests/Callbacks/CustomUserTest.php
@@ -5,8 +5,8 @@ namespace Bugsnag\Tests\Callbacks;
 use Bugsnag\Callbacks\CustomUser;
 use Bugsnag\Configuration;
 use Bugsnag\Report;
+use Bugsnag\Tests\TestCase;
 use Exception;
-use PHPUnit_Framework_TestCase as TestCase;
 
 class CustomUserTest extends TestCase
 {

--- a/tests/Callbacks/EnvironmentDataTest.php
+++ b/tests/Callbacks/EnvironmentDataTest.php
@@ -5,8 +5,8 @@ namespace Bugsnag\Tests\Callbacks;
 use Bugsnag\Callbacks\EnvironmentData;
 use Bugsnag\Configuration;
 use Bugsnag\Report;
+use Bugsnag\Tests\TestCase;
 use Exception;
-use PHPUnit_Framework_TestCase as TestCase;
 
 class EnvironmentDataTest extends TestCase
 {

--- a/tests/Callbacks/GlobalMetaDataTest.php
+++ b/tests/Callbacks/GlobalMetaDataTest.php
@@ -5,8 +5,8 @@ namespace Bugsnag\Tests\Callbacks;
 use Bugsnag\Callbacks\GlobalMetaData;
 use Bugsnag\Configuration;
 use Bugsnag\Report;
+use Bugsnag\Tests\TestCase;
 use Exception;
-use PHPUnit_Framework_TestCase as TestCase;
 
 class GlobalMetaDataTest extends TestCase
 {

--- a/tests/Callbacks/RequestContextTest.php
+++ b/tests/Callbacks/RequestContextTest.php
@@ -6,8 +6,8 @@ use Bugsnag\Callbacks\RequestContext;
 use Bugsnag\Configuration;
 use Bugsnag\Report;
 use Bugsnag\Request\BasicResolver;
+use Bugsnag\Tests\TestCase;
 use Exception;
-use PHPUnit_Framework_TestCase as TestCase;
 
 class RequestContextTest extends TestCase
 {

--- a/tests/Callbacks/RequestCookiesTest.php
+++ b/tests/Callbacks/RequestCookiesTest.php
@@ -6,8 +6,8 @@ use Bugsnag\Callbacks\RequestCookies;
 use Bugsnag\Configuration;
 use Bugsnag\Report;
 use Bugsnag\Request\BasicResolver;
+use Bugsnag\Tests\TestCase;
 use Exception;
-use PHPUnit_Framework_TestCase as TestCase;
 
 class RequestCookiesTest extends TestCase
 {

--- a/tests/Callbacks/RequestMetaDataTest.php
+++ b/tests/Callbacks/RequestMetaDataTest.php
@@ -6,8 +6,8 @@ use Bugsnag\Callbacks\RequestMetaData;
 use Bugsnag\Configuration;
 use Bugsnag\Report;
 use Bugsnag\Request\BasicResolver;
+use Bugsnag\Tests\TestCase;
 use Exception;
-use PHPUnit_Framework_TestCase as TestCase;
 
 class RequestMetaDataTest extends TestCase
 {

--- a/tests/Callbacks/RequestSessionTest.php
+++ b/tests/Callbacks/RequestSessionTest.php
@@ -6,8 +6,8 @@ use Bugsnag\Callbacks\RequestSession;
 use Bugsnag\Configuration;
 use Bugsnag\Report;
 use Bugsnag\Request\BasicResolver;
+use Bugsnag\Tests\TestCase;
 use Exception;
-use PHPUnit_Framework_TestCase as TestCase;
 
 class RequestSessionTest extends TestCase
 {

--- a/tests/Callbacks/RequestUserTest.php
+++ b/tests/Callbacks/RequestUserTest.php
@@ -6,8 +6,8 @@ use Bugsnag\Callbacks\RequestUser;
 use Bugsnag\Configuration;
 use Bugsnag\Report;
 use Bugsnag\Request\BasicResolver;
+use Bugsnag\Tests\TestCase;
 use Exception;
-use PHPUnit_Framework_TestCase as TestCase;
 
 class RequestUserTest extends TestCase
 {

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -11,14 +11,11 @@ use Exception;
 use GuzzleHttp\Client as Guzzle;
 use GuzzleHttp\ClientInterface;
 use GuzzleHttp\Psr7\Uri;
-use phpmock\phpunit\PHPMock;
-use PHPUnit_Framework_TestCase as TestCase;
+use Mockery;
 use ReflectionClass;
 
 class ClientTest extends TestCase
 {
-    use PHPMock;
-
     protected $guzzle;
     protected $config;
     protected $client;
@@ -907,13 +904,10 @@ class ClientTest extends TestCase
         $this->assertSame(['foo' => 'bar'], $client->getNotifier());
     }
 
-    /**
-     * @doesNotPerformAssertions
-     */
     public function testShutdownStrategyIsCalledWithinConstructor()
     {
-        $mockShutdown = \Mockery::mock(PhpShutdownStrategy::class);
+        $mockShutdown = Mockery::mock(PhpShutdownStrategy::class);
         $mockShutdown->shouldReceive('registerShutdownStrategy')->once();
-        $client = new Client($this->config, null, null, $mockShutdown);
+        new Client($this->config, null, null, $mockShutdown);
     }
 }

--- a/tests/ConfigurationTest.php
+++ b/tests/ConfigurationTest.php
@@ -5,7 +5,6 @@ namespace Bugsnag\Tests;
 use Bugsnag\Configuration;
 use GuzzleHttp\Client as GuzzleClient;
 use GuzzleHttp\ClientInterface;
-use PHPUnit_Framework_TestCase as TestCase;
 
 class ConfigurationTest extends TestCase
 {
@@ -16,20 +15,20 @@ class ConfigurationTest extends TestCase
         $this->config = new Configuration('API-KEY');
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     */
     public function testDoesNotAcceptBadApiKey()
     {
+        $this->expectedException(\InvalidArgumentException::class);
+
         new Configuration([]);
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     * @expectedExpcetionMessage Invalid strip path regex: [thisisnotavalidregex
-     */
     public function testDoesNotAcceptBadStripPathRegex()
     {
+        $this->expectedException(
+            \InvalidArgumentException::class,
+            'Invalid strip path regex: [thisisnotavalidregex'
+        );
+
         $this->config->setStripPathRegex('[thisisnotavalidregex');
     }
 
@@ -176,12 +175,13 @@ class ConfigurationTest extends TestCase
         $this->assertSame('x/foo/thing.php', $this->config->getStrippedFilePath('x/foo/thing.php'));
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     * @expectedExpcetionMessage Invalid project root regex: [thisisnotavalidregex
-     */
     public function testInvalidRootPathRegexThrows()
     {
+        $this->expectedException(
+            \InvalidArgumentException::class,
+            'Invalid project root regex: [thisisnotavalidregex'
+        );
+
         $this->config->setProjectRootRegex('[thisisnotavalidregex');
     }
 

--- a/tests/ErrorTypesTest.php
+++ b/tests/ErrorTypesTest.php
@@ -3,7 +3,6 @@
 namespace Bugsnag\Tests;
 
 use Bugsnag\ErrorTypes;
-use PHPUnit_Framework_TestCase as TestCase;
 
 class ErrorTypesTest extends TestCase
 {

--- a/tests/HandlerTest.php
+++ b/tests/HandlerTest.php
@@ -21,13 +21,9 @@ namespace Bugsnag\Tests {
     use Bugsnag\Configuration;
     use Bugsnag\Handler;
     use Exception;
-    use phpmock\phpunit\PHPMock;
-    use PHPUnit_Framework_TestCase as TestCase;
 
     class HandlerTest extends TestCase
     {
-        use PHPMock;
-
         protected $client;
 
         protected function setUp()
@@ -49,11 +45,14 @@ namespace Bugsnag\Tests {
             Handler::register($this->client)->errorHandler(E_WARNING, 'Something broke', 'somefile.php', 123);
         }
 
-        /**
-         * @expectedException PHPUnit_Framework_Error_Warning
-         */
         public function testErrorHandlerWithPrevious()
         {
+            if (class_exists(\PHPUnit_Framework_Error_Warning::class)) {
+                $this->expectedException(\PHPUnit_Framework_Error_Warning::class);
+            } else {
+                $this->expectedException(\PHPUnit\Framework\Error\Warning::class);
+            }
+
             Handler::registerWithPrevious($this->client)->errorHandler(E_WARNING, 'Something broke', 'somefile.php', 123);
         }
 

--- a/tests/HttpClientTest.php
+++ b/tests/HttpClientTest.php
@@ -7,13 +7,9 @@ use Bugsnag\HttpClient;
 use Bugsnag\Report;
 use Exception;
 use GuzzleHttp\Client;
-use phpmock\phpunit\PHPMock;
-use PHPUnit_Framework_TestCase as TestCase;
 
 class HttpClientTest extends TestCase
 {
-    use PHPMock;
-
     protected $config;
     protected $guzzle;
     protected $http;
@@ -29,6 +25,15 @@ class HttpClientTest extends TestCase
         $this->http = new HttpClient($this->config, $this->guzzle);
     }
 
+    private static function getInvocationParameters($invocation)
+    {
+        if (is_callable([$invocation, 'getParameters'])) {
+            return $invocation->getParameters();
+        }
+
+        return $invocation->parameters;
+    }
+
     public function testHttpClient()
     {
         // Expect request to be called
@@ -39,7 +44,7 @@ class HttpClientTest extends TestCase
         $this->http->send();
 
         $this->assertCount(1, $invocations = $spy->getInvocations());
-        $params = $invocations[0]->parameters;
+        $params = self::getInvocationParameters($invocations[0]);
         $this->assertCount(2, $params);
         $this->assertSame('', $params[0]);
         $this->assertInternalType('array', $params[1]);
@@ -83,7 +88,7 @@ class HttpClientTest extends TestCase
         $this->http->send();
 
         $this->assertCount(1, $invocations = $spy->getInvocations());
-        $params = $invocations[0]->parameters;
+        $params = self::getInvocationParameters($invocations[0]);
         $this->assertCount(2, $params);
         $this->assertSame('', $params[0]);
         $this->assertInternalType('array', $params[1]);
@@ -131,7 +136,7 @@ class HttpClientTest extends TestCase
         $this->http->send();
 
         $this->assertCount(1, $invocations = $spy->getInvocations());
-        $params = $invocations[0]->parameters;
+        $params = self::getInvocationParameters($invocations[0]);
         $this->assertCount(2, $params);
         $this->assertSame('', $params[0]);
         $this->assertInternalType('array', $params[1]);

--- a/tests/Middleware/BreadcrumbsDataTest.php
+++ b/tests/Middleware/BreadcrumbsDataTest.php
@@ -7,8 +7,8 @@ use Bugsnag\Breadcrumbs\Recorder;
 use Bugsnag\Configuration;
 use Bugsnag\Middleware\BreadcrumbData;
 use Bugsnag\Report;
+use Bugsnag\Tests\TestCase;
 use Exception;
-use PHPUnit_Framework_TestCase as TestCase;
 
 class BreadcrumbsDataTest extends TestCase
 {

--- a/tests/Middleware/CallbackBridgeTest.php
+++ b/tests/Middleware/CallbackBridgeTest.php
@@ -5,8 +5,8 @@ namespace Bugsnag\Tests\Middleware;
 use Bugsnag\Configuration;
 use Bugsnag\Middleware\CallbackBridge;
 use Bugsnag\Report;
+use Bugsnag\Tests\TestCase;
 use Exception;
-use PHPUnit_Framework_TestCase as TestCase;
 
 class CallbackBridgeTest extends TestCase
 {

--- a/tests/Middleware/NotificationSkipperTest.php
+++ b/tests/Middleware/NotificationSkipperTest.php
@@ -5,8 +5,8 @@ namespace Bugsnag\Tests\Middleware;
 use Bugsnag\Configuration;
 use Bugsnag\Middleware\NotificationSkipper;
 use Bugsnag\Report;
+use Bugsnag\Tests\TestCase;
 use Exception;
-use PHPUnit_Framework_TestCase as TestCase;
 
 class NotificationSkipperTest extends TestCase
 {

--- a/tests/Middleware/SessionDataTest.php
+++ b/tests/Middleware/SessionDataTest.php
@@ -6,14 +6,11 @@ use Bugsnag\Client;
 use Bugsnag\Middleware\SessionData;
 use Bugsnag\Report;
 use Bugsnag\SessionTracker;
-use GrahamCampbell\TestBenchCore\MockeryTrait;
+use Bugsnag\Tests\TestCase;
 use Mockery;
-use PHPUnit_Framework_TestCase as TestCase;
 
 class SessionDataTest extends TestCase
 {
-    use MockeryTrait;
-
     public function testUnhandledError()
     {
         $sessionTracker = Mockery::mock(SessionTracker::class);

--- a/tests/PipelineTest.php
+++ b/tests/PipelineTest.php
@@ -3,39 +3,6 @@
 namespace Bugsnag\Tests;
 
 use Bugsnag\Pipeline;
-use PHPUnit_Framework_TestCase as TestCase;
-
-class ReturnObject
-{
-    public $result = '';
-}
-
-class TestCallbackA
-{
-    public function __invoke($item, $next)
-    {
-        $item->result .= 'A';
-        $next($item);
-    }
-}
-
-class TestCallbackB
-{
-    public function __invoke($item, $next)
-    {
-        $item->result .= 'B';
-        $next($item);
-    }
-}
-
-class TestCallbackC
-{
-    public function __invoke($item, $next)
-    {
-        $item->result .= 'C';
-        $next($item);
-    }
-}
 
 class PipelineTest extends TestCase
 {
@@ -83,5 +50,37 @@ class PipelineTest extends TestCase
         $pipeline->execute($returnItem, function ($item) {
         });
         $this->assertSame('ACB', $returnItem->result);
+    }
+}
+
+class ReturnObject
+{
+    public $result = '';
+}
+
+class TestCallbackA
+{
+    public function __invoke($item, $next)
+    {
+        $item->result .= 'A';
+        $next($item);
+    }
+}
+
+class TestCallbackB
+{
+    public function __invoke($item, $next)
+    {
+        $item->result .= 'B';
+        $next($item);
+    }
+}
+
+class TestCallbackC
+{
+    public function __invoke($item, $next)
+    {
+        $item->result .= 'C';
+        $next($item);
     }
 }

--- a/tests/ReportTest.php
+++ b/tests/ReportTest.php
@@ -8,7 +8,6 @@ use Bugsnag\Stacktrace;
 use Exception;
 use InvalidArgumentException;
 use ParseError;
-use PHPUnit_Framework_TestCase as TestCase;
 use stdClass;
 
 class ReportTest extends TestCase
@@ -125,7 +124,12 @@ class ReportTest extends TestCase
         $trace = $this->report->getStacktrace();
 
         $this->assertInstanceOf(Stacktrace::class, $trace);
-        $this->assertCount(8, $trace->toArray());
+
+        if (class_exists(\PHPUnit_Framework_TestCase::class)) {
+            $this->assertCount(8, $trace->toArray());
+        } else {
+            $this->assertCount(7, $trace->toArray());
+        }
     }
 
     public function testNoticeName()
@@ -197,11 +201,9 @@ class ReportTest extends TestCase
         $this->assertSame($event['severity'], 'error');
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     */
     public function testInvalidSeverity()
     {
+        $this->expectedException(InvalidArgumentException::class);
         $this->report->setSeverity('bunk');
     }
 
@@ -247,35 +249,27 @@ class ReportTest extends TestCase
         $this->assertSame($this->report, $this->report->setPHPThrowable($exception));
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     */
     public function testSetNotThrowable()
     {
+        $this->expectedException(InvalidArgumentException::class);
         $this->assertSame($this->report, $this->report->setPHPThrowable(new stdClass()));
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     */
     public function testSetNotObject()
     {
+        $this->expectedException(InvalidArgumentException::class);
         $this->assertSame($this->report, $this->report->setPHPThrowable('foo'));
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     */
     public function testBadSetName()
     {
+        $this->expectedException(InvalidArgumentException::class);
         $this->report->setName([]);
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     */
     public function testBadSetMessage()
     {
+        $this->expectedException(InvalidArgumentException::class);
         $this->report->setMessage(new stdClass());
     }
 

--- a/tests/RequestTest.php
+++ b/tests/RequestTest.php
@@ -8,7 +8,6 @@ use Bugsnag\Request\NullRequest;
 use Bugsnag\Request\PhpRequest;
 use Bugsnag\Request\RequestInterface;
 use Bugsnag\Request\ResolverInterface;
-use PHPUnit_Framework_TestCase as TestCase;
 use ReflectionClass;
 
 class RequestTest extends TestCase

--- a/tests/SessionTrackerTest.php
+++ b/tests/SessionTrackerTest.php
@@ -4,13 +4,9 @@ namespace Bugsnag\Tests;
 
 use Bugsnag\Configuration;
 use Bugsnag\SessionTracker;
-use phpmock\phpunit\PHPMock;
-use PHPUnit_Framework_TestCase as TestCase;
 
 class SessionTrackerTest extends TestCase
 {
-    use PHPMock;
-
     protected $sessionTracker;
     protected $config;
     protected $http;

--- a/tests/Shutdown/PhpShutdownStrategyTest.php
+++ b/tests/Shutdown/PhpShutdownStrategyTest.php
@@ -4,19 +4,20 @@ namespace Bugsnag\Tests\Shutdown;
 
 use Bugsnag\Client;
 use Bugsnag\Shutdown\PhpShutdownStrategy;
+use Bugsnag\Tests\TestCase;
 use phpmock\spy\Spy;
-use PHPUnit_Framework_TestCase as TestCase;
+use Mockery;
 
 class PhpShutdownStrategyTest extends TestCase
 {
     public function testRegisterShutdownFunction()
     {
         // Override/spy on the native PHP method when executed within the Bugsnag\Shutdown namespace
-        $shutdownSpy = new Spy("Bugsnag\Shutdown", 'register_shutdown_function');
+        $shutdownSpy = new Spy('Bugsnag\Shutdown', 'register_shutdown_function');
         $shutdownSpy->enable();
 
         // Mock a bugsnag client
-        $mockClient = \Mockery::mock(Client::class);
+        $mockClient = Mockery::mock(Client::class);
         $mockClient->shouldReceive('flush');
 
         // Execute the shutdown strategy
@@ -32,7 +33,7 @@ class PhpShutdownStrategyTest extends TestCase
     public function testDefaultShutdownStrategyIsCreatedWithinClientConstructor()
     {
         // Override/spy on the native PHP method when executed within the Bugsnag\Shutdown namespace
-        $shutdownSpy = new Spy("Bugsnag\Shutdown", 'register_shutdown_function');
+        $shutdownSpy = new Spy('Bugsnag\Shutdown', 'register_shutdown_function');
         $shutdownSpy->enable();
 
         $client = Client::make('api-key-here');

--- a/tests/Shutdown/PhpShutdownStrategyTest.php
+++ b/tests/Shutdown/PhpShutdownStrategyTest.php
@@ -5,8 +5,8 @@ namespace Bugsnag\Tests\Shutdown;
 use Bugsnag\Client;
 use Bugsnag\Shutdown\PhpShutdownStrategy;
 use Bugsnag\Tests\TestCase;
-use phpmock\spy\Spy;
 use Mockery;
+use phpmock\spy\Spy;
 
 class PhpShutdownStrategyTest extends TestCase
 {

--- a/tests/StacktraceTest.php
+++ b/tests/StacktraceTest.php
@@ -4,13 +4,9 @@ namespace Bugsnag\Tests;
 
 use Bugsnag\Configuration;
 use Bugsnag\Stacktrace;
-use phpmock\phpunit\PHPMock;
-use PHPUnit_Framework_TestCase as TestCase;
 
 class StacktraceTest extends TestCase
 {
-    use PHPMock;
-
     protected $config;
 
     protected function setUp()
@@ -183,15 +179,13 @@ class StacktraceTest extends TestCase
         $this->assertCount(2, $stacktrace->toArray());
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     * @expectedExceptionMessage Invalid frame index to remove.
-     */
     public function testCanNotRemoveBadFrame()
     {
         $fixture = $this->getJsonFixture('backtraces/exception_handler.json');
         $this->config->setStripPath('/Users/james/src/bugsnag/bugsnag-php/');
         $stacktrace = Stacktrace::fromBacktrace($this->config, $fixture['backtrace'], $fixture['file'], $fixture['line']);
+
+        $this->expectedException(\InvalidArgumentException::class, 'Invalid frame index to remove.');
 
         $stacktrace->removeFrame(4);
     }

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Bugsnag\Tests;
+
+use GrahamCampbell\TestBenchCore\MockeryTrait;
+use phpmock\phpunit\PHPMock;
+use PHPUnit\Framework\TestCase as BaseTestCase;
+
+abstract class TestCase extends BaseTestCase
+{
+    use PHPMock, MockeryTrait;
+
+    public function expectedException($class, $msg = null)
+    {
+        if (class_exists(\PHPUnit_Framework_TestCase::class)) {
+            $this->setExpectedException($class, $msg);
+        } else {
+            $this->expectException($class);
+            if ($msg !== null) {
+                $this->expectExceptionMessage($msg);
+            }
+        }
+    }
+}


### PR DESCRIPTION
This updates the tests so they can run on a newer version of PHPUnit as well as the old version, so we can continue to support PHP 5. This then allows us to run the test suite on PHP 7.4 without issues.