### PR TITLE
Dropped PHP 5.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -49,7 +49,7 @@ before_install:
   - composer require "guzzlehttp/guzzle:${GUZZLE_VERSION}" --no-update
 
 install:
-  - travis_retry composer install $COMPOSER_OPTIONS
+  - travis_retry composer update $COMPOSER_OPTIONS
 
 script:
   - make test

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,18 +2,12 @@ language: php
 
 matrix:
   include:
-    - php: 5.5.9
-      dist: trusty
-      env: GUZZLE_VERSION=^5.3
-    - php: 5.5.9
-      dist: trusty
-      env: GUZZLE_VERSION=^6.0
-    - php: 5.5
-      dist: trusty
-      env: GUZZLE_VERSION=^5.3
-    - php: 5.5
-      dist: trusty
-      env: GUZZLE_VERSION=^6.0
+    - php: 5.6
+      dist: xenial
+      env: GUZZLE_VERSION=^5.3 COMPOSER_OPTIONS="--prefer-lowest"
+    - php: 5.6
+      dist: xenial
+      env: GUZZLE_VERSION=^6.0 COMPOSER_OPTIONS="--prefer-lowest"
     - php: 5.6
       dist: xenial
       env: GUZZLE_VERSION=^5.3
@@ -55,8 +49,7 @@ before_install:
   - composer require "guzzlehttp/guzzle:${GUZZLE_VERSION}" --no-update
 
 install:
-  - if [[ $TRAVIS_PHP_VERSION == 5.5.9 ]]; then travis_retry composer update --no-interaction --prefer-source --prefer-lowest ; fi
-  - if [[ $TRAVIS_PHP_VERSION != 5.5.9 ]]; then travis_retry composer update --no-interaction --prefer-source ; fi
+  - travis_retry composer install $COMPOSER_OPTIONS
 
 script:
   - make test

--- a/composer.json
+++ b/composer.json
@@ -11,8 +11,7 @@
         "homepage": "https://bugsnag.com"
     }],
     "require": {
-        "php": ">=5.5",
-        "composer/ca-bundle": "^1.0",
+        "php": ">=5.6",
         "guzzlehttp/guzzle": "^5.0|^6.0"
     },
     "require-dev": {

--- a/src/Client.php
+++ b/src/Client.php
@@ -18,7 +18,6 @@ use Bugsnag\Request\BasicResolver;
 use Bugsnag\Request\ResolverInterface;
 use Bugsnag\Shutdown\PhpShutdownStrategy;
 use Bugsnag\Shutdown\ShutdownStrategyInterface;
-use Composer\CaBundle\CaBundle;
 use GuzzleHttp\Client as Guzzle;
 use GuzzleHttp\ClientInterface;
 use ReflectionClass;
@@ -145,25 +144,7 @@ class Client
 
         $options[$key] = $base ?: static::ENDPOINT;
 
-        if ($path = static::getCaBundlePath()) {
-            $options['verify'] = $path;
-        }
-
         return new Guzzle($options);
-    }
-
-    /**
-     * Get the ca bundle path if one exists.
-     *
-     * @return string|false
-     */
-    protected static function getCaBundlePath()
-    {
-        if (!class_exists(CaBundle::class)) {
-            return false;
-        }
-
-        return realpath(CaBundle::getSystemCaRootBundlePath());
     }
 
     /**


### PR DESCRIPTION
PHP 5.5 has been EOL for some time and is not widely used. PHP 5.5 users can reasonably easily upgrade to PHP 5.6, and should ultimately look to upgrade to PHP 7 as soon as possible.

The reported issue here is the complaint that the search for a CA file is raising silenced errors. The best course of action is probably to remove this code entirely, since it is not needed in PHP 5.6+, and drop PHP 5.5.

---

Closes https://github.com/bugsnag/bugsnag-php/issues/504.