### PR TITLE
Bumped branch alias to 3.20

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -34,7 +34,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-master": "3.19-dev"
+            "dev-master": "3.20-dev"
         }
     },
     "minimum-stability": "dev",


### PR DESCRIPTION
Next release will be `v3.20.0`, due to the new feature (so far) of Guzzle 7 support. This also allows me to ask for `^3.20` in the other packages to get the new code, even before it is released.