### PR TITLE
Use full class names in breadcrumbs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 Changelog
 =========
 
+## Unreleased
+
+### Enhancements
+
+* Use full class names in breadcrumbs
+  [#578](https://github.com/bugsnag/bugsnag-php/pull/578)
+
 ## 3.20.0 (2020-02-26)
 
 ### Enhancements

--- a/src/Client.php
+++ b/src/Client.php
@@ -21,8 +21,6 @@ use Bugsnag\Shutdown\ShutdownStrategyInterface;
 use Composer\CaBundle\CaBundle;
 use GuzzleHttp\Client as Guzzle;
 use GuzzleHttp\ClientInterface;
-use ReflectionClass;
-use ReflectionException;
 
 class Client
 {
@@ -242,12 +240,6 @@ class Client
      */
     public function leaveBreadcrumb($name, $type = null, array $metaData = [])
     {
-        try {
-            $name = (new ReflectionClass($name))->getShortName();
-        } catch (ReflectionException $e) {
-            //
-        }
-
         $type = in_array($type, Breadcrumb::getTypes(), true) ? $type : Breadcrumb::MANUAL_TYPE;
 
         $this->recorder->record(new Breadcrumb($name, $type, $metaData));

--- a/src/Request/BasicResolver.php
+++ b/src/Request/BasicResolver.php
@@ -18,11 +18,13 @@ class BasicResolver implements ResolverInterface
                 $params = static::getInputParams($_SERVER, $_POST, true);
             }
 
-            return new PhpRequest($_SERVER,
+            return new PhpRequest(
+                $_SERVER,
                 empty($_SESSION) ? [] : $_SESSION,
                 empty($_COOKIE) ? [] : $_COOKIE,
                 static::getRequestHeaders($_SERVER),
-                $params);
+                $params
+            );
         }
 
         if (PHP_SAPI === 'cli' && isset($_SERVER['argv'])) {

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -351,7 +351,7 @@ class ClientTest extends TestCase
         $this->assertFalse(isset($breadcrumbs[0]['metaData']));
     }
 
-    public function testBreadcrumbsNoName()
+    public function testBreadcrumbsWithNoName()
     {
         $this->client = new Client($this->config = new Configuration('example-api-key'), null, $this->guzzle);
 
@@ -372,7 +372,7 @@ class ClientTest extends TestCase
         $this->assertTrue(isset($breadcrumbs[0]['metaData']));
     }
 
-    public function testBreadcrumbsGetShortNameClass()
+    public function testBreadcrumbsWithClassName()
     {
         $this->client = new Client($this->config = new Configuration('example-api-key'), null, $this->guzzle);
 
@@ -386,7 +386,7 @@ class ClientTest extends TestCase
 
         $this->assertCount(3, $breadcrumbs[0]);
         $this->assertInternalType('string', $breadcrumbs[0]['timestamp']);
-        $this->assertSame('Client', $breadcrumbs[0]['name']);
+        $this->assertSame('Bugsnag\Client', $breadcrumbs[0]['name']);
         $this->assertSame('state', $breadcrumbs[0]['type']);
         $this->assertFalse(isset($breadcrumbs[0]['metaData']));
     }


### PR DESCRIPTION
Replaces https://github.com/bugsnag/bugsnag-php/pull/470. We can do this now, since the UI can now deal with much larger names and the limit on breadcrumb size was removed from the library in https://github.com/bugsnag/bugsnag-php/pull/544.