### PR TITLE
Fix session tracker count raising a warning on PHP 7.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ Changelog
 * Added support for getting the "original error"
   [#576](https://github.com/bugsnag/bugsnag-php/pull/576)
 
+* Fixed session tracker possibly raising a warning on PHP 7.2 and above
+  [#579](https://github.com/bugsnag/bugsnag-php/pull/579)
+
 ## 3.20.0 (2020-02-26)
 
 ### Enhancements

--- a/src/Client.php
+++ b/src/Client.php
@@ -19,7 +19,7 @@ use Bugsnag\Request\ResolverInterface;
 use Bugsnag\Shutdown\PhpShutdownStrategy;
 use Bugsnag\Shutdown\ShutdownStrategyInterface;
 use Composer\CaBundle\CaBundle;
-use GuzzleHttp\Client as Guzzle;
+use GuzzleHttp\Client as GuzzleClient;
 use GuzzleHttp\ClientInterface;
 
 class Client
@@ -147,7 +147,7 @@ class Client
             $options['verify'] = $path;
         }
 
-        return new Guzzle($options);
+        return new GuzzleClient($options);
     }
 
     /**

--- a/src/Client.php
+++ b/src/Client.php
@@ -798,7 +798,7 @@ class Client
     /**
      * Get the session client.
      *
-     * @return \Guzzle\ClientInterface
+     * @return \GuzzleHttp\ClientInterface
      */
     public function getSessionClient()
     {

--- a/src/Configuration.php
+++ b/src/Configuration.php
@@ -125,7 +125,7 @@ class Configuration
     /**
      * A client to use to send sessions.
      *
-     * @var \Guzzle\ClientInterface
+     * @var \GuzzleHttp\ClientInterface
      */
     protected $sessionClient;
 
@@ -622,7 +622,7 @@ class Configuration
     /**
      * Get the session client.
      *
-     * @return \Guzzle\ClientInterface
+     * @return \GuzzleHttp\ClientInterface
      */
     public function getSessionClient()
     {

--- a/src/SessionTracker.php
+++ b/src/SessionTracker.php
@@ -306,7 +306,6 @@ class SessionTracker
             return [];
         }
 
-
         return $this->sessionCounts;
     }
 

--- a/src/SessionTracker.php
+++ b/src/SessionTracker.php
@@ -298,25 +298,24 @@ class SessionTracker
         }
 
         $http = $this->config->getSessionClient();
-        $payload = $this->constructPayload($sessions);
 
-        $headers = [
-            'Bugsnag-Api-Key' => $this->config->getApiKey(),
-            'Bugsnag-Payload-Version' => self::$SESSION_PAYLOAD_VERSION,
-            'Bugsnag-Sent-At' => strftime('%Y-%m-%dT%H:%M:%S'),
+        $options = [
+            'json' => $this->constructPayload($sessions),
+            'headers' => [
+                'Bugsnag-Api-Key' => $this->config->getApiKey(),
+                'Bugsnag-Payload-Version' => self::$SESSION_PAYLOAD_VERSION,
+                'Bugsnag-Sent-At' => strftime('%Y-%m-%dT%H:%M:%S'),
+            ],
         ];
 
         $this->setLastSent();
 
         try {
-            $http->request(
-                'POST',
-                '',
-                [
-                    'json' => $payload,
-                    'headers' => $headers,
-                ]
-            );
+            if (method_exists($http, 'request')) {
+                $http->request('POST', '', $options);
+            } else {
+                $http->post('', $options);
+            }
         } catch (Exception $e) {
             error_log('Bugsnag Warning: Couldn\'t notify. '.$e->getMessage());
             if (!is_null($this->retryFunction)) {

--- a/src/SessionTracker.php
+++ b/src/SessionTracker.php
@@ -108,14 +108,23 @@ class SessionTracker
         $this->lastSent = 0;
     }
 
+    /**
+     * @param Configuration $config
+     *
+     * @return void
+     */
     public function setConfig(Configuration $config)
     {
         $this->config = $config;
     }
 
+    /**
+     * @return void
+     */
     public function startSession()
     {
         $currentTime = strftime('%Y-%m-%dT%H:%M:00');
+
         $session = [
             'id' => uniqid('', true),
             'startedAt' => $currentTime,
@@ -124,10 +133,16 @@ class SessionTracker
                 'unhandled' => 0,
             ],
         ];
+
         $this->setCurrentSession($session);
         $this->incrementSessions($currentTime);
     }
 
+    /**
+     * @param array $session
+     *
+     * @return void
+     */
     protected function setCurrentSession(array $session)
     {
         if (!is_null($this->sessionFunction)) {
@@ -137,6 +152,9 @@ class SessionTracker
         }
     }
 
+    /**
+     * @return mixed
+     */
     public function getCurrentSession()
     {
         if (!is_null($this->sessionFunction)) {
@@ -146,6 +164,9 @@ class SessionTracker
         }
     }
 
+    /**
+     * @return void
+     */
     public function sendSessions()
     {
         $locked = false;
@@ -163,6 +184,12 @@ class SessionTracker
         }
     }
 
+    /**
+     * @param callable $lock
+     * @param callable $unlock
+     *
+     * @return void
+     */
     public function setLockFunctions($lock, $unlock)
     {
         if (!is_callable($lock) || !is_callable($unlock)) {
@@ -173,15 +200,25 @@ class SessionTracker
         $this->unlockFunction = $unlock;
     }
 
-    public function setRetryFunction($retry)
+    /**
+     * @param callable $function
+     *
+     * @return void
+     */
+    public function setRetryFunction($function)
     {
-        if (!is_callable($retry)) {
+        if (!is_callable($function)) {
             throw new InvalidArgumentException('The retry function must be callable');
         }
 
-        $this->retryFunction = $retry;
+        $this->retryFunction = $function;
     }
 
+    /**
+     * @param callable $function
+     *
+     * @return void
+     */
     public function setStorageFunction($function)
     {
         if (!is_callable($function)) {
@@ -191,6 +228,11 @@ class SessionTracker
         $this->storageFunction = $function;
     }
 
+    /**
+     * @param callable $function
+     *
+     * @return void
+     */
     public function setSessionFunction($function)
     {
         if (!is_callable($function)) {
@@ -200,6 +242,13 @@ class SessionTracker
         $this->sessionFunction = $function;
     }
 
+    /**
+     * @param string $minute
+     * @param int $count
+     * @param bool $deliver
+     *
+     * @return void
+     */
     protected function incrementSessions($minute, $count = 1, $deliver = true)
     {
         $locked = false;
@@ -243,6 +292,9 @@ class SessionTracker
         }
     }
 
+    /**
+     * @return mixed
+     */
     protected function getSessionCounts()
     {
         if (!is_null($this->storageFunction)) {
@@ -252,6 +304,11 @@ class SessionTracker
         }
     }
 
+    /**
+     * @param array $sessionCounts
+     *
+     * @return void
+     */
     protected function setSessionCounts(array $sessionCounts)
     {
         if (!is_null($this->storageFunction)) {
@@ -261,6 +318,9 @@ class SessionTracker
         }
     }
 
+    /**
+     * @return void
+     */
     protected function trimOldestSessions()
     {
         $sessions = $this->getSessionCounts();
@@ -272,7 +332,12 @@ class SessionTracker
         $this->setSessionCounts($sessionCounts);
     }
 
-    protected function constructPayload($sessions)
+    /**
+     * @param array $sessions
+     *
+     * @return array
+     */
+    protected function constructPayload(array $sessions)
     {
         $formattedSessions = [];
         foreach ($sessions as $minute => $count) {
@@ -287,6 +352,9 @@ class SessionTracker
         ];
     }
 
+    /**
+     * @return void
+     */
     protected function deliverSessions()
     {
         $sessions = $this->getSessionCounts();
@@ -332,6 +400,9 @@ class SessionTracker
         }
     }
 
+    /**
+     * @return void
+     */
     protected function setLastSent()
     {
         $time = time();
@@ -342,6 +413,9 @@ class SessionTracker
         }
     }
 
+    /**
+     * @return mixed
+     */
     protected function getLastSent()
     {
         if (!is_null($this->storageFunction)) {

--- a/src/SessionTracker.php
+++ b/src/SessionTracker.php
@@ -3,6 +3,7 @@
 namespace Bugsnag;
 
 use Exception;
+use GuzzleHttp\ClientInterface;
 use InvalidArgumentException;
 
 class SessionTracker
@@ -391,7 +392,10 @@ class SessionTracker
         $this->setLastSent();
 
         try {
-            if (method_exists($http, 'request')) {
+            // Support later Guzzle versions — note we check the interface to make
+            // sure "request" is a public method as on PHP 7.4 "method_exists" will
+            // return true for private methods
+            if (method_exists(ClientInterface::class, 'request')) {
                 $http->request('POST', '', $options);
             } else {
                 $http->post('', $options);

--- a/src/SessionTracker.php
+++ b/src/SessionTracker.php
@@ -301,10 +301,14 @@ class SessionTracker
         $this->setLastSent();
 
         try {
-            $http->post('', [
-                'json' => $payload,
-                'headers' => $headers,
-            ]);
+            $http->request(
+                'POST',
+                '',
+                [
+                    'json' => $payload,
+                    'headers' => $headers,
+                ]
+            );
         } catch (Exception $e) {
             error_log('Bugsnag Warning: Couldn\'t notify. '.$e->getMessage());
             if (!is_null($this->retryFunction)) {

--- a/src/SessionTracker.php
+++ b/src/SessionTracker.php
@@ -2,6 +2,9 @@
 
 namespace Bugsnag;
 
+use Exception;
+use InvalidArgumentException;
+
 class SessionTracker
 {
     /**

--- a/src/SessionTracker.php
+++ b/src/SessionTracker.php
@@ -226,7 +226,9 @@ class SessionTracker
             if (count($sessionCounts) > self::$MAX_SESSION_COUNT) {
                 $this->trimOldestSessions();
             }
+
             $lastSent = $this->getLastSent();
+
             if ($deliver && ((time() - $lastSent) > self::$DELIVERY_INTERVAL)) {
                 $this->deliverSessions();
             }
@@ -284,20 +286,26 @@ class SessionTracker
     protected function deliverSessions()
     {
         $sessions = $this->getSessionCounts();
+
         $this->setSessionCounts([]);
-        if (count($sessions) == 0) {
+
+        if (!is_array($sessions) || count($sessions) === 0) {
             return;
         }
+
         if (!$this->config->shouldNotify()) {
             return;
         }
+
         $http = $this->config->getSessionClient();
         $payload = $this->constructPayload($sessions);
+
         $headers = [
             'Bugsnag-Api-Key' => $this->config->getApiKey(),
             'Bugsnag-Payload-Version' => self::$SESSION_PAYLOAD_VERSION,
             'Bugsnag-Sent-At' => strftime('%Y-%m-%dT%H:%M:%S'),
         ];
+
         $this->setLastSent();
 
         try {

--- a/src/SessionTracker.php
+++ b/src/SessionTracker.php
@@ -145,7 +145,7 @@ class SessionTracker
      */
     protected function setCurrentSession(array $session)
     {
-        if (!is_null($this->sessionFunction)) {
+        if (is_callable($this->sessionFunction)) {
             call_user_func($this->sessionFunction, $session);
         } else {
             $this->currentSession = $session;
@@ -157,11 +157,11 @@ class SessionTracker
      */
     public function getCurrentSession()
     {
-        if (!is_null($this->sessionFunction)) {
+        if (is_callable($this->sessionFunction)) {
             return call_user_func($this->sessionFunction);
-        } else {
-            return $this->currentSession;
         }
+
+        return $this->currentSession;
     }
 
     /**
@@ -170,7 +170,7 @@ class SessionTracker
     public function sendSessions()
     {
         $locked = false;
-        if (!is_null($this->lockFunction) && !is_null($this->unlockFunction)) {
+        if (is_callable($this->lockFunction) && is_callable($this->unlockFunction)) {
             call_user_func($this->lockFunction);
             $locked = true;
         }
@@ -252,7 +252,8 @@ class SessionTracker
     protected function incrementSessions($minute, $count = 1, $deliver = true)
     {
         $locked = false;
-        if (!is_null($this->lockFunction) && !is_null($this->unlockFunction)) {
+
+        if (is_callable($this->lockFunction) && is_callable($this->unlockFunction)) {
             call_user_func($this->lockFunction);
             $locked = true;
         }
@@ -297,11 +298,11 @@ class SessionTracker
      */
     protected function getSessionCounts()
     {
-        if (!is_null($this->storageFunction)) {
+        if (is_callable($this->storageFunction)) {
             return call_user_func($this->storageFunction, self::$SESSION_COUNTS_KEY);
-        } else {
-            return $this->sessionCounts;
         }
+
+        return $this->sessionCounts;
     }
 
     /**
@@ -311,11 +312,11 @@ class SessionTracker
      */
     protected function setSessionCounts(array $sessionCounts)
     {
-        if (!is_null($this->storageFunction)) {
+        if (is_callable($this->storageFunction)) {
             return call_user_func($this->storageFunction, self::$SESSION_COUNTS_KEY, $sessionCounts);
-        } else {
-            $this->sessionCounts = $sessionCounts;
         }
+
+        $this->sessionCounts = $sessionCounts;
     }
 
     /**
@@ -390,7 +391,7 @@ class SessionTracker
             }
         } catch (Exception $e) {
             error_log('Bugsnag Warning: Couldn\'t notify. '.$e->getMessage());
-            if (!is_null($this->retryFunction)) {
+            if (is_callable($this->retryFunction)) {
                 call_user_func($this->retryFunction, $sessions);
             } else {
                 foreach ($sessions as $minute => $count) {
@@ -406,7 +407,7 @@ class SessionTracker
     protected function setLastSent()
     {
         $time = time();
-        if (!is_null($this->storageFunction)) {
+        if (is_callable($this->storageFunction)) {
             call_user_func($this->storageFunction, self::$SESSIONS_LAST_SENT_KEY, $time);
         } else {
             $this->lastSent = $time;
@@ -418,10 +419,10 @@ class SessionTracker
      */
     protected function getLastSent()
     {
-        if (!is_null($this->storageFunction)) {
+        if (is_callable($this->storageFunction)) {
             return call_user_func($this->storageFunction, self::$SESSIONS_LAST_SENT_KEY);
-        } else {
-            return $this->lastSent;
         }
+
+        return $this->lastSent;
     }
 }

--- a/src/SessionTracker.php
+++ b/src/SessionTracker.php
@@ -313,7 +313,7 @@ class SessionTracker
     protected function setSessionCounts(array $sessionCounts)
     {
         if (is_callable($this->storageFunction)) {
-            return call_user_func($this->storageFunction, self::$SESSION_COUNTS_KEY, $sessionCounts);
+            call_user_func($this->storageFunction, self::$SESSION_COUNTS_KEY, $sessionCounts);
         }
 
         $this->sessionCounts = $sessionCounts;

--- a/src/SessionTracker.php
+++ b/src/SessionTracker.php
@@ -165,39 +165,39 @@ class SessionTracker
 
     public function setLockFunctions($lock, $unlock)
     {
-        if (is_callable($lock) && is_callable($unlock)) {
-            $this->lockFunction = $lock;
-            $this->unlockFunction = $unlock;
-        } else {
+        if (!is_callable($lock) || !is_callable($unlock)) {
             throw new InvalidArgumentException('Both lock and unlock functions must be callable');
         }
+
+        $this->lockFunction = $lock;
+        $this->unlockFunction = $unlock;
     }
 
     public function setRetryFunction($retry)
     {
-        if (is_callable($retry)) {
-            $this->retryFunction = $retry;
-        } else {
+        if (!is_callable($retry)) {
             throw new InvalidArgumentException('The retry function must be callable');
         }
+
+        $this->retryFunction = $retry;
     }
 
     public function setStorageFunction($function)
     {
-        if (is_callable($function)) {
-            $this->storageFunction = $function;
-        } else {
+        if (!is_callable($function)) {
             throw new InvalidArgumentException('Storage function must be callable');
         }
+
+        $this->storageFunction = $function;
     }
 
     public function setSessionFunction($function)
     {
-        if (is_callable($function)) {
-            $this->sessionFunction = $function;
-        } else {
+        if (!is_callable($function)) {
             throw new InvalidArgumentException('Session function must be callable');
         }
+
+        $this->sessionFunction = $function;
     }
 
     protected function incrementSessions($minute, $count = 1, $deliver = true)

--- a/src/SessionTracker.php
+++ b/src/SessionTracker.php
@@ -211,7 +211,7 @@ class SessionTracker
         try {
             $sessionCounts = $this->getSessionCounts();
 
-            if (is_null($sessionCounts)) {
+            if (!is_array($sessionCounts)) {
                 $sessionCounts = [];
             }
 

--- a/src/SessionTracker.php
+++ b/src/SessionTracker.php
@@ -229,7 +229,11 @@ class SessionTracker
 
             $lastSent = $this->getLastSent();
 
-            if ($deliver && ((time() - $lastSent) > self::$DELIVERY_INTERVAL)) {
+            if ($lastSent === null) {
+                $lastSent = 0;
+            }
+
+            if ($deliver && is_int($lastSent) && ((time() - $lastSent) > self::$DELIVERY_INTERVAL)) {
                 $this->deliverSessions();
             }
         } finally {

--- a/tests/SessionTrackerTest.php
+++ b/tests/SessionTrackerTest.php
@@ -3,7 +3,6 @@
 namespace Bugsnag\Tests;
 
 use Bugsnag\Configuration;
-use Bugsnag\HttpClient;
 use Bugsnag\SessionTracker;
 use GuzzleHttp\ClientInterface;
 use InvalidArgumentException;
@@ -17,8 +16,6 @@ class SessionTrackerTest extends TestCase
     private $sessionTracker;
     /** @var Configuration&MockObject */
     private $config;
-    /** @var HttpClient&MockObject */
-    private $httpClient;
     /** @var ClientInterface&MockObject */
     private $guzzleClient;
 
@@ -31,11 +28,6 @@ class SessionTrackerTest extends TestCase
 
         $this->sessionTracker = new SessionTracker($this->config);
 
-        $this->httpClient = $this->getMockBuilder(HttpClient::class)
-            ->disableOriginalConstructor()
-            ->setMethods(['post'])
-            ->getMock();
-
         $this->guzzleClient = $this->getMockBuilder(ClientInterface::class)
             ->getMock();
     }
@@ -43,7 +35,6 @@ class SessionTrackerTest extends TestCase
     public function testSendSessionsEmpty()
     {
         $this->config->expects($this->never())->method('getSessionClient');
-        $this->httpClient->expects($this->never())->method('post');
 
         $this->sessionTracker->sendSessions();
     }
@@ -67,7 +58,6 @@ class SessionTrackerTest extends TestCase
 
         $this->config->expects($this->once())->method('shouldNotify')->willReturn(false);
         $this->config->expects($this->never())->method('getSessionClient');
-        $this->httpClient->expects($this->never())->method('post');
 
         $this->sessionTracker->sendSessions();
 
@@ -113,7 +103,7 @@ class SessionTrackerTest extends TestCase
 
     public function testSendSessionsSuccessWhenCallingSendSessions()
     {
-        $this->sessionTracker->setStorageFunction(function ($key, $value = null) {
+        $this->sessionTracker->setStorageFunction(function () {
             return ['2000-01-01T00:00:00' => 1];
         });
 

--- a/tests/SessionTrackerTest.php
+++ b/tests/SessionTrackerTest.php
@@ -2,8 +2,8 @@
 
 namespace Bugsnag\Tests;
 
-use Bugsnag\HttpClient;
 use Bugsnag\Configuration;
+use Bugsnag\HttpClient;
 use Bugsnag\SessionTracker;
 use GuzzleHttp\ClientInterface;
 use PHPUnit\Framework\MockObject\MockObject;
@@ -51,7 +51,7 @@ class SessionTrackerTest extends TestCase
         $numberOfCalls = 0;
 
         $this->sessionTracker->setStorageFunction(function ($key, $value = null) use (&$numberOfCalls) {
-            ++$numberOfCalls;
+            $numberOfCalls++;
 
             if ($value === null) {
                 $this->assertSame(1, $numberOfCalls, 'Expected the first call to be a read ($value === null)');
@@ -74,6 +74,7 @@ class SessionTrackerTest extends TestCase
 
     /**
      * @param mixed $returnValue
+     *
      * @return void
      *
      * @dataProvider storageFunctionEmptyReturnValueProvider
@@ -104,7 +105,7 @@ class SessionTrackerTest extends TestCase
             'float' => [1.2],
             'bool (true)' => [true],
             'bool (false)' => [false],
-            'object' => [new stdClass],
+            'object' => [new stdClass()],
         ];
     }
 

--- a/tests/SessionTrackerTest.php
+++ b/tests/SessionTrackerTest.php
@@ -124,24 +124,28 @@ class SessionTrackerTest extends TestCase
         $this->config->expects($this->once())->method('getAppData')->willReturn('app_data');
         $this->config->expects($this->once())->method('getApiKey')->willReturn('example-api-key');
 
-        $this->guzzleClient->expects($this->once())
-            ->method($this->getGuzzleMethod())
-            ->with(
-                $this->equalTo('POST'),
-                $this->equalTo(''),
-                $this->callback(function ($sessionPayload) {
-                    return count($sessionPayload) == 2
-                        && $sessionPayload['json']['notifier'] === 'test_notifier'
-                        && $sessionPayload['json']['device'] === 'device_data'
-                        && $sessionPayload['json']['app'] === 'app_data'
-                        && count($sessionPayload['json']['sessionCounts']) === 1
-                        && $sessionPayload['json']['sessionCounts'][0]['startedAt'] === '2000-01-01T00:00:00'
-                        && $sessionPayload['json']['sessionCounts'][0]['sessionsStarted'] === 1
-                        && $sessionPayload['headers']['Bugsnag-Api-Key'] == 'example-api-key'
-                        && preg_match('/(\d+\.)+/', $sessionPayload['headers']['Bugsnag-Payload-Version'])
-                        && preg_match('/\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}/', $sessionPayload['headers']['Bugsnag-Sent-At']);
-                })
-            );
+        $expectCallback = function ($sessionPayload) {
+            return count($sessionPayload) == 2
+                && $sessionPayload['json']['notifier'] === 'test_notifier'
+                && $sessionPayload['json']['device'] === 'device_data'
+                && $sessionPayload['json']['app'] === 'app_data'
+                && count($sessionPayload['json']['sessionCounts']) === 1
+                && $sessionPayload['json']['sessionCounts'][0]['startedAt'] === '2000-01-01T00:00:00'
+                && $sessionPayload['json']['sessionCounts'][0]['sessionsStarted'] === 1
+                && $sessionPayload['headers']['Bugsnag-Api-Key'] == 'example-api-key'
+                && preg_match('/(\d+\.)+/', $sessionPayload['headers']['Bugsnag-Payload-Version'])
+                && preg_match('/\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}/', $sessionPayload['headers']['Bugsnag-Sent-At']);
+        };
+
+        if ($this->getGuzzleMethod() === 'post') {
+            $this->guzzleClient->expects($this->once())
+                ->method($this->getGuzzleMethod())
+                ->with('', $this->callback($expectCallback));
+        } else {
+            $this->guzzleClient->expects($this->once())
+                ->method($this->getGuzzleMethod())
+                ->with('POST', '', $this->callback($expectCallback));
+        }
 
         $this->sessionTracker->sendSessions();
     }
@@ -169,24 +173,28 @@ class SessionTrackerTest extends TestCase
         $this->config->expects($this->once())->method('getAppData')->willReturn('app_data');
         $this->config->expects($this->once())->method('getApiKey')->willReturn('example-api-key');
 
-        $this->guzzleClient->expects($this->once())
-            ->method($this->getGuzzleMethod())
-            ->with(
-                $this->equalTo('POST'),
-                $this->equalTo(''),
-                $this->callback(function ($sessionPayload) {
-                    return count($sessionPayload) == 2
-                        && $sessionPayload['json']['notifier'] === 'test_notifier'
-                        && $sessionPayload['json']['device'] === 'device_data'
-                        && $sessionPayload['json']['app'] === 'app_data'
-                        && count($sessionPayload['json']['sessionCounts']) === 1
-                        && preg_match('/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}$/', $sessionPayload['json']['sessionCounts'][0]['startedAt'])
-                        && $sessionPayload['json']['sessionCounts'][0]['sessionsStarted'] === 1
-                        && $sessionPayload['headers']['Bugsnag-Api-Key'] == 'example-api-key'
-                        && preg_match('/(\d+\.)+/', $sessionPayload['headers']['Bugsnag-Payload-Version'])
-                        && preg_match('/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}$/', $sessionPayload['headers']['Bugsnag-Sent-At']);
-                })
-            );
+        $expectCallback = function ($sessionPayload) {
+            return count($sessionPayload) == 2
+                && $sessionPayload['json']['notifier'] === 'test_notifier'
+                && $sessionPayload['json']['device'] === 'device_data'
+                && $sessionPayload['json']['app'] === 'app_data'
+                && count($sessionPayload['json']['sessionCounts']) === 1
+                && preg_match('/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}$/', $sessionPayload['json']['sessionCounts'][0]['startedAt'])
+                && $sessionPayload['json']['sessionCounts'][0]['sessionsStarted'] === 1
+                && $sessionPayload['headers']['Bugsnag-Api-Key'] == 'example-api-key'
+                && preg_match('/(\d+\.)+/', $sessionPayload['headers']['Bugsnag-Payload-Version'])
+                && preg_match('/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}$/', $sessionPayload['headers']['Bugsnag-Sent-At']);
+        };
+
+        if ($this->getGuzzleMethod() === 'post') {
+            $this->guzzleClient->expects($this->once())
+                ->method($this->getGuzzleMethod())
+                ->with('', $this->callback($expectCallback));
+        } else {
+            $this->guzzleClient->expects($this->once())
+                ->method($this->getGuzzleMethod())
+                ->with('POST', '', $this->callback($expectCallback));
+        }
 
         $this->sessionTracker->startSession();
     }

--- a/tests/SessionTrackerTest.php
+++ b/tests/SessionTrackerTest.php
@@ -2,71 +2,143 @@
 
 namespace Bugsnag\Tests;
 
+use Bugsnag\HttpClient;
 use Bugsnag\Configuration;
 use Bugsnag\SessionTracker;
+use GuzzleHttp\ClientInterface;
+use PHPUnit\Framework\MockObject\MockObject;
+use stdClass;
 
 class SessionTrackerTest extends TestCase
 {
-    protected $sessionTracker;
-    protected $config;
-    protected $http;
+    /** @var SessionTracker */
+    private $sessionTracker;
+    /** @var Configuration&MockObject */
+    private $config;
+    /** @var HttpClient&MockObject */
+    private $httpClient;
+    /** @var ClientInterface&MockObject */
+    private $guzzleClient;
 
-    protected function setUp()
+    public function setUp()
     {
+        /** @var Configuration&MockObject */
         $this->config = $this->getMockBuilder(Configuration::class)
-                            ->setConstructorArgs(['example-api-key'])
-                            ->getMock();
-        $this->sessionTracker = $this->getMockBuilder(SessionTracker::class)
-                             ->setMethods(['getSessionCounts', 'setLastSent'])
-                             ->setConstructorArgs([$this->config])
-                             ->getMock();
-        $this->http = $this->getMockBuilder(HttpClient::class)
-                            ->setMethods(['post'])
-                            ->getMock();
+            ->setConstructorArgs(['example-api-key'])
+            ->getMock();
+
+        $this->sessionTracker = new SessionTracker($this->config);
+
+        $this->httpClient = $this->getMockBuilder(HttpClient::class)
+            ->disableOriginalConstructor()
+            ->setMethods(['post'])
+            ->getMock();
+
+        $this->guzzleClient = $this->getMockBuilder(ClientInterface::class)
+            ->getMock();
     }
 
     public function testSendSessionsEmpty()
     {
-        $this->sessionTracker->expects($this->once())->method('getSessionCounts')->willReturn([]);
         $this->config->expects($this->never())->method('getSessionClient');
-        $this->http->expects($this->never())->method('post');
+        $this->httpClient->expects($this->never())->method('post');
 
         $this->sessionTracker->sendSessions();
     }
 
     public function testSendSessionsShouldNotNotify()
     {
-        $this->sessionTracker->expects($this->once())->method('getSessionCounts')->willReturn(['2000-01-01T00:00:00' => 1]);
+        $numberOfCalls = 0;
+
+        $this->sessionTracker->setStorageFunction(function ($key, $value = null) use (&$numberOfCalls) {
+            ++$numberOfCalls;
+
+            if ($value === null) {
+                $this->assertSame(1, $numberOfCalls, 'Expected the first call to be a read ($value === null)');
+
+                return ['2000-01-01T00:00:00' => 1];
+            }
+
+            $this->assertSame(2, $numberOfCalls, 'Expected the second call to be a write ($value === [])');
+            $this->assertSame([], $value, 'Expected the second call to be a write ($value === [])');
+        });
+
         $this->config->expects($this->once())->method('shouldNotify')->willReturn(false);
         $this->config->expects($this->never())->method('getSessionClient');
-        $this->http->expects($this->never())->method('post');
+        $this->httpClient->expects($this->never())->method('post');
+
+        $this->sessionTracker->sendSessions();
+
+        $this->assertSame(2, $numberOfCalls, 'Expected there to be two calls to the session storage function');
+    }
+
+    /**
+     * @param mixed $returnValue
+     * @return void
+     *
+     * @dataProvider storageFunctionEmptyReturnValueProvider
+     */
+    public function testSendSessionsReturnsEarlyWhenGetSessionCountsReturnsAValueThatsNotAPopulatedArray($returnValue)
+    {
+        $this->sessionTracker->setStorageFunction(function () use ($returnValue) {
+            return $returnValue;
+        });
+
+        $this->config->expects($this->never())->method('shouldNotify');
+        $this->config->expects($this->never())->method('getSessionClient');
+        $this->config->expects($this->never())->method('getNotifier');
+        $this->config->expects($this->never())->method('getDeviceData');
+        $this->config->expects($this->never())->method('getAppData');
+        $this->config->expects($this->never())->method('getApiKey');
+        $this->guzzleClient->expects($this->never())->method('request');
 
         $this->sessionTracker->sendSessions();
     }
 
-    public function testSendSessions()
+    public function storageFunctionEmptyReturnValueProvider()
     {
-        $this->sessionTracker->expects($this->once())->method('getSessionCounts')->willReturn(['2000-01-01T00:00:00' => 1]);
+        return [
+            'null' => [null],
+            'empty array' => [[]],
+            'int' => [1],
+            'float' => [1.2],
+            'bool (true)' => [true],
+            'bool (false)' => [false],
+            'object' => [new stdClass],
+        ];
+    }
+
+    public function testSendSessionsSuccess()
+    {
+        $this->sessionTracker->setStorageFunction(function ($key, $value = null) {
+            return ['2000-01-01T00:00:00' => 1];
+        });
+
         $this->config->expects($this->once())->method('shouldNotify')->willReturn(true);
-        $this->config->expects($this->once())->method('getSessionClient')->willReturn($this->http);
+        $this->config->expects($this->once())->method('getSessionClient')->willReturn($this->guzzleClient);
         $this->config->expects($this->once())->method('getNotifier')->willReturn('test_notifier');
         $this->config->expects($this->once())->method('getDeviceData')->willReturn('device_data');
         $this->config->expects($this->once())->method('getAppData')->willReturn('app_data');
         $this->config->expects($this->once())->method('getApiKey')->willReturn('example-api-key');
-        $this->sessionTracker->expects($this->once())->method('setLastSent');
 
-        $this->http->expects($this->once())->method('post')->with($this->equalTo(''), $this->callback(function ($sessionPayload) {
-            return count($sessionPayload) == 2
-                   && $sessionPayload['json']['notifier'] == 'test_notifier'
-                   && $sessionPayload['json']['device'] == 'device_data'
-                   && $sessionPayload['json']['app'] == 'app_data'
-                   && count($sessionPayload['json']['sessionCounts']) == 1
-                   && $sessionPayload['json']['sessionCounts'][0]['startedAt'] == '2000-01-01T00:00:00'
-                   && $sessionPayload['json']['sessionCounts'][0]['sessionsStarted'] == 1
-                   && $sessionPayload['headers']['Bugsnag-Api-Key'] == 'example-api-key'
-                   && preg_match('/(\d+\.)+/', $sessionPayload['headers']['Bugsnag-Payload-Version'])
-                   && preg_match('/\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}/', $sessionPayload['headers']['Bugsnag-Sent-At']);
-        }));
+        $this->guzzleClient->expects($this->once())
+            ->method('request')
+            ->with(
+                $this->equalTo('POST'),
+                $this->equalTo(''),
+                $this->callback(function ($sessionPayload) {
+                    return count($sessionPayload) == 2
+                        && $sessionPayload['json']['notifier'] === 'test_notifier'
+                        && $sessionPayload['json']['device'] === 'device_data'
+                        && $sessionPayload['json']['app'] === 'app_data'
+                        && count($sessionPayload['json']['sessionCounts']) === 1
+                        && $sessionPayload['json']['sessionCounts'][0]['startedAt'] === '2000-01-01T00:00:00'
+                        && $sessionPayload['json']['sessionCounts'][0]['sessionsStarted'] === 1
+                        && $sessionPayload['headers']['Bugsnag-Api-Key'] == 'example-api-key'
+                        && preg_match('/(\d+\.)+/', $sessionPayload['headers']['Bugsnag-Payload-Version'])
+                        && preg_match('/\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}/', $sessionPayload['headers']['Bugsnag-Sent-At']);
+                })
+            );
 
         $this->sessionTracker->sendSessions();
     }

--- a/tests/SessionTrackerTest.php
+++ b/tests/SessionTrackerTest.php
@@ -117,6 +117,30 @@ class SessionTrackerTest extends TestCase
         $this->sessionTracker->startSession();
     }
 
+    /**
+     * @param mixed $returnValue
+     *
+     * @return void
+     *
+     * @dataProvider storageFunctionEmptyReturnValueProvider
+     */
+    public function testStartSessionDoesNotDeliverSessionsWhenGetSessionCountsReturnsAValueThatsNotAPopulatedArray($returnValue)
+    {
+        $this->sessionTracker->setStorageFunction(function ($key) use ($returnValue) {
+            return $returnValue;
+        });
+
+        $this->config->expects($this->never())->method('shouldNotify');
+        $this->config->expects($this->never())->method('getSessionClient');
+        $this->config->expects($this->never())->method('getNotifier');
+        $this->config->expects($this->never())->method('getDeviceData');
+        $this->config->expects($this->never())->method('getAppData');
+        $this->config->expects($this->never())->method('getApiKey');
+        $this->guzzleClient->expects($this->never())->method($this->getGuzzleMethod());
+
+        $this->sessionTracker->startSession();
+    }
+
     public function storageFunctionEmptyReturnValueProvider()
     {
         return [

--- a/tests/SessionTrackerTest.php
+++ b/tests/SessionTrackerTest.php
@@ -91,7 +91,7 @@ class SessionTrackerTest extends TestCase
         $this->config->expects($this->never())->method('getDeviceData');
         $this->config->expects($this->never())->method('getAppData');
         $this->config->expects($this->never())->method('getApiKey');
-        $this->guzzleClient->expects($this->never())->method('request');
+        $this->guzzleClient->expects($this->never())->method($this->getGuzzleMethod());
 
         $this->sessionTracker->sendSessions();
     }
@@ -123,7 +123,7 @@ class SessionTrackerTest extends TestCase
         $this->config->expects($this->once())->method('getApiKey')->willReturn('example-api-key');
 
         $this->guzzleClient->expects($this->once())
-            ->method('request')
+            ->method($this->getGuzzleMethod())
             ->with(
                 $this->equalTo('POST'),
                 $this->equalTo(''),
@@ -168,7 +168,7 @@ class SessionTrackerTest extends TestCase
         $this->config->expects($this->once())->method('getApiKey')->willReturn('example-api-key');
 
         $this->guzzleClient->expects($this->once())
-            ->method('request')
+            ->method($this->getGuzzleMethod())
             ->with(
                 $this->equalTo('POST'),
                 $this->equalTo(''),

--- a/tests/SessionTrackerTest.php
+++ b/tests/SessionTrackerTest.php
@@ -191,21 +191,21 @@ class SessionTrackerTest extends TestCase
 
     public function testSetLockFunctionsThrowsWhenBothFunctionsAreNotCallable()
     {
-        $this->expectExceptionObject(new InvalidArgumentException('Both lock and unlock functions must be callable'));
+        $this->expectedException(InvalidArgumentException::class, 'Both lock and unlock functions must be callable');
 
         $this->sessionTracker->setLockFunctions(null, function () {});
     }
 
     public function testSetLockFunctionsThrowsWhenLockIsNotCallable()
     {
-        $this->expectExceptionObject(new InvalidArgumentException('Both lock and unlock functions must be callable'));
+        $this->expectedException(InvalidArgumentException::class, 'Both lock and unlock functions must be callable');
 
         $this->sessionTracker->setLockFunctions(null, function () {});
     }
 
     public function testSetLockFunctionsThrowsWhenUnlockIsNotCallable()
     {
-        $this->expectExceptionObject(new InvalidArgumentException('Both lock and unlock functions must be callable'));
+        $this->expectedException(InvalidArgumentException::class, 'Both lock and unlock functions must be callable');
 
         $this->sessionTracker->setLockFunctions(function () {}, null);
     }
@@ -290,21 +290,21 @@ class SessionTrackerTest extends TestCase
 
     public function testSetRetryFunctionThrowsWhenNotGivenACallable()
     {
-        $this->expectExceptionObject(new InvalidArgumentException('The retry function must be callable'));
+        $this->expectedException(InvalidArgumentException::class, 'The retry function must be callable');
 
         $this->sessionTracker->setRetryFunction(null);
     }
 
     public function testSetStorageFunctionThrowsWhenNotGivenACallable()
     {
-        $this->expectExceptionObject(new InvalidArgumentException('Storage function must be callable'));
+        $this->expectedException(InvalidArgumentException::class, 'Storage function must be callable');
 
         $this->sessionTracker->setStorageFunction(null);
     }
 
     public function testSetSessionFunctionThrowsWhenNotGivenACallable()
     {
-        $this->expectExceptionObject(new InvalidArgumentException('Session function must be callable'));
+        $this->expectedException(InvalidArgumentException::class, 'Session function must be callable');
 
         $this->sessionTracker->setSessionFunction(null);
     }

--- a/tests/SessionTrackerTest.php
+++ b/tests/SessionTrackerTest.php
@@ -88,6 +88,35 @@ class SessionTrackerTest extends TestCase
         $this->sessionTracker->sendSessions();
     }
 
+    /**
+     * @param mixed $returnValue
+     *
+     * @return void
+     *
+     * @dataProvider storageFunctionEmptyReturnValueProvider
+     */
+    public function testStartSessionDoesNotDeliverSessionsWhenLastSentIsNotAnInteger($returnValue)
+    {
+        $this->sessionTracker->setStorageFunction(function ($key) use ($returnValue) {
+            // We only care about the "last sent" value here
+            if ($key === 'bugsnag-sessions-last-sent') {
+                return $returnValue;
+            }
+
+            return null;
+        });
+
+        $this->config->expects($this->never())->method('shouldNotify');
+        $this->config->expects($this->never())->method('getSessionClient');
+        $this->config->expects($this->never())->method('getNotifier');
+        $this->config->expects($this->never())->method('getDeviceData');
+        $this->config->expects($this->never())->method('getAppData');
+        $this->config->expects($this->never())->method('getApiKey');
+        $this->guzzleClient->expects($this->never())->method($this->getGuzzleMethod());
+
+        $this->sessionTracker->startSession();
+    }
+
     public function storageFunctionEmptyReturnValueProvider()
     {
         return [
@@ -101,7 +130,7 @@ class SessionTrackerTest extends TestCase
         ];
     }
 
-    public function testSendSessionsSuccessWhenCallingSendSessions()
+    public function testSendSessionsSuccess()
     {
         $this->sessionTracker->setStorageFunction(function () {
             return ['2000-01-01T00:00:00' => 1];
@@ -140,7 +169,7 @@ class SessionTrackerTest extends TestCase
         $this->sessionTracker->sendSessions();
     }
 
-    public function testSendSessionsSuccessWhenCallingStartSession()
+    public function testStartSessionsSuccess()
     {
         $session = [];
 

--- a/tests/SessionTrackerTest.php
+++ b/tests/SessionTrackerTest.php
@@ -297,4 +297,25 @@ class SessionTrackerTest extends TestCase
         $this->assertTrue($lockWasCalled, 'Expected the `lockFunction` to be called');
         $this->assertTrue($unlockWasCalled, 'Expected the `unlockFunction` to be called');
     }
+
+    public function testSetRetryFunctionThrowsWhenNotGivenACallable()
+    {
+        $this->expectExceptionObject(new InvalidArgumentException('The retry function must be callable'));
+
+        $this->sessionTracker->setRetryFunction(null);
+    }
+
+    public function testSetStorageFunctionThrowsWhenNotGivenACallable()
+    {
+        $this->expectExceptionObject(new InvalidArgumentException('Storage function must be callable'));
+
+        $this->sessionTracker->setStorageFunction(null);
+    }
+
+    public function testSetSessionFunctionThrowsWhenNotGivenACallable()
+    {
+        $this->expectExceptionObject(new InvalidArgumentException('Session function must be callable'));
+
+        $this->sessionTracker->setSessionFunction(null);
+    }
 }

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -2,6 +2,7 @@
 
 namespace Bugsnag\Tests;
 
+use Exception;
 use GrahamCampbell\TestBenchCore\MockeryTrait;
 use GuzzleHttp\Client as Guzzle;
 use GuzzleHttp\ClientInterface;
@@ -15,15 +16,18 @@ abstract class TestCase extends BaseTestCase
     use PHPMock;
     use MockeryTrait;
 
-    public function expectedException($class, $msg = null)
+    public function expectedException($class, $message = null)
     {
         if (class_exists(\PHPUnit_Framework_TestCase::class)) {
-            $this->setExpectedException($class, $msg);
-        } else {
-            $this->expectException($class);
-            if ($msg !== null) {
-                $this->expectExceptionMessage($msg);
-            }
+            $this->setExpectedException($class, $message);
+
+            return;
+        }
+
+        $this->expectException($class);
+
+        if ($message !== null) {
+            $this->expectExceptionMessage($message);
         }
     }
 

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -2,7 +2,6 @@
 
 namespace Bugsnag\Tests;
 
-use Exception;
 use GrahamCampbell\TestBenchCore\MockeryTrait;
 use GuzzleHttp\Client as Guzzle;
 use GuzzleHttp\ClientInterface;


### PR DESCRIPTION
## Goal

<!-- What is the intent of this change?
e.g. "When initializing the Bugsnag client, it is currently difficult to (...)
      this change simplifies the process by (...)"

     "Improves the performance of data filtering"

     "Adds additional test coverage to multi-threaded use of Configuration
      objects"
-->

Fix a warning being raised when a session storage function returns `null` on PHP versions >=7.2 — see #557

## Changeset

### Added

- More tests for `SessionTracker`

### Changed

- `SessionTracker::deliverSessions` now checks if the return value from the session storage function is an array before calling `count` on it
- `SessionTracker::incrementSessions` now checks the return value from the session storage function is an array before calling `array_key_exists` on it
- `SessionTracker::incrementSessions` also checks the return value for "last sent" is an integer before doing maths with it, though we specifically cast `null` to `0` to keep the previous behaviour with `null` values
    I think this is a safe change because our code should be the only place this value is set (`setLastSent`), so this should only be a change in behaviour for incorrectly implemented `storageFunction` callbacks
- `SessionTracker` didn't import `Exception` or `InvalidArgumentException`
    This means none of the `setXFunction` methods would throw if given invalid parameters (they'd crash due to no `Bugsnag\InvalidArgumentException` class existing instead)
    It also means we wouldn't catch exceptions when `deliverSessions` was called, so the retry functionality wasn't working correctly
- Some of the namespaces for returned Guzzle `Client` objects have been updated
- StyleCI is failing on master so the suggested fixes have been applied on this branch (in 1364246ff0316ebe4114c93b1059d0bdd20e34de)

## Tests

- I've added a test for non-array return values for `getSessionCounts` to make sure the fix is working — these will fail if the warning was still being raised
- I improved the tests to avoid mocking the `SessionTracker` class itself, as it's the class being tested
- I've also added a test for when `startSession` is called, which is mostly the same as `sendSessions` but the session is pre-populated

## Discussion

### Alternative Approaches

<!-- What other approaches were considered or discussed? -->

### Outstanding Questions

<!-- Are there any parts of the design or the implementation which seem
     less than ideal and that could require additional discussion?
     List here: -->

- The return value of `Configuration::getSessionClient` is `GuzzleHttp\ClientInterface` which no longer has a `post` method available (as of Guzzle v6)
    This means we need to check whether it exists or not, to know which version we're on and therefore which method to call
    We could change the return type to the concrete `GuzzleHttp\Client` class instead, which has a `post` method in v7, v6 and v5 of Guzzle

### Linked issues

Fixes #557 
Supersedes https://github.com/bugsnag/bugsnag-laravel/pull/378 and https://github.com/bugsnag/bugsnag-php/pull/561

## Review

<!-- When submitting for review, consider the points for self-review and the
     criteria which will be used for secondary review -->

For the submitter, initial self-review:

- [x] Commented on code changes inline explain the reasoning behind the approach
- [x] Reviewed the test cases added for completeness and possible points for discussion
- [ ] A changelog entry was added for the goal of this pull request
- [x] Check the scope of the changeset - is everything in the diff required for the pull request?
- This pull request is ready for:
  - [x] Initial review of the intended approach, not yet feature complete
  - [x] Structural review of the classes, functions, and properties modified
  - [x] Final review

For the pull request reviewer(s), this changeset has been reviewed for:

- [ ] Consistency across platforms for structures or concepts added or modified
- [ ] Consistency between the changeset and the goal stated above
- [ ] Internal consistency with the rest of the library - is there any overlap between existing interfaces and any which have been added?
- [ ] Usage friction - is the proposed change in usage cumbersome or complicated?
- [ ] Performance and complexity - are there any cases of unexpected O(n^3) when iterating, recursing, flat mapping, etc?
- [ ] Concurrency concerns - if components are accessed asynchronously, what issues will arise
- [ ] Thoroughness of added tests and any missing edge cases
- [ ] Idiomatic use of the language
