### PR TITLE
Add caching abstraction around PSR-6, PSR-16 and Doctrine Cache

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -64,8 +64,8 @@ before_install:
   - travis_retry composer require "guzzlehttp/guzzle:${GUZZLE_VERSION}" --no-update
 
 install:
-  - if [[ $TRAVIS_PHP_VERSION == 5.5.9 ]]; then travis_retry composer update --no-interaction --prefer-source --prefer-lowest ; fi
-  - if [[ $TRAVIS_PHP_VERSION != 5.5.9 ]]; then travis_retry composer update --no-interaction --prefer-source ; fi
+  - if [[ $TRAVIS_PHP_VERSION == 5.5.9 ]]; then travis_retry composer update --no-interaction --prefer-dist --prefer-lowest ; fi
+  - if [[ $TRAVIS_PHP_VERSION != 5.5.9 ]]; then travis_retry composer update --no-interaction --prefer-dist ; fi
   - composer show --direct
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -66,6 +66,7 @@ before_install:
 install:
   - if [[ $TRAVIS_PHP_VERSION == 5.5.9 ]]; then travis_retry composer update --no-interaction --prefer-source --prefer-lowest ; fi
   - if [[ $TRAVIS_PHP_VERSION != 5.5.9 ]]; then travis_retry composer update --no-interaction --prefer-source ; fi
+  - composer show --direct
 
 script:
   - make test

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
         "guzzlehttp/psr7": "^1.3",
         "mockery/mockery": "^0.9.4|^1.3.1",
         "mtdowling/burgomaster": "dev-master#72151eddf5f0cf101502b94bf5031f9c53501a04",
-        "phpunit/phpunit": "^4.8.36|^7.5.15",
+        "phpunit/phpunit": "^4.8.36|^6.5.14|^7.5.15",
         "php-mock/php-mock-phpunit": "^1.1|^2.1",
         "psr/simple-cache": "^1.0",
         "psr/cache": "^1.0",

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,8 @@
         "mockery/mockery": "^0.9.4|^1.3.1",
         "mtdowling/burgomaster": "dev-master#72151eddf5f0cf101502b94bf5031f9c53501a04",
         "phpunit/phpunit": "^4.8.36|^7.5.15",
-        "php-mock/php-mock-phpunit": "^1.1|^2.1"
+        "php-mock/php-mock-phpunit": "^1.1|^2.1",
+        "psr/simple-cache": "^1.0"
     },
     "autoload": {
         "psr-4" : {

--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,8 @@
         "phpunit/phpunit": "^4.8.36|^7.5.15",
         "php-mock/php-mock-phpunit": "^1.1|^2.1",
         "psr/simple-cache": "^1.0",
-        "psr/cache": "^1.0"
+        "psr/cache": "^1.0",
+        "doctrine/cache": "^1.6"
     },
     "autoload": {
         "psr-4" : {

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,8 @@
         "mtdowling/burgomaster": "dev-master#72151eddf5f0cf101502b94bf5031f9c53501a04",
         "phpunit/phpunit": "^4.8.36|^7.5.15",
         "php-mock/php-mock-phpunit": "^1.1|^2.1",
-        "psr/simple-cache": "^1.0"
+        "psr/simple-cache": "^1.0",
+        "psr/cache": "^1.0"
     },
     "autoload": {
         "psr-4" : {

--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,8 @@
         "php-mock/php-mock-phpunit": "^1.1|^2.1",
         "psr/simple-cache": "^1.0",
         "psr/cache": "^1.0",
-        "doctrine/cache": "^1.6"
+        "doctrine/cache": "^1.6",
+        "sebastian/version": ">=1.0.3"
     },
     "autoload": {
         "psr-4" : {

--- a/src/Cache/Adapter/CacheAdapterInterface.php
+++ b/src/Cache/Adapter/CacheAdapterInterface.php
@@ -5,6 +5,11 @@ namespace Bugsnag\Cache\Adapter;
 interface CacheAdapterInterface
 {
     /**
+     * One hour in seconds (60 * 60 * 24).
+     */
+    const ONE_HOUR = 86400;
+
+    /**
      * Fetches a value from the cache.
      *
      * @param string $key
@@ -19,8 +24,11 @@ interface CacheAdapterInterface
      *
      * @param string $key
      * @param mixed  $value
+     * @param int    $ttl   How long this entry should be stored, in seconds.
+     *                      '0' is not treated as special, instead it means the
+     *                      value expires in 0 seconds (i.e. immediately).
      *
      * @return bool
      */
-    public function set($key, $value);
+    public function set($key, $value, $ttl = self::ONE_HOUR);
 }

--- a/src/Cache/Adapter/CacheAdapterInterface.php
+++ b/src/Cache/Adapter/CacheAdapterInterface.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Bugsnag\Cache\Adapter;
+
+interface CacheAdapterInterface
+{
+    /**
+     * Fetches a value from the cache.
+     *
+     * @param string $key
+     * @param mixed  $default
+     *
+     * @return mixed The cached item, or $default if the key was not found
+     */
+    public function get($key, $default = null);
+
+    /**
+     * Persists a value to the cache.
+     *
+     * @param string $key
+     * @param mixed  $value
+     *
+     * @return bool
+     */
+    public function set($key, $value);
+}

--- a/src/Cache/Adapter/DoctrineCacheAdapter.php
+++ b/src/Cache/Adapter/DoctrineCacheAdapter.php
@@ -38,8 +38,8 @@ final class DoctrineCacheAdapter implements CacheAdapterInterface
             }
 
             return $value;
-        } catch (Throwable $e) {
         } catch (Exception $e) {
+        } catch (Throwable $e) {
         }
 
         return $default;
@@ -49,8 +49,8 @@ final class DoctrineCacheAdapter implements CacheAdapterInterface
     {
         try {
             return $this->cache->save($key, $value);
-        } catch (Throwable $e) {
         } catch (Exception $e) {
+        } catch (Throwable $e) {
         }
 
         return false;

--- a/src/Cache/Adapter/DoctrineCacheAdapter.php
+++ b/src/Cache/Adapter/DoctrineCacheAdapter.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace Bugsnag\Cache\Adapter;
+
+use Doctrine\Common\Cache\Cache as DoctrineCache;
+
+final class DoctrineCacheAdapter implements CacheAdapterInterface
+{
+    /**
+     * @var DoctrineCache
+     */
+    private $cache;
+
+    public function __construct(DoctrineCache $cache)
+    {
+        $this->cache = $cache;
+    }
+
+    public function get($key, $default = null)
+    {
+        $value = $this->cache->fetch($key);
+
+        if ($value === false) {
+            // Doctrine Cache specifies returning false if a key is not found.
+            // However, 'false' is a possible value to cache so we need to make
+            // sure the key doesn't exist
+            // TODO we probably don't need to store 'false' in the cache so can
+            //      probably get away without doing this — this would save a
+            //      second round trip to the cache
+            if ($this->cache->contains($key)) {
+                return false;
+            }
+
+            return $default;
+        }
+
+        return $value;
+    }
+
+    public function set($key, $value)
+    {
+        return $this->cache->save($key, $value);
+    }
+}

--- a/src/Cache/Adapter/DoctrineCacheAdapter.php
+++ b/src/Cache/Adapter/DoctrineCacheAdapter.php
@@ -3,6 +3,8 @@
 namespace Bugsnag\Cache\Adapter;
 
 use Doctrine\Common\Cache\Cache as DoctrineCache;
+use Exception;
+use Throwable;
 
 final class DoctrineCacheAdapter implements CacheAdapterInterface
 {
@@ -18,27 +20,39 @@ final class DoctrineCacheAdapter implements CacheAdapterInterface
 
     public function get($key, $default = null)
     {
-        $value = $this->cache->fetch($key);
+        try {
+            $value = $this->cache->fetch($key);
 
-        if ($value === false) {
-            // Doctrine Cache specifies returning false if a key is not found.
-            // However, 'false' is a possible value to cache so we need to make
-            // sure the key doesn't exist
-            // TODO we probably don't need to store 'false' in the cache so can
-            //      probably get away without doing this — this would save a
-            //      second round trip to the cache
-            if ($this->cache->contains($key)) {
-                return false;
+            if ($value === false) {
+                // Doctrine Cache specifies returning false if a key is not
+                // found. However, 'false' is a possible value to cache so we
+                // need to make sure the key doesn't exist
+                // TODO we probably don't need to store 'false' in the cache so
+                //      can probably get away without doing this — this would
+                //      save a second round trip to the cache
+                if ($this->cache->contains($key)) {
+                    return false;
+                }
+
+                return $default;
             }
 
-            return $default;
+            return $value;
+        } catch (Throwable $e) {
+        } catch (Exception $e) {
         }
 
-        return $value;
+        return $default;
     }
 
     public function set($key, $value)
     {
-        return $this->cache->save($key, $value);
+        try {
+            return $this->cache->save($key, $value);
+        } catch (Throwable $e) {
+        } catch (Exception $e) {
+        }
+
+        return false;
     }
 }

--- a/src/Cache/Adapter/Psr16Adapter.php
+++ b/src/Cache/Adapter/Psr16Adapter.php
@@ -2,8 +2,9 @@
 
 namespace Bugsnag\Cache\Adapter;
 
+use Exception;
 use Psr\SimpleCache\CacheInterface;
-use Psr\SimpleCache\InvalidArgumentException;
+use Throwable;
 
 final class Psr16Adapter implements CacheAdapterInterface
 {
@@ -21,17 +22,21 @@ final class Psr16Adapter implements CacheAdapterInterface
     {
         try {
             return $this->cache->get($key, $default);
-        } catch (InvalidArgumentException $e) {
-            return $default;
+        } catch (Throwable $e) {
+        } catch (Exception $e) {
         }
+
+        return $default;
     }
 
     public function set($key, $value)
     {
         try {
             return $this->cache->set($key, $value);
-        } catch (InvalidArgumentException $e) {
-            return false;
+        } catch (Throwable $e) {
+        } catch (Exception $e) {
         }
+
+        return false;
     }
 }

--- a/src/Cache/Adapter/Psr16Adapter.php
+++ b/src/Cache/Adapter/Psr16Adapter.php
@@ -29,10 +29,18 @@ final class Psr16Adapter implements CacheAdapterInterface
         return $default;
     }
 
-    public function set($key, $value)
+    public function set($key, $value, $ttl = self::ONE_HOUR)
     {
         try {
-            return $this->cache->set($key, $value);
+            // Reset a null TTL to our default. There is no specification for
+            // what libraries should do when given null, so we can't be sure
+            // that forwarding it on is OK. Instead we sidestep the issue by
+            // using a sensible default
+            if (!is_int($ttl)) {
+                $ttl = self::ONE_HOUR;
+            }
+
+            return $this->cache->set($key, $value, $ttl);
         } catch (Exception $e) {
         } catch (Throwable $e) {
         }

--- a/src/Cache/Adapter/Psr16Adapter.php
+++ b/src/Cache/Adapter/Psr16Adapter.php
@@ -22,8 +22,8 @@ final class Psr16Adapter implements CacheAdapterInterface
     {
         try {
             return $this->cache->get($key, $default);
-        } catch (Throwable $e) {
         } catch (Exception $e) {
+        } catch (Throwable $e) {
         }
 
         return $default;
@@ -33,8 +33,8 @@ final class Psr16Adapter implements CacheAdapterInterface
     {
         try {
             return $this->cache->set($key, $value);
-        } catch (Throwable $e) {
         } catch (Exception $e) {
+        } catch (Throwable $e) {
         }
 
         return false;

--- a/src/Cache/Adapter/Psr16Adapter.php
+++ b/src/Cache/Adapter/Psr16Adapter.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Bugsnag\Cache\Adapter;
+
+use Psr\SimpleCache\CacheInterface;
+use Psr\SimpleCache\InvalidArgumentException;
+
+final class Psr16Adapter implements CacheAdapterInterface
+{
+    /**
+     * @var CacheInterface
+     */
+    private $cache;
+
+    public function __construct(CacheInterface $cache)
+    {
+        $this->cache = $cache;
+    }
+
+    public function get($key, $default = null)
+    {
+        try {
+            return $this->cache->get($key, $default);
+        } catch (InvalidArgumentException $e) {
+            return $default;
+        }
+    }
+
+    public function set($key, $value)
+    {
+        try {
+            return $this->cache->set($key, $value);
+        } catch (InvalidArgumentException $e) {
+            return false;
+        }
+    }
+}

--- a/src/Cache/Adapter/Psr6Adapter.php
+++ b/src/Cache/Adapter/Psr6Adapter.php
@@ -2,7 +2,9 @@
 
 namespace Bugsnag\Cache\Adapter;
 
+use Exception;
 use Psr\Cache\CacheItemPoolInterface;
+use Throwable;
 
 final class Psr6Adapter implements CacheAdapterInterface
 {
@@ -18,10 +20,14 @@ final class Psr6Adapter implements CacheAdapterInterface
 
     public function get($key, $default = null)
     {
-        $item = $this->cache->getItem($key);
+        try {
+            $item = $this->cache->getItem($key);
 
-        if ($item->isHit()) {
-            return $item->get();
+            if ($item->isHit()) {
+                return $item->get();
+            }
+        } catch (Throwable $e) {
+        } catch (Exception $e) {
         }
 
         return $default;
@@ -29,9 +35,15 @@ final class Psr6Adapter implements CacheAdapterInterface
 
     public function set($key, $value)
     {
-        $item = $this->cache->getItem($key);
-        $item->set($value);
+        try {
+            $item = $this->cache->getItem($key);
+            $item->set($value);
 
-        return $this->cache->save($item);
+            return $this->cache->save($item);
+        } catch (Throwable $e) {
+        } catch (Exception $e) {
+        }
+
+        return false;
     }
 }

--- a/src/Cache/Adapter/Psr6Adapter.php
+++ b/src/Cache/Adapter/Psr6Adapter.php
@@ -33,11 +33,21 @@ final class Psr6Adapter implements CacheAdapterInterface
         return $default;
     }
 
-    public function set($key, $value)
+    public function set($key, $value, $ttl = self::ONE_HOUR)
     {
         try {
             $item = $this->cache->getItem($key);
             $item->set($value);
+
+            // Reset a null TTL to our default. There is no specification for
+            // what libraries should do when given null, so we can't be sure
+            // that forwarding it on is OK. Instead we sidestep the issue by
+            // using a sensible default
+            if (!is_int($ttl)) {
+                $ttl = self::ONE_HOUR;
+            }
+
+            $item->expiresAfter($ttl);
 
             return $this->cache->save($item);
         } catch (Exception $e) {

--- a/src/Cache/Adapter/Psr6Adapter.php
+++ b/src/Cache/Adapter/Psr6Adapter.php
@@ -26,8 +26,8 @@ final class Psr6Adapter implements CacheAdapterInterface
             if ($item->isHit()) {
                 return $item->get();
             }
-        } catch (Throwable $e) {
         } catch (Exception $e) {
+        } catch (Throwable $e) {
         }
 
         return $default;
@@ -40,8 +40,8 @@ final class Psr6Adapter implements CacheAdapterInterface
             $item->set($value);
 
             return $this->cache->save($item);
-        } catch (Throwable $e) {
         } catch (Exception $e) {
+        } catch (Throwable $e) {
         }
 
         return false;

--- a/src/Cache/Adapter/Psr6Adapter.php
+++ b/src/Cache/Adapter/Psr6Adapter.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Bugsnag\Cache\Adapter;
+
+use Psr\Cache\CacheItemPoolInterface;
+
+final class Psr6Adapter implements CacheAdapterInterface
+{
+    /**
+     * @var CacheItemPoolInterface
+     */
+    private $cache;
+
+    public function __construct(CacheItemPoolInterface $cache)
+    {
+        $this->cache = $cache;
+    }
+
+    public function get($key, $default = null)
+    {
+        $item = $this->cache->getItem($key);
+
+        if ($item->isHit()) {
+            return $item->get();
+        }
+
+        return $default;
+    }
+
+    public function set($key, $value)
+    {
+        $item = $this->cache->getItem($key);
+        $item->set($value);
+
+        return $this->cache->save($item);
+    }
+}

--- a/src/Cache/CacheFactory.php
+++ b/src/Cache/CacheFactory.php
@@ -3,8 +3,10 @@
 namespace Bugsnag\Cache;
 
 use Bugsnag\Cache\Adapter\CacheAdapterInterface;
+use Bugsnag\Cache\Adapter\DoctrineCacheAdapter;
 use Bugsnag\Cache\Adapter\Psr16Adapter;
 use Bugsnag\Cache\Adapter\Psr6Adapter;
+use Doctrine\Common\Cache\Cache as DoctrineCache;
 use InvalidArgumentException;
 use Psr\Cache\CacheItemPoolInterface as Psr6CacheInterface;
 use Psr\SimpleCache\CacheInterface as Psr16CacheInterface;
@@ -12,7 +14,7 @@ use Psr\SimpleCache\CacheInterface as Psr16CacheInterface;
 final class CacheFactory
 {
     /**
-     * @param Psr16CacheInterface|Psr6CacheInterface $cache
+     * @param Psr16CacheInterface|Psr6CacheInterface|DoctrineCache $cache
      *
      * @return CacheAdapterInterface
      */
@@ -26,13 +28,18 @@ final class CacheFactory
             return new Psr6Adapter($cache);
         }
 
+        if ($cache instanceof DoctrineCache) {
+            return new DoctrineCacheAdapter($cache);
+        }
+
         throw new InvalidArgumentException(
             sprintf(
-                '%s::%s expects an instance of "%s" or "%s", got "%s"',
+                '%s::%s expects an instance of "%s", "%s" or "%s", got "%s"',
                 self::class,
                 __METHOD__,
                 Psr6CacheInterface::class,
                 Psr16CacheInterface::class,
+                DoctrineCache::class,
                 is_object($cache) ? get_class($cache) : gettype($cache)
             )
         );

--- a/src/Cache/CacheFactory.php
+++ b/src/Cache/CacheFactory.php
@@ -4,30 +4,37 @@ namespace Bugsnag\Cache;
 
 use Bugsnag\Cache\Adapter\CacheAdapterInterface;
 use Bugsnag\Cache\Adapter\Psr16Adapter;
+use Bugsnag\Cache\Adapter\Psr6Adapter;
 use InvalidArgumentException;
+use Psr\Cache\CacheItemPoolInterface as Psr6CacheInterface;
 use Psr\SimpleCache\CacheInterface as Psr16CacheInterface;
 
 final class CacheFactory
 {
     /**
-     * @param Psr16CacheInterface $cache
+     * @param Psr16CacheInterface|Psr6CacheInterface $cache
      *
      * @return CacheAdapterInterface
      */
     public function create($cache)
     {
-        if (!$cache instanceof Psr16CacheInterface) {
-            throw new InvalidArgumentException(
-                sprintf(
-                    '%s::%s expects an instance of "%s", got "%s"',
-                    self::class,
-                    __METHOD__,
-                    Psr16CacheInterface::class,
-                    is_object($cache) ? get_class($cache) : gettype($cache)
-                )
-            );
+        if ($cache instanceof Psr16CacheInterface) {
+            return new Psr16Adapter($cache);
         }
 
-        return new Psr16Adapter($cache);
+        if ($cache instanceof Psr6CacheInterface) {
+            return new Psr6Adapter($cache);
+        }
+
+        throw new InvalidArgumentException(
+            sprintf(
+                '%s::%s expects an instance of "%s" or "%s", got "%s"',
+                self::class,
+                __METHOD__,
+                Psr6CacheInterface::class,
+                Psr16CacheInterface::class,
+                is_object($cache) ? get_class($cache) : gettype($cache)
+            )
+        );
     }
 }

--- a/src/Cache/CacheFactory.php
+++ b/src/Cache/CacheFactory.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Bugsnag\Cache;
+
+use Bugsnag\Cache\Adapter\CacheAdapterInterface;
+use Bugsnag\Cache\Adapter\Psr16Adapter;
+use InvalidArgumentException;
+use Psr\SimpleCache\CacheInterface as Psr16CacheInterface;
+
+final class CacheFactory
+{
+    /**
+     * @param Psr16CacheInterface $cache
+     *
+     * @return CacheAdapterInterface
+     */
+    public function create($cache)
+    {
+        if (!$cache instanceof Psr16CacheInterface) {
+            throw new InvalidArgumentException(
+                sprintf(
+                    '%s::%s expects an instance of "%s", got "%s"',
+                    self::class,
+                    __METHOD__,
+                    Psr16CacheInterface::class,
+                    is_object($cache) ? get_class($cache) : gettype($cache)
+                )
+            );
+        }
+
+        return new Psr16Adapter($cache);
+    }
+}

--- a/tests/Cache/Adapter/AdapterTest.php
+++ b/tests/Cache/Adapter/AdapterTest.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace Bugsnag\Tests\Cache\Adapter;
+
+use Bugsnag\Cache\Adapter\CacheAdapterInterface;
+use Bugsnag\Tests\TestCase;
+
+/**
+ * An abstract test class to ensure all adapters work identically.
+ */
+abstract class AdapterTest extends TestCase
+{
+    /**
+     * @return CacheAdapterInterface
+     */
+    abstract protected function getAdapter();
+
+    public function testAdapter()
+    {
+        $adapter = $this->getAdapter();
+
+        $adapter->set('hello', 'world');
+        $this->assertSame('world', $adapter->get('hello'));
+
+        $adapter->set('key', 'value');
+        $this->assertSame('value', $adapter->get('key'));
+
+        $adapter->set('hello', 'goodbye');
+        $this->assertSame('goodbye', $adapter->get('hello'));
+        $this->assertSame('value', $adapter->get('key'));
+
+        $this->assertSame(null, $adapter->get('does not exist'));
+        $this->assertSame(123, $adapter->get('also does not exist', 123));
+        $this->assertSame(false, $adapter->get('does not exist too', false));
+        $this->assertSame($this, $adapter->get('definitely does not exist', $this));
+
+        $this->assertFalse($adapter->set([], 'abc'));
+        $this->assertFalse($adapter->set($this, 'abc'));
+
+        $this->assertSame(null, $adapter->get([]));
+        $this->assertSame(false, $adapter->get([], false));
+        $this->assertSame('hello', $adapter->get([], 'hello'));
+        $this->assertSame(null, $adapter->get($this));
+        $this->assertSame(false, $adapter->get($this, false));
+        $this->assertSame('hello', $adapter->get($this, 'hello'));
+    }
+
+    final public function adapterProvider()
+    {
+        $manuallyInstantiated = $this->getAdapter();
+
+        $factory = new CacheFactory();
+        $factoryInstantiated = $factory->create($this->getImplementation());
+
+        // Sanity check we're doing the right thing in the concrete test class
+        $this->assertInstanceOf(
+            get_class($manuallyInstantiated),
+            $factoryInstantiated
+        );
+
+        return [
+            'manually instantiated' => [$manuallyInstantiated],
+            'factory instantiated' => [$factoryInstantiated],
+        ];
+    }
+}

--- a/tests/Cache/Adapter/DoctrineCacheAdapterTest.php
+++ b/tests/Cache/Adapter/DoctrineCacheAdapterTest.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Bugsnag\Tests\Cache\Adapter;
+
+use Bugsnag\Cache\Adapter\DoctrineCacheAdapter;
+use Doctrine\Common\Cache\ArrayCache;
+
+final class DoctrineCacheAdapterTest extends AdapterTest
+{
+    protected function getAdapter()
+    {
+        return new DoctrineCacheAdapter($this->getImplementation());
+    }
+
+    protected function getImplementation()
+    {
+        return new ArrayCache();
+    }
+}

--- a/tests/Cache/Adapter/Psr16AdapterTest.php
+++ b/tests/Cache/Adapter/Psr16AdapterTest.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Bugsnag\Tests\Cache\Adapter;
+
+use Bugsnag\Cache\Adapter\Psr16Adapter;
+use Bugsnag\Tests\Fake\FakePsr16Cache;
+
+final class Psr16AdapterTest extends AdapterTest
+{
+    protected function getAdapter()
+    {
+        return new Psr16Adapter(new FakePsr16Cache());
+    }
+}

--- a/tests/Cache/Adapter/Psr16AdapterTest.php
+++ b/tests/Cache/Adapter/Psr16AdapterTest.php
@@ -9,6 +9,11 @@ final class Psr16AdapterTest extends AdapterTest
 {
     protected function getAdapter()
     {
-        return new Psr16Adapter(new FakePsr16Cache());
+        return new Psr16Adapter($this->getImplementation());
+    }
+
+    protected function getImplementation()
+    {
+        return new FakePsr16Cache();
     }
 }

--- a/tests/Cache/Adapter/Psr16AdapterTest.php
+++ b/tests/Cache/Adapter/Psr16AdapterTest.php
@@ -4,6 +4,8 @@ namespace Bugsnag\Tests\Cache\Adapter;
 
 use Bugsnag\Cache\Adapter\Psr16Adapter;
 use Bugsnag\Tests\Fake\FakePsr16Cache;
+use Psr\SimpleCache\CacheInterface;
+use TypeError;
 
 final class Psr16AdapterTest extends AdapterTest
 {
@@ -15,5 +17,31 @@ final class Psr16AdapterTest extends AdapterTest
     protected function getImplementation()
     {
         return new FakePsr16Cache();
+    }
+
+    /**
+     * This test requires 'TypeError' and 'Throwable' to exist, which is only
+     * true on PHP 7+.
+     *
+     * This doesn't need to be tested on PHP 5 because if 'Throwable' doesn't
+     * exist then it's not possible to throw or catch anything that's not an
+     * 'Exception' anyway
+     *
+     * @requires PHP 7.0
+     */
+    public function testItHandlesErrorsNotJustExceptions()
+    {
+        /** @var CacheInterface&\PHPUnit\Framework\MockObject\MockObject $cache */
+        $cache = $this->getMockBuilder(CacheInterface::class)->getMock();
+
+        $this->willThrow($cache, $this->exactly(3), 'get', new TypeError('no'));
+        $this->willThrow($cache, $this->once(), 'set', new TypeError('no'));
+
+        $adapter = new Psr16Adapter($cache);
+
+        $this->assertFalse($adapter->set('test', 1));
+        $this->assertSame(null, $adapter->get('test'));
+        $this->assertSame(true, $adapter->get('test', true));
+        $this->assertSame('abc', $adapter->get('test', 'abc'));
     }
 }

--- a/tests/Cache/Adapter/Psr16AdapterTest.php
+++ b/tests/Cache/Adapter/Psr16AdapterTest.php
@@ -34,8 +34,17 @@ final class Psr16AdapterTest extends AdapterTest
         /** @var CacheInterface&\PHPUnit\Framework\MockObject\MockObject $cache */
         $cache = $this->getMockBuilder(CacheInterface::class)->getMock();
 
-        $this->willThrow($cache, $this->exactly(3), 'get', new TypeError('no'));
-        $this->willThrow($cache, $this->once(), 'set', new TypeError('no'));
+        $cache->expects($this->exactly(3))
+            ->method('get')
+            ->willReturnCallback(function () {
+                throw new TypeError('oh no!');
+            });
+
+        $cache->expects($this->once())
+            ->method('set')
+            ->willReturnCallback(function () {
+                throw new TypeError('oh no!');
+            });
 
         $adapter = new Psr16Adapter($cache);
 

--- a/tests/Cache/Adapter/Psr6AdapterTest.php
+++ b/tests/Cache/Adapter/Psr6AdapterTest.php
@@ -48,7 +48,7 @@ final class Psr6AdapterTest extends AdapterTest
                 // implementation, but it's how the interface is supposed to
                 // work so I think it's fine (if a bit ugly)
                 if ($calls === 1) {
-                    return new FakePsr6CacheItem($key, null, false);
+                    return new FakePsr6CacheItem($key);
                 }
 
                 throw new TypeError('Oh no!');

--- a/tests/Cache/Adapter/Psr6AdapterTest.php
+++ b/tests/Cache/Adapter/Psr6AdapterTest.php
@@ -3,7 +3,10 @@
 namespace Bugsnag\Tests\Cache\Adapter;
 
 use Bugsnag\Cache\Adapter\Psr6Adapter;
+use Bugsnag\Tests\Fake\FakePsr6CacheItem;
 use Bugsnag\Tests\Fake\FakePsr6CachePool;
+use Psr\Cache\CacheItemPoolInterface;
+use TypeError;
 
 final class Psr6AdapterTest extends AdapterTest
 {
@@ -15,5 +18,49 @@ final class Psr6AdapterTest extends AdapterTest
     protected function getImplementation()
     {
         return new FakePsr6CachePool();
+    }
+
+    /**
+     * This test requires 'TypeError' and 'Throwable' to exist, which is only
+     * true on PHP 7+.
+     *
+     * This doesn't need to be tested on PHP 5 because if 'Throwable' doesn't
+     * exist then it's not possible to throw or catch anything that's not an
+     * 'Exception' anyway
+     *
+     * @requires PHP 7.0
+     */
+    public function testItHandlesErrorsNotJustExceptions()
+    {
+        /** @var CacheItemPoolInterface&\PHPUnit\Framework\MockObject\MockObject $cache */
+        $cache = $this->getMockBuilder(CacheItemPoolInterface::class)->getMock();
+
+        $calls = 0;
+        $cache->expects($this->exactly(4))
+            ->method('getItem')
+            ->withAnyParameters()
+            ->willReturnCallback(function ($key) use (&$calls) {
+                $calls++;
+
+                // On the first call we want 'getItem' to return something
+                // rather than throw, because 'set' relies on getting a cache
+                // item from the pool. This is kind of coupled to the adapter
+                // implementation, but it's how the interface is supposed to
+                // work so I think it's fine (if a bit ugly)
+                if ($calls === 1) {
+                    return new FakePsr6CacheItem($key, null, false);
+                }
+
+                throw new TypeError('Oh no!');
+            });
+
+        $this->willThrow($cache, $this->once(), 'save', new TypeError('no'));
+
+        $adapter = new Psr6Adapter($cache);
+
+        $this->assertFalse($adapter->set('test', 1));
+        $this->assertSame(null, $adapter->get('test'));
+        $this->assertSame(true, $adapter->get('test', true));
+        $this->assertSame('abc', $adapter->get('test', 'abc'));
     }
 }

--- a/tests/Cache/Adapter/Psr6AdapterTest.php
+++ b/tests/Cache/Adapter/Psr6AdapterTest.php
@@ -54,7 +54,11 @@ final class Psr6AdapterTest extends AdapterTest
                 throw new TypeError('Oh no!');
             });
 
-        $this->willThrow($cache, $this->once(), 'save', new TypeError('no'));
+        $cache->expects($this->once())
+            ->method('save')
+            ->willReturnCallback(function () {
+                throw new TypeError('oh no!');
+            });
 
         $adapter = new Psr6Adapter($cache);
 

--- a/tests/Cache/Adapter/Psr6AdapterTest.php
+++ b/tests/Cache/Adapter/Psr6AdapterTest.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Bugsnag\Tests\Cache\Adapter;
+
+use Bugsnag\Cache\Adapter\Psr6Adapter;
+use Bugsnag\Tests\Fake\FakePsr6CachePool;
+
+final class Psr6AdapterTest extends AdapterTest
+{
+    protected function getAdapter()
+    {
+        return new Psr6Adapter($this->getImplementation());
+    }
+
+    protected function getImplementation()
+    {
+        return new FakePsr6CachePool();
+    }
+}

--- a/tests/Cache/CacheFactoryTest.php
+++ b/tests/Cache/CacheFactoryTest.php
@@ -5,8 +5,10 @@ namespace Bugsnag\Tests\Cache;
 use Bugsnag\Cache\Adapter\CacheAdapterInterface;
 use Bugsnag\Cache\CacheFactory;
 use Bugsnag\Tests\Fake\FakePsr16Cache;
+use Bugsnag\Tests\Fake\FakePsr6CachePool;
 use Bugsnag\Tests\TestCase;
 use InvalidArgumentException;
+use Psr\Cache\CacheItemPoolInterface as Psr6CacheInterface;
 use Psr\SimpleCache\CacheInterface as Psr16CacheInterface;
 use stdClass;
 
@@ -16,6 +18,14 @@ final class CacheFactoryTest extends TestCase
     {
         $factory = new CacheFactory();
         $adapter = $factory->create(new FakePsr16Cache());
+
+        $this->assertInstanceOf(CacheAdapterInterface::class, $adapter);
+    }
+
+    public function testItCreatesACacheAdapterForPsr6()
+    {
+        $factory = new CacheFactory();
+        $adapter = $factory->create(new FakePsr6CachePool());
 
         $this->assertInstanceOf(CacheAdapterInterface::class, $adapter);
     }
@@ -35,8 +45,9 @@ final class CacheFactoryTest extends TestCase
         $this->expectedException(
             InvalidArgumentException::class,
             sprintf(
-                '%s::create expects an instance of "%s", got "%s"',
+                '%s::create expects an instance of "%s" or "%s", got "%s"',
                 CacheFactory::class,
+                Psr6CacheInterface::class,
                 Psr16CacheInterface::class,
                 $type
             )

--- a/tests/Cache/CacheFactoryTest.php
+++ b/tests/Cache/CacheFactoryTest.php
@@ -7,6 +7,8 @@ use Bugsnag\Cache\CacheFactory;
 use Bugsnag\Tests\Fake\FakePsr16Cache;
 use Bugsnag\Tests\Fake\FakePsr6CachePool;
 use Bugsnag\Tests\TestCase;
+use Doctrine\Common\Cache\ArrayCache;
+use Doctrine\Common\Cache\Cache as DoctrineCache;
 use InvalidArgumentException;
 use Psr\Cache\CacheItemPoolInterface as Psr6CacheInterface;
 use Psr\SimpleCache\CacheInterface as Psr16CacheInterface;
@@ -30,6 +32,14 @@ final class CacheFactoryTest extends TestCase
         $this->assertInstanceOf(CacheAdapterInterface::class, $adapter);
     }
 
+    public function testItCreatesACacheAdapterForDoctrineCache()
+    {
+        $factory = new CacheFactory();
+        $adapter = $factory->create(new ArrayCache());
+
+        $this->assertInstanceOf(CacheAdapterInterface::class, $adapter);
+    }
+
     /**
      * @param string $type
      * @param mixed  $cache
@@ -45,10 +55,11 @@ final class CacheFactoryTest extends TestCase
         $this->expectedException(
             InvalidArgumentException::class,
             sprintf(
-                '%s::create expects an instance of "%s" or "%s", got "%s"',
+                '%s::create expects an instance of "%s", "%s" or "%s", got "%s"',
                 CacheFactory::class,
                 Psr6CacheInterface::class,
                 Psr16CacheInterface::class,
+                DoctrineCache::class,
                 $type
             )
         );

--- a/tests/Cache/CacheFactoryTest.php
+++ b/tests/Cache/CacheFactoryTest.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace Bugsnag\Tests\Cache;
+
+use Bugsnag\Cache\Adapter\CacheAdapterInterface;
+use Bugsnag\Cache\CacheFactory;
+use Bugsnag\Tests\Fake\FakePsr16Cache;
+use Bugsnag\Tests\TestCase;
+use InvalidArgumentException;
+use Psr\SimpleCache\CacheInterface as Psr16CacheInterface;
+use stdClass;
+
+final class CacheFactoryTest extends TestCase
+{
+    public function testItCreatesACacheAdapterForPsr16()
+    {
+        $factory = new CacheFactory();
+        $adapter = $factory->create(new FakePsr16Cache());
+
+        $this->assertInstanceOf(CacheAdapterInterface::class, $adapter);
+    }
+
+    /**
+     * @param string $type
+     * @param mixed  $cache
+     *
+     * @return void
+     *
+     * @dataProvider invalidTypeProvider
+     */
+    public function testItThrowsWhenGivenAnInvalidType($type, $cache)
+    {
+        $factory = new CacheFactory();
+
+        $this->expectedException(
+            InvalidArgumentException::class,
+            sprintf(
+                '%s::create expects an instance of "%s", got "%s"',
+                CacheFactory::class,
+                Psr16CacheInterface::class,
+                $type
+            )
+        );
+
+        $factory->create($cache);
+    }
+
+    public function invalidTypeProvider()
+    {
+        $tests = [
+            ['NULL', null],
+            ['string', 'hello'],
+            ['integer', 123],
+            ['boolean', false],
+            ['array', ['hello', 123, false]],
+            [stdClass::class, new stdClass()],
+            [self::class, $this],
+        ];
+
+        foreach ($tests as $test) {
+            yield $test[0] => $test;
+        }
+    }
+}

--- a/tests/Fake/FakePsr16Cache.php
+++ b/tests/Fake/FakePsr16Cache.php
@@ -1,0 +1,74 @@
+<?php
+
+namespace Bugsnag\Tests\Fake;
+
+use BadMethodCallException;
+use Psr\SimpleCache\CacheInterface;
+
+/**
+ * A fake PSR-16 implementation for use in unit tests.
+ *
+ * This implements the bare minimum methods that we need and will throw an
+ * exception if any upimplemented method is called.
+ */
+final class FakePsr16Cache implements CacheInterface
+{
+    /**
+     * @var array
+     */
+    private $cache = [];
+
+    public function get($key, $default = null)
+    {
+        if (!is_string($key)) {
+            throw new FakePsr16Exception('Invalid key given');
+        }
+
+        if (array_key_exists($key, $this->cache)) {
+            return $this->cache[$key];
+        }
+
+        return $default;
+    }
+
+    public function set($key, $value, $ttl = null)
+    {
+        if (!is_string($key)) {
+            throw new FakePsr16Exception('Invalid key given');
+        }
+
+        $this->cache[$key] = $value;
+
+        return true;
+    }
+
+    public function delete($key)
+    {
+        throw new BadMethodCallException(__METHOD__.' is not implemented');
+    }
+
+    public function clear()
+    {
+        throw new BadMethodCallException(__METHOD__.' is not implemented');
+    }
+
+    public function getMultiple($keys, $default = null)
+    {
+        throw new BadMethodCallException(__METHOD__.' is not implemented');
+    }
+
+    public function setMultiple($values, $ttl = null)
+    {
+        throw new BadMethodCallException(__METHOD__.' is not implemented');
+    }
+
+    public function deleteMultiple($keys)
+    {
+        throw new BadMethodCallException(__METHOD__.' is not implemented');
+    }
+
+    public function has($key)
+    {
+        throw new BadMethodCallException(__METHOD__.' is not implemented');
+    }
+}

--- a/tests/Fake/FakePsr16Exception.php
+++ b/tests/Fake/FakePsr16Exception.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Bugsnag\Tests\Fake;
+
+use Psr\SimpleCache\InvalidArgumentException;
+use RuntimeException;
+
+/**
+ * A fake PSR-16 exception for use by the fake PSR-16 implementation.
+ */
+final class FakePsr16Exception extends RuntimeException implements InvalidArgumentException
+{
+}

--- a/tests/Fake/FakePsr6CacheItem.php
+++ b/tests/Fake/FakePsr6CacheItem.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace Bugsnag\Tests\Fake;
+
+use BadMethodCallException;
+use Psr\Cache\CacheItemInterface;
+
+/**
+ * A fake PSR-6 cache item implementation for use in unit tests.
+ *
+ * This implements the bare minimum methods that we need and will throw an
+ * exception if any upimplemented method is called.
+ */
+final class FakePsr6CacheItem implements CacheItemInterface
+{
+    private $key;
+    private $value;
+    private $isHit;
+
+    public function __construct($key, $value, $isHit)
+    {
+        $this->key = $key;
+        $this->value = $value;
+        $this->isHit = $isHit;
+    }
+
+    public function getKey()
+    {
+        return $this->key;
+    }
+
+    public function get()
+    {
+        return $this->value;
+    }
+
+    public function isHit()
+    {
+        return $this->isHit;
+    }
+
+    public function set($value)
+    {
+        $this->value = $value;
+    }
+
+    public function expiresAt($expiration)
+    {
+        throw new BadMethodCallException(__METHOD__.' is not implemented');
+    }
+
+    public function expiresAfter($time)
+    {
+        throw new BadMethodCallException(__METHOD__.' is not implemented');
+    }
+}

--- a/tests/Fake/FakePsr6CachePool.php
+++ b/tests/Fake/FakePsr6CachePool.php
@@ -1,0 +1,71 @@
+<?php
+
+namespace Bugsnag\Tests\Fake;
+
+use BadMethodCallException;
+use Psr\Cache\CacheItemInterface;
+use Psr\Cache\CacheItemPoolInterface;
+
+/**
+ * A fake PSR-6 cache item pool implementation for use in unit tests.
+ *
+ * This implements the bare minimum methods that we need and will throw an
+ * exception if any upimplemented method is called.
+ */
+final class FakePsr6CachePool implements CacheItemPoolInterface
+{
+    private $cache = [];
+
+    public function getItem($key)
+    {
+        if (array_key_exists($key, $this->cache)) {
+            $value = $this->cache[$key];
+
+            return new FakePsr6CacheItem($key, $value, true);
+        }
+
+        return new FakePsr6CacheItem($key, null, false);
+    }
+
+    public function save(CacheItemInterface $item)
+    {
+        $this->cache[$item->getKey()] = $item->get();
+
+        return true;
+    }
+
+    public function getItems(array $keys = [])
+    {
+        throw new BadMethodCallException(__METHOD__.' is not implemented');
+    }
+
+    public function hasItem($key)
+    {
+        throw new BadMethodCallException(__METHOD__.' is not implemented');
+    }
+
+    public function clear()
+    {
+        throw new BadMethodCallException(__METHOD__.' is not implemented');
+    }
+
+    public function deleteItem($key)
+    {
+        throw new BadMethodCallException(__METHOD__.' is not implemented');
+    }
+
+    public function deleteItems(array $keys)
+    {
+        throw new BadMethodCallException(__METHOD__.' is not implemented');
+    }
+
+    public function saveDeferred(CacheItemInterface $item)
+    {
+        throw new BadMethodCallException(__METHOD__.' is not implemented');
+    }
+
+    public function commit()
+    {
+        throw new BadMethodCallException(__METHOD__.' is not implemented');
+    }
+}

--- a/tests/Fake/FakePsr6CachePool.php
+++ b/tests/Fake/FakePsr6CachePool.php
@@ -23,17 +23,19 @@ final class FakePsr6CachePool implements CacheItemPoolInterface
         }
 
         if (array_key_exists($key, $this->cache)) {
-            $value = $this->cache[$key];
-
-            return new FakePsr6CacheItem($key, $value, true);
+            return $this->cache[$key];
         }
 
-        return new FakePsr6CacheItem($key, null, false);
+        return new FakePsr6CacheItem($key);
     }
 
     public function save(CacheItemInterface $item)
     {
-        $this->cache[$item->getKey()] = $item->get();
+        if (!$item instanceof FakePsr6CacheItem) {
+            throw new FakePsr6Exception('Invalid item given: '.get_class($item));
+        }
+
+        $this->cache[$item->getKey()] = $item->save();
 
         return true;
     }

--- a/tests/Fake/FakePsr6CachePool.php
+++ b/tests/Fake/FakePsr6CachePool.php
@@ -18,6 +18,10 @@ final class FakePsr6CachePool implements CacheItemPoolInterface
 
     public function getItem($key)
     {
+        if (!is_string($key)) {
+            throw new FakePsr6Exception('Invalid key given');
+        }
+
         if (array_key_exists($key, $this->cache)) {
             $value = $this->cache[$key];
 

--- a/tests/Fake/FakePsr6Exception.php
+++ b/tests/Fake/FakePsr6Exception.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Bugsnag\Tests\Fake;
+
+use Psr\Cache\InvalidArgumentException;
+use RuntimeException;
+
+/**
+ * A fake PSR-6 exception for use by the fake PSR-6 implementation.
+ */
+final class FakePsr6Exception extends RuntimeException implements InvalidArgumentException
+{
+}

--- a/tests/ReportTest.php
+++ b/tests/ReportTest.php
@@ -125,11 +125,11 @@ class ReportTest extends TestCase
 
         $this->assertInstanceOf(Stacktrace::class, $trace);
 
-        if (class_exists(\PHPUnit_Framework_TestCase::class)) {
-            $this->assertCount(8, $trace->toArray());
-        } else {
-            $this->assertCount(7, $trace->toArray());
-        }
+        // Before PHPUnit 7 tests were executed via ReflectionMethod::invokeArgs
+        // which adds a line to the stacktrace
+        $expectedCount = $this->isPhpUnit7() ? 7 : 8;
+
+        $this->assertCount($expectedCount, $trace->toArray());
     }
 
     public function testNoticeName()

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -5,8 +5,12 @@ namespace Bugsnag\Tests;
 use GrahamCampbell\TestBenchCore\MockeryTrait;
 use GuzzleHttp\ClientInterface;
 use phpmock\phpunit\PHPMock;
+use PHPUnit\Framework\MockObject\Matcher\InvokedCount;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\MockObject\Stub\Exception as ExceptionStub;
 use PHPUnit\Framework\TestCase as BaseTestCase;
-use ReflectionObject;
+use PHPUnit\Runner\Version as PhpUnitVersion;
+use Throwable;
 
 abstract class TestCase extends BaseTestCase
 {
@@ -15,7 +19,7 @@ abstract class TestCase extends BaseTestCase
 
     public function expectedException($class, $message = null)
     {
-        if (class_exists(\PHPUnit_Framework_TestCase::class)) {
+        if ($this->isPhpUnit4()) {
             $this->setExpectedException($class, $message);
 
             return;
@@ -29,6 +33,56 @@ abstract class TestCase extends BaseTestCase
     }
 
     /**
+     * Wrapper around 'willThrowException' with support for Throwable on PHPUnit
+     * versions before 7.
+     *
+     * @param MockObject   $mock
+     * @param InvokedCount $invokedCount
+     * @param string       $methodName
+     * @param Throwable    $throwable
+     *
+     * @return void
+     */
+    protected function willThrow(
+        MockObject $mock,
+        InvokedCount $invokedCount,
+        $methodName,
+        Throwable $throwable
+    ) {
+        // Before PHPUnit 7 'willThrowException' required an Exception, rather
+        // than a Throwable so we have to handle these versions differently
+        if ($this->isPhpUnit7()) {
+            $mock->expects($invokedCount)
+                ->method($methodName)
+                ->withAnyParameters()
+                ->willThrowException($throwable);
+        } else {
+            $mock->expects($invokedCount)
+                ->method($methodName)
+                ->withAnyParameters()
+                ->will(new ExceptionStub($throwable));
+        }
+    }
+
+    protected function isPhpUnit7()
+    {
+        return version_compare($this->phpUnitVersion(), '7.0.0', '>=')
+            && version_compare($this->phpUnitVersion(), '8.0.0', '<');
+    }
+
+    protected function isPhpUnit6()
+    {
+        return version_compare($this->phpUnitVersion(), '6.0.0', '>=')
+            && version_compare($this->phpUnitVersion(), '7.0.0', '<');
+    }
+
+    protected function isPhpUnit4()
+    {
+        return version_compare($this->phpUnitVersion(), '4.0.0', '>=')
+            && version_compare($this->phpUnitVersion(), '5.0.0', '<');
+    }
+
+    /**
      * @return string
      */
     protected static function getGuzzleMethod()
@@ -36,18 +90,14 @@ abstract class TestCase extends BaseTestCase
         return method_exists(ClientInterface::class, 'request') ? 'request' : 'post';
     }
 
-    private static function readObjectAttribute($object, $attributeName)
+    private function phpUnitVersion()
     {
-        $reflector = new ReflectionObject($object);
-
-        $attribute = $reflector->getProperty($attributeName);
-
-        if (!$attribute || $attribute->isPublic()) {
-            return $object->$attributeName;
+        // Support versions of PHPUnit before 6.0.0 when native namespaces were
+        // introduced for the Version class
+        if (class_exists(\PHPUnit_Runner_Version::class)) {
+            return \PHPUnit_Runner_Version::id();
         }
 
-        $attribute->setAccessible(true);
-
-        return $attribute->getValue($object);
+        return PhpUnitVersion::id();
     }
 }

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -5,12 +5,8 @@ namespace Bugsnag\Tests;
 use GrahamCampbell\TestBenchCore\MockeryTrait;
 use GuzzleHttp\ClientInterface;
 use phpmock\phpunit\PHPMock;
-use PHPUnit\Framework\MockObject\Matcher\InvokedCount;
-use PHPUnit\Framework\MockObject\MockObject;
-use PHPUnit\Framework\MockObject\Stub\Exception as ExceptionStub;
 use PHPUnit\Framework\TestCase as BaseTestCase;
 use PHPUnit\Runner\Version as PhpUnitVersion;
-use Throwable;
 
 abstract class TestCase extends BaseTestCase
 {
@@ -29,38 +25,6 @@ abstract class TestCase extends BaseTestCase
 
         if ($message !== null) {
             $this->expectExceptionMessage($message);
-        }
-    }
-
-    /**
-     * Wrapper around 'willThrowException' with support for Throwable on PHPUnit
-     * versions before 7.
-     *
-     * @param MockObject   $mock
-     * @param InvokedCount $invokedCount
-     * @param string       $methodName
-     * @param Throwable    $throwable
-     *
-     * @return void
-     */
-    protected function willThrow(
-        MockObject $mock,
-        InvokedCount $invokedCount,
-        $methodName,
-        Throwable $throwable
-    ) {
-        // Before PHPUnit 7 'willThrowException' required an Exception, rather
-        // than a Throwable so we have to handle these versions differently
-        if ($this->isPhpUnit7()) {
-            $mock->expects($invokedCount)
-                ->method($methodName)
-                ->withAnyParameters()
-                ->willThrowException($throwable);
-        } else {
-            $mock->expects($invokedCount)
-                ->method($methodName)
-                ->withAnyParameters()
-                ->will(new ExceptionStub($throwable));
         }
     }
 


### PR DESCRIPTION
## Goal

This PR adds a caching abstraction which can wrap a PSR-6, PSR-16 or Doctrine Cache instance in a unified interface. More abstractions are easy to add by adding a wrapper class and a condition to the `CacheFactory`

This isn't used yet, but will be in an upcoming PR

## Tests

As PSR-6 and PSR-16 are only interfaces, I've added bare-minimum implementations so that we can write tests for them. These should eventually be expanded upon with integration tests against, e.g. a real Memcache instance, but that would require adding even more dev dependencies which I'd like to avoid. We can look into adding tests against an example project in another PR

The implementations are forced to behave the same via the `AdapterTest` abstract test case, which runs the same tests against all three implementations

## Review

<!-- When submitting for review, consider the points for self-review and the
     criteria which will be used for secondary review -->

For the submitter, initial self-review:

- [x] Commented on code changes inline explain the reasoning behind the approach
- [x] Reviewed the test cases added for completeness and possible points for discussion
- [ ] A changelog entry was added for the goal of this pull request
- [x] Check the scope of the changeset - is everything in the diff required for the pull request?
- This pull request is ready for:
  - [ ] Initial review of the intended approach, not yet feature complete
  - [ ] Structural review of the classes, functions, and properties modified
  - [x] Final review

For the pull request reviewer(s), this changeset has been reviewed for:

- [ ] Consistency across platforms for structures or concepts added or modified
- [ ] Consistency between the changeset and the goal stated above
- [ ] Internal consistency with the rest of the library - is there any overlap between existing interfaces and any which have been added?
- [ ] Usage friction - is the proposed change in usage cumbersome or complicated?
- [ ] Performance and complexity - are there any cases of unexpected O(n^3) when iterating, recursing, flat mapping, etc?
- [ ] Concurrency concerns - if components are accessed asynchronously, what issues will arise
- [ ] Thoroughness of added tests and any missing edge cases
- [ ] Idiomatic use of the language
