### PR TITLE
Pass all http headers in request metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,18 @@
 Changelog
 =========
 
+## TBD
+
+### Enhancements
+
+* Include all HTTP headers in request metadata
+  [#588](https://github.com/bugsnag/bugsnag-php/pull/588)
+
+### Bug Fixes
+
+* TBD
+
+
 ## 3.21.0 (2020-04-29)
 
 ### Enhancements

--- a/src/Request/BasicResolver.php
+++ b/src/Request/BasicResolver.php
@@ -65,10 +65,10 @@ class BasicResolver implements ResolverInterface
         foreach ($server as $name => $value) {
             if (substr($name, 0, 5) == 'HTTP_') {
                 $headers[str_replace(' ', '-', ucwords(strtolower(str_replace('_', ' ', substr($name, 5)))))] = $value;
-            } elseif ($name === "CONTENT_TYPE") {
-                $headers["Content-Type"] = $value;
-            } elseif ($name === "CONTENT_LENGTH") {
-                $headers["Content-Length"] = $value;
+            } elseif ($name === 'CONTENT_TYPE') {
+                $headers['Content-Type'] = $value;
+            } elseif ($name === 'CONTENT_LENGTH') {
+                $headers['Content-Length'] = $value;
             }
         }
 

--- a/src/Request/BasicResolver.php
+++ b/src/Request/BasicResolver.php
@@ -63,6 +63,9 @@ class BasicResolver implements ResolverInterface
                 if (substr($name, 0, 5) == 'HTTP_') {
                     $headers[str_replace(' ', '-', ucwords(strtolower(str_replace('_', ' ', substr($name, 5)))))] = $value;
                 }
+                else if ($name === "CONTENT_TYPE") {
+                    $headers["Content-Type"] = $value;
+                }
             }
         } else {
             $headers = getallheaders();

--- a/src/Request/BasicResolver.php
+++ b/src/Request/BasicResolver.php
@@ -56,19 +56,22 @@ class BasicResolver implements ResolverInterface
             return $headers;
         }
 
+        if (function_exists('getallheaders')) {
+            return getallheaders();
+        }
+
         $headers = [];
 
-        if (!function_exists('getallheaders')) {
-            foreach ($server as $name => $value) {
-                if (substr($name, 0, 5) == 'HTTP_') {
-                    $headers[str_replace(' ', '-', ucwords(strtolower(str_replace('_', ' ', substr($name, 5)))))] = $value;
-                }
-                else if ($name === "CONTENT_TYPE") {
-                    $headers["Content-Type"] = $value;
-                }
+        foreach ($server as $name => $value) {
+            if (substr($name, 0, 5) == 'HTTP_') {
+                $headers[str_replace(' ', '-', ucwords(strtolower(str_replace('_', ' ', substr($name, 5)))))] = $value;
             }
-        } else {
-            $headers = getallheaders();
+            elseif ($name === "CONTENT_TYPE") {
+                $headers["Content-Type"] = $value;
+            }
+            elseif ($name === "CONTENT_LENGTH") {
+                $headers["Content-Length"] = $value;
+            }
         }
 
         return $headers;

--- a/src/Request/BasicResolver.php
+++ b/src/Request/BasicResolver.php
@@ -58,10 +58,14 @@ class BasicResolver implements ResolverInterface
 
         $headers = [];
 
-        foreach ($server as $name => $value) {
-            if (substr($name, 0, 5) == 'HTTP_') {
-                $headers[str_replace(' ', '-', ucwords(strtolower(str_replace('_', ' ', substr($name, 5)))))] = $value;
+        if (!function_exists('getallheaders')) {
+            foreach ($server as $name => $value) {
+                if (substr($name, 0, 5) == 'HTTP_') {
+                    $headers[str_replace(' ', '-', ucwords(strtolower(str_replace('_', ' ', substr($name, 5)))))] = $value;
+                }
             }
+        } else {
+            $headers = getallheaders();
         }
 
         return $headers;

--- a/src/Request/BasicResolver.php
+++ b/src/Request/BasicResolver.php
@@ -65,11 +65,9 @@ class BasicResolver implements ResolverInterface
         foreach ($server as $name => $value) {
             if (substr($name, 0, 5) == 'HTTP_') {
                 $headers[str_replace(' ', '-', ucwords(strtolower(str_replace('_', ' ', substr($name, 5)))))] = $value;
-            }
-            elseif ($name === "CONTENT_TYPE") {
+            } elseif ($name === "CONTENT_TYPE") {
                 $headers["Content-Type"] = $value;
-            }
-            elseif ($name === "CONTENT_LENGTH") {
+            } elseif ($name === "CONTENT_LENGTH") {
                 $headers["Content-Length"] = $value;
             }
         }

--- a/tests/RequestTest.php
+++ b/tests/RequestTest.php
@@ -129,7 +129,7 @@ class RequestTest extends TestCase
             'params' => ['foo' => 'baz'],
             'clientIp' => '123.45.67.8',
             'userAgent' => 'Example Browser 1.2.3',
-            'headers' => ['Host' => 'example.com', 'User-Agent' => 'Example Browser 1.2.3'],
+            'headers' => ['Host' => 'example.com', 'User-Agent' => 'Example Browser 1.2.3', 'Content-Type' => 'application/json'],
         ];
 
         $this->assertSame(['request' => $data], $this->resolver->resolve()->getMetaData());


### PR DESCRIPTION
PLAT-4629

## Goal

The notifier currently only append headers that start with HTTP_ prefix.  Instead all headers should be sent.

## Changeset

Update the BasicResolver to use getallheaders if it exists, this will set all HTTP headers

## Tests

Update to existing RequestTest.php

## Discussion

### Alternative Approaches

### Outstanding Questions

### Linked issues

## Review

For the submitter, initial self-review:

- [ x] Commented on code changes inline explain the reasoning behind the approach
- [ x] Reviewed the test cases added for completeness and possible points for discussion
- [ ] A changelog entry was added for the goal of this pull request
- [ x] Check the scope of the changeset - is everything in the diff required for the pull request?
- This pull request is ready for:
  - [ x] Initial review of the intended approach, not yet feature complete
  - [ x] Structural review of the classes, functions, and properties modified
  - [ x] Final review

For the pull request reviewer(s), this changeset has been reviewed for:

- [ ] Consistency across platforms for structures or concepts added or modified
- [ ] Consistency between the changeset and the goal stated above
- [ ] Internal consistency with the rest of the library - is there any overlap between existing interfaces and any which have been added?
- [ ] Usage friction - is the proposed change in usage cumbersome or complicated?
- [ ] Performance and complexity - are there any cases of unexpected O(n^3) when iterating, recursing, flat mapping, etc?
- [ ] Concurrency concerns - if components are accessed asynchronously, what issues will arise
- [ ] Thoroughness of added tests and any missing edge cases
- [ ] Idiomatic use of the language
