### PR TITLE
Don't overwrite the notify endpoint if one is already set

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -193,6 +193,13 @@ class Client
         Configuration $configuration,
         GuzzleHttp\ClientInterface $guzzle
     ) {
+        // Don't change the endpoint if one is already set, otherwise we could be
+        // resetting it back to the default as the Guzzle base URL will always
+        // be set by 'makeGuzzle'.
+        if ($configuration->getNotifyEndpoint() !== Configuration::NOTIFY_ENDPOINT) {
+            return;
+        }
+
         $base = $this->getGuzzleBaseUri($guzzle);
 
         if (is_string($base) || method_exists($base, '__toString')) {

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -133,6 +133,42 @@ class ClientTest extends TestCase
         $this->assertEquals('https://example.com', $client->getNotifyEndpoint());
     }
 
+    public function testTheNotifyEndpointWontBeOverwrittenWhenOneIsAlreadySetOnConfiguration()
+    {
+        $config = new Configuration('abc');
+        $config->setNotifyEndpoint('https://foo.com');
+
+        $client = new Client($config);
+
+        $this->assertEquals('https://foo.com', $client->getNotifyEndpoint());
+    }
+
+    public function testTheNotifyEndpointWontBeOverwrittenByGivenGuzzleInstanceWhenOneIsAlreadySetOnConfiguration()
+    {
+        $config = new Configuration('abc');
+        $config->setNotifyEndpoint('https://foo.com');
+
+        $guzzle = new Guzzle([
+            $this->getGuzzleBaseOptionName() => 'https://example.com',
+        ]);
+
+        $client = new Client($config, null, $guzzle);
+
+        $this->assertEquals('https://foo.com', $client->getNotifyEndpoint());
+    }
+
+    public function testTheNotifyEndpointWontBeOverwrittenByMakeGuzzleWhenOneIsAlreadySetOnConfiguration()
+    {
+        $config = new Configuration('abc');
+        $config->setNotifyEndpoint('https://foo.com');
+
+        $guzzle = Client::makeGuzzle();
+
+        $client = new Client($config, null, $guzzle);
+
+        $this->assertEquals('https://foo.com', $client->getNotifyEndpoint());
+    }
+
     public function testTheNotifyEndpointCanBeSetBySettingItOnAGuzzleInstanceWithAnArray()
     {
         if (!$this->isUsingGuzzle5()) {


### PR DESCRIPTION
## Goal

This fixes a bug in the `next` branch where we would overwrite a custom Configuration's notify endpoint when attempting to sync it with the Guzzle base URL

We now only set the notify endpoint to the Guzzle base if the endpoint is still the default. The tests should explain the scenarios where this happens, but I think the only common one is where a `Configuration` instance is given without also giving a Guzzle instance, e.g.

```php
$config = new Configuration('abc');
$config->setNotifyEndpoint('https://example.com');

$client = new Client($config);
```

Before this change the above snippet would result in a notify endpoint of `https://notify.bugsnag.com` because we would overwrite the given endpoint with the one we set in `makeGuzzle`. Now we will correctly keep the custom endpoint (`https://example.com`)

The other examples in the new tests should be relatively rare, especially having a Guzzle instance with a different base URL to the Configuration's endpoint, but they are possible

## Review

<!-- When submitting for review, consider the points for self-review and the
     criteria which will be used for secondary review -->

For the submitter, initial self-review:

- [x] Commented on code changes inline explain the reasoning behind the approach
- [x] Reviewed the test cases added for completeness and possible points for discussion
- [x] A changelog entry was added for the goal of this pull request
- [x] Check the scope of the changeset - is everything in the diff required for the pull request?
- This pull request is ready for:
  - [ ] Initial review of the intended approach, not yet feature complete
  - [ ] Structural review of the classes, functions, and properties modified
  - [x] Final review

For the pull request reviewer(s), this changeset has been reviewed for:

- [ ] Consistency across platforms for structures or concepts added or modified
- [ ] Consistency between the changeset and the goal stated above
- [ ] Internal consistency with the rest of the library - is there any overlap between existing interfaces and any which have been added?
- [ ] Usage friction - is the proposed change in usage cumbersome or complicated?
- [ ] Performance and complexity - are there any cases of unexpected O(n^3) when iterating, recursing, flat mapping, etc?
- [ ] Concurrency concerns - if components are accessed asynchronously, what issues will arise
- [ ] Thoroughness of added tests and any missing edge cases
- [ ] Idiomatic use of the language
