### PR TITLE
Release v3.22.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -64,8 +64,9 @@ before_install:
   - travis_retry composer require "guzzlehttp/guzzle:${GUZZLE_VERSION}" --no-update
 
 install:
-  - if [[ $TRAVIS_PHP_VERSION == 5.5.9 ]]; then travis_retry composer update --no-interaction --prefer-source --prefer-lowest ; fi
-  - if [[ $TRAVIS_PHP_VERSION != 5.5.9 ]]; then travis_retry composer update --no-interaction --prefer-source ; fi
+  - if [[ $TRAVIS_PHP_VERSION == 5.5.9 ]]; then travis_retry composer update --no-interaction --prefer-dist --prefer-lowest ; fi
+  - if [[ $TRAVIS_PHP_VERSION != 5.5.9 ]]; then travis_retry composer update --no-interaction --prefer-dist ; fi
+  - composer show --direct
 
 script:
   - make test

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,10 +8,54 @@ Changelog
 * Include all HTTP headers in request metadata
   [#588](https://github.com/bugsnag/bugsnag-php/pull/588)
 
-### Bug Fixes
+* The `Client` and `SessionTracker` now share a single Guzzle instance
+  [#587](https://github.com/bugsnag/bugsnag-php/pull/587)
 
-* TBD
+### Deprecations
 
+* `Client::ENDPOINT`
+  This is ambiguous as we have three separate endpoints
+  Use `Configuration::NOTIFY_ENDPOINT` instead
+
+* `HttpClient::PAYLOAD_VERSION`
+  This is ambiguous as there is a session payload version too
+  Use `HttpClient::NOTIFY_PAYLOAD_VERSION` instead
+
+* `Report::PAYLOAD_VERSION`
+  As above. This was also unused by the notifier
+  Use `HttpClient::NOTIFY_PAYLOAD_VERSION` instead
+
+* `SessionTracker::$SESSION_PAYLOAD_VERSION`
+  Use `HttpClient::SESSION_PAYLOAD_VERSION` instead
+
+* `HttpClient::send`
+  Use `HttpClient::sendEvents` instead
+  
+* `HttpClient::build`
+  Use `HttpClient::getEventPayload` instead
+
+* `HttpClient::postJson`
+  Use `HttpClient::deliverEvents` instead
+
+* Using the `base_uri`/`base_url` on a Guzzle instance
+  The base URI is ambiguous as there are three separate endpoints which could be used, therefore all Guzzle requests now use absolute URIs. We will extract the `base_uri`/`base_url` Guzzle option if one is set and use it as the notification endpoint URI, however this will be removed in the next major version
+  Set the notification endpoint manually with `Configuration::setNotifyEndpoint` instead
+
+* Calling `HttpClient::getHeaders` without providing a payload version
+  This is deprecated as the version is ambiguous between the notification payload version and session payload version
+  Call this with the correct `HttpClient` payload version constants instead
+
+* `Client::getSessionClient` and `Configuration::getSessionClient`
+  This method is dangerous to use as there is now only one Guzzle instance used across every request, so changing this client would also affect the notification client. Changes to this Guzzle client will now be ignored
+  Use the `$guzzle` parameter of the `Client` constructor to customise the Guzzle client instead
+
+* `SessionData::$client`
+  The `SessionData` class will be passed a `SessionTracker` instead of a `Client` instance in its constructor in the next major version
+
+* `SessionTracker` should be constructed with a `HttpClient`
+  The `SessionTracker` class should now always be passed a `HttpClient`
+  In this version it will construct its own `HttpClient` if one is not provided
+  In the next major version, this fallback will be removed and passing a `HttpClient` will be mandatory 
 
 ## 3.21.0 (2020-04-29)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 Changelog
 =========
 
-## TBD
+## 3.22.0 (2020-08-20)
 
 ### Enhancements
 

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,8 @@
         "mockery/mockery": "^0.9.4|^1.3.1",
         "mtdowling/burgomaster": "dev-master#72151eddf5f0cf101502b94bf5031f9c53501a04",
         "phpunit/phpunit": "^4.8.36|^7.5.15",
-        "php-mock/php-mock-phpunit": "^1.1|^2.1"
+        "php-mock/php-mock-phpunit": "^1.1|^2.1",
+        "sebastian/version": ">=1.0.3"
     },
     "autoload": {
         "psr-4" : {

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -10,7 +10,7 @@
          convertWarningsToExceptions="true"
          failOnRisky="true"
          failOnWarning="true"
-         processIsolation="true"
+         processIsolation="false"
          stopOnError="false"
          stopOnFailure="false"
          verbose="true"

--- a/src/Client.php
+++ b/src/Client.php
@@ -193,6 +193,13 @@ class Client
         Configuration $configuration,
         GuzzleHttp\ClientInterface $guzzle
     ) {
+        // Don't change the endpoint if one is already set, otherwise we could be
+        // resetting it back to the default as the Guzzle base URL will always
+        // be set by 'makeGuzzle'.
+        if ($configuration->getNotifyEndpoint() !== Configuration::NOTIFY_ENDPOINT) {
+            return;
+        }
+
         $base = $this->getGuzzleBaseUri($guzzle);
 
         if (is_string($base) || method_exists($base, '__toString')) {

--- a/src/Client.php
+++ b/src/Client.php
@@ -19,17 +19,18 @@ use Bugsnag\Request\ResolverInterface;
 use Bugsnag\Shutdown\PhpShutdownStrategy;
 use Bugsnag\Shutdown\ShutdownStrategyInterface;
 use Composer\CaBundle\CaBundle;
-use GuzzleHttp\Client as GuzzleClient;
-use GuzzleHttp\ClientInterface;
+use GuzzleHttp;
 
 class Client
 {
     /**
-     * The default endpoint.
+     * The default event notification endpoint.
      *
      * @var string
+     *
+     * @deprecated Use {@see Configuration::NOTIFY_ENDPOINT} instead.
      */
-    const ENDPOINT = 'https://notify.bugsnag.com';
+    const ENDPOINT = Configuration::NOTIFY_ENDPOINT;
 
     /**
      * The config instance.
@@ -78,19 +79,21 @@ class Client
      *
      * If you don't pass in a key, we'll try to read it from the env variables.
      *
-     * @param string|null $apiKey   your bugsnag api key
-     * @param string|null $endpoint your bugsnag endpoint
-     * @param bool        $default  if we should register our default callbacks
+     * @param string|null $apiKey         your bugsnag api key
+     * @param string|null $notifyEndpoint your bugsnag notify endpoint
+     * @param bool        $defaults       if we should register our default callbacks
      *
      * @return static
      */
-    public static function make($apiKey = null, $endpoint = null, $defaults = true)
-    {
-        // Retrieves environment variables
+    public static function make(
+        $apiKey = null,
+        $notifyEndpoint = null,
+        $defaults = true
+    ) {
         $env = new Env();
 
         $config = new Configuration($apiKey ?: $env->get('BUGSNAG_API_KEY'));
-        $guzzle = static::makeGuzzle($endpoint ?: $env->get('BUGSNAG_ENDPOINT'));
+        $guzzle = static::makeGuzzle($notifyEndpoint ?: $env->get('BUGSNAG_ENDPOINT'));
 
         $client = new static($config, null, $guzzle);
 
@@ -102,23 +105,27 @@ class Client
     }
 
     /**
-     * Create a new client instance.
-     *
-     * @param \Bugsnag\Configuration                            $config
-     * @param \Bugsnag\Request\ResolverInterface|null           $resolver
-     * @param \GuzzleHttp\ClientInterface|null                  $guzzle
-     * @param \Bugsnag\Shutdown\ShutdownStrategyInterface|null  $shutdownStrategy
-     *
-     * @return void
+     * @param \Bugsnag\Configuration $config
+     * @param \Bugsnag\Request\ResolverInterface|null $resolver
+     * @param \GuzzleHttp\ClientInterface|null $guzzle
+     * @param \Bugsnag\Shutdown\ShutdownStrategyInterface|null $shutdownStrategy
      */
-    public function __construct(Configuration $config, ResolverInterface $resolver = null, ClientInterface $guzzle = null, ShutdownStrategyInterface $shutdownStrategy = null)
-    {
+    public function __construct(
+        Configuration $config,
+        ResolverInterface $resolver = null,
+        GuzzleHttp\ClientInterface $guzzle = null,
+        ShutdownStrategyInterface $shutdownStrategy = null
+    ) {
+        $guzzle = $guzzle ?: self::makeGuzzle();
+
+        $this->syncNotifyEndpointWithGuzzleBaseUri($config, $guzzle);
+
         $this->config = $config;
         $this->resolver = $resolver ?: new BasicResolver();
         $this->recorder = new Recorder();
         $this->pipeline = new Pipeline();
-        $this->http = new HttpClient($config, $guzzle ?: static::makeGuzzle());
-        $this->sessionTracker = new SessionTracker($config);
+        $this->http = new HttpClient($config, $guzzle);
+        $this->sessionTracker = new SessionTracker($config, $this->http);
 
         $this->registerMiddleware(new NotificationSkipper($config));
         $this->registerMiddleware(new BreadcrumbData($this->recorder));
@@ -135,19 +142,62 @@ class Client
      * @param string|null $base
      * @param array       $options
      *
-     * @return \GuzzleHttp\ClientInterface
+     * @return GuzzleHttp\ClientInterface
      */
     public static function makeGuzzle($base = null, array $options = [])
     {
-        $key = method_exists(ClientInterface::class, 'request') ? 'base_uri' : 'base_url';
+        $key = self::getGuzzleBaseUriOptionName();
 
-        $options[$key] = $base ?: static::ENDPOINT;
+        $options[$key] = $base ?: Configuration::NOTIFY_ENDPOINT;
 
         if ($path = static::getCaBundlePath()) {
             $options['verify'] = $path;
         }
 
-        return new GuzzleClient($options);
+        return new GuzzleHttp\Client($options);
+    }
+
+    /**
+     * Get the base URL/URI option name, which depends on the Guzzle version.
+     *
+     * @return string
+     */
+    private static function getGuzzleBaseUriOptionName()
+    {
+        return method_exists(GuzzleHttp\ClientInterface::class, 'request')
+            ? 'base_uri'
+            : 'base_url';
+    }
+
+    /**
+     * Get the base URL/URI, which depends on the Guzzle version.
+     *
+     * @return mixed
+     */
+    private function getGuzzleBaseUri(GuzzleHttp\ClientInterface $guzzle)
+    {
+        return method_exists(GuzzleHttp\ClientInterface::class, 'getBaseUrl')
+            ? $guzzle->getBaseUrl()
+            : $guzzle->getConfig(self::getGuzzleBaseUriOptionName());
+    }
+
+    /**
+     * Ensure the notify endpoint is synchronised with Guzzle's base URL.
+     *
+     * @param \Bugsnag\Configuration $configuration
+     * @param \GuzzleHttp\ClientInterface $guzzle
+     *
+     * @return void
+     */
+    private function syncNotifyEndpointWithGuzzleBaseUri(
+        Configuration $configuration,
+        GuzzleHttp\ClientInterface $guzzle
+    ) {
+        $base = $this->getGuzzleBaseUri($guzzle);
+
+        if (is_string($base) || method_exists($base, '__toString')) {
+            $configuration->setNotifyEndpoint((string) $base);
+        }
     }
 
     /**
@@ -326,13 +376,13 @@ class Client
     /**
      * Notify Bugsnag of a deployment.
      *
-     * @deprecated This function is being deprecated in favour of `build`.
-     *
      * @param string|null $repository the repository from which you are deploying the code
      * @param string|null $branch     the source control branch from which you are deploying
      * @param string|null $revision   the source control revision you are currently deploying
      *
      * @return void
+     *
+     * @deprecated Use {@see Client::build} instead.
      */
     public function deploy($repository = null, $branch = null, $revision = null)
     {
@@ -379,7 +429,7 @@ class Client
      */
     public function flush()
     {
-        $this->http->send();
+        $this->http->sendEvents();
     }
 
     /**
@@ -768,23 +818,33 @@ class Client
     }
 
     /**
-     * Set session tracking state and pass in optional guzzle.
+     * Set notification delivery endpoint.
      *
-     * @param bool $track whether to track sessions
+     * @param string $endpoint
      *
      * @return $this
      */
-    public function setAutoCaptureSessions($track)
+    public function setNotifyEndpoint($endpoint)
     {
-        $this->config->setAutoCaptureSessions($track);
+        $this->config->setNotifyEndpoint($endpoint);
 
         return $this;
     }
 
     /**
+     * Get notification delivery endpoint.
+     *
+     * @return string
+     */
+    public function getNotifyEndpoint()
+    {
+        return $this->config->getNotifyEndpoint();
+    }
+
+    /**
      * Set session delivery endpoint.
      *
-     * @param string $endpoint the session endpoint
+     * @param string $endpoint
      *
      * @return $this
      */
@@ -796,27 +856,17 @@ class Client
     }
 
     /**
-     * Get the session client.
+     * Get session delivery endpoint.
      *
-     * @return \GuzzleHttp\ClientInterface
+     * @return string
      */
-    public function getSessionClient()
+    public function getSessionEndpoint()
     {
-        return $this->config->getSessionClient();
+        return $this->config->getSessionEndpoint();
     }
 
     /**
-     * Whether should be auto-capturing sessions.
-     *
-     * @return bool
-     */
-    public function shouldCaptureSessions()
-    {
-        return $this->config->shouldCaptureSessions();
-    }
-
-    /**
-     * Sets the build endpoint.
+     * Set the build endpoint.
      *
      * @param string $endpoint the build endpoint
      *
@@ -830,12 +880,48 @@ class Client
     }
 
     /**
-     * Returns the build endpoint.
+     * Get the build endpoint.
      *
      * @return string
      */
     public function getBuildEndpoint()
     {
         return $this->config->getBuildEndpoint();
+    }
+
+    /**
+     * Set session tracking state.
+     *
+     * @param bool $track whether to track sessions
+     *
+     * @return $this
+     */
+    public function setAutoCaptureSessions($track)
+    {
+        $this->config->setAutoCaptureSessions($track);
+
+        return $this;
+    }
+
+    /**
+     * Whether should be auto-capturing sessions.
+     *
+     * @return bool
+     */
+    public function shouldCaptureSessions()
+    {
+        return $this->config->shouldCaptureSessions();
+    }
+
+    /**
+     * Get the session client.
+     *
+     * @return \GuzzleHttp\ClientInterface
+     *
+     * @deprecated This will be removed in the next major version.
+     */
+    public function getSessionClient()
+    {
+        return $this->config->getSessionClient();
     }
 }

--- a/src/Configuration.php
+++ b/src/Configuration.php
@@ -75,7 +75,7 @@ class Configuration
      */
     protected $notifier = [
         'name' => 'Bugsnag PHP (Official)',
-        'version' => '3.21.0',
+        'version' => '3.22.0',
         'url' => 'https://bugsnag.com',
     ];
 

--- a/src/Configuration.php
+++ b/src/Configuration.php
@@ -481,7 +481,7 @@ class Configuration
      *
      * @param array $data an associative array containing the new data to be added
      *
-     * @return this
+     * @return $this
      */
     public function mergeDeviceData($data)
     {

--- a/src/Configuration.php
+++ b/src/Configuration.php
@@ -7,22 +7,21 @@ use InvalidArgumentException;
 class Configuration
 {
     /**
-     * The default endpoint.
-     *
-     * @var string
+     * The default endpoint for event notifications.
+     */
+    const NOTIFY_ENDPOINT = 'https://notify.bugsnag.com';
+
+    /**
+     * The default endpoint for session tracking.
      */
     const SESSION_ENDPOINT = 'https://sessions.bugsnag.com';
 
     /**
-     * The default build endpoint.
-     *
-     * @var string
+     * The default endpoint for build notifications.
      */
     const BUILD_ENDPOINT = 'https://build.bugsnag.com';
 
     /**
-     * The Bugsnag API Key.
-     *
      * @var string
      */
     protected $apiKey;
@@ -126,22 +125,25 @@ class Configuration
      * A client to use to send sessions.
      *
      * @var \GuzzleHttp\ClientInterface
+     *
+     * @deprecated This will be removed in the next major version.
      */
     protected $sessionClient;
 
     /**
-     * The endpoint to deliver sessions to.
-     *
+     * @var string
+     */
+    protected $notifyEndpoint = self::NOTIFY_ENDPOINT;
+
+    /**
      * @var string
      */
     protected $sessionEndpoint = self::SESSION_ENDPOINT;
 
     /**
-     * The endpoint to deliver build notifications to.
-     *
      * @var string
      */
-    protected $buildEndpoint;
+    protected $buildEndpoint = self::BUILD_ENDPOINT;
 
     /**
      * Create a new config instance.
@@ -590,23 +592,33 @@ class Configuration
     }
 
     /**
-     * Set session tracking state and pass in optional guzzle.
+     * Set event notification endpoint.
      *
-     * @param bool $track whether to track sessions
+     * @param string $endpoint
      *
      * @return $this
      */
-    public function setAutoCaptureSessions($track)
+    public function setNotifyEndpoint($endpoint)
     {
-        $this->autoCaptureSessions = $track;
+        $this->notifyEndpoint = $endpoint;
 
         return $this;
     }
 
     /**
+     * Get event notification endpoint.
+     *
+     * @return string
+     */
+    public function getNotifyEndpoint()
+    {
+        return $this->notifyEndpoint;
+    }
+
+    /**
      * Set session delivery endpoint.
      *
-     * @param string $endpoint the session endpoint
+     * @param string $endpoint
      *
      * @return $this
      */
@@ -614,37 +626,21 @@ class Configuration
     {
         $this->sessionEndpoint = $endpoint;
 
-        $this->sessionClient = Client::makeGuzzle($this->sessionEndpoint);
-
         return $this;
     }
 
     /**
-     * Get the session client.
+     * Get session delivery endpoint.
      *
-     * @return \GuzzleHttp\ClientInterface
+     * @return string
      */
-    public function getSessionClient()
+    public function getSessionEndpoint()
     {
-        if (is_null($this->sessionClient)) {
-            $this->sessionClient = Client::makeGuzzle($this->sessionEndpoint);
-        }
-
-        return $this->sessionClient;
+        return $this->sessionEndpoint;
     }
 
     /**
-     * Whether should be auto-capturing sessions.
-     *
-     * @return bool
-     */
-    public function shouldCaptureSessions()
-    {
-        return $this->autoCaptureSessions;
-    }
-
-    /**
-     * Sets the build endpoint.
+     * Set the build endpoint.
      *
      * @param string $endpoint the build endpoint
      *
@@ -658,16 +654,52 @@ class Configuration
     }
 
     /**
-     * Returns the build endpoint.
+     * Get the build endpoint.
      *
      * @return string
      */
     public function getBuildEndpoint()
     {
-        if (isset($this->buildEndpoint)) {
-            return $this->buildEndpoint;
+        return $this->buildEndpoint;
+    }
+
+    /**
+     * Set session tracking state.
+     *
+     * @param bool $track whether to track sessions
+     *
+     * @return $this
+     */
+    public function setAutoCaptureSessions($track)
+    {
+        $this->autoCaptureSessions = $track;
+
+        return $this;
+    }
+
+    /**
+     * Whether should be auto-capturing sessions.
+     *
+     * @return bool
+     */
+    public function shouldCaptureSessions()
+    {
+        return $this->autoCaptureSessions;
+    }
+
+    /**
+     * Get the session client.
+     *
+     * @return \GuzzleHttp\ClientInterface
+     *
+     * @deprecated This will be removed in the next major version.
+     */
+    public function getSessionClient()
+    {
+        if (is_null($this->sessionClient)) {
+            $this->sessionClient = Client::makeGuzzle($this->sessionEndpoint);
         }
 
-        return self::BUILD_ENDPOINT;
+        return $this->sessionClient;
     }
 }

--- a/src/Env.php
+++ b/src/Env.php
@@ -12,9 +12,9 @@ class Env
      * Copied from phpdotenv: https://github.com/vlucas/phpdotenv/blob/2.6/src/Loader.php#L291. BSD 3-Clause license
      * provided at this bottom of this file.
      *
-     * @param $name
+     * @param string $name
      *
-     * @return array|false|mixed|string|null
+     * @return mixed
      */
     public function get($name)
     {

--- a/src/HttpClient.php
+++ b/src/HttpClient.php
@@ -9,15 +9,11 @@ use RuntimeException;
 class HttpClient
 {
     /**
-     * The config instance.
-     *
      * @var \Bugsnag\Configuration
      */
     protected $config;
 
     /**
-     * The guzzle client instance.
-     *
      * @var \GuzzleHttp\ClientInterface
      */
     protected $guzzle;
@@ -37,19 +33,25 @@ class HttpClient
     const MAX_SIZE = 1048576;
 
     /**
-     * The current payload version.
-     *
-     * @var string
+     * The payload version for the error notification API.
      */
-    const PAYLOAD_VERSION = '4.0';
+    const NOTIFY_PAYLOAD_VERSION = '4.0';
 
     /**
-     * Create a new http client instance.
+     * The payload version for the session API.
+     */
+    const SESSION_PAYLOAD_VERSION = '1.0';
+
+    /**
+     * The payload version for the error notification API.
      *
-     * @param \Bugsnag\Configuration      $config the configuration instance
-     * @param \GuzzleHttp\ClientInterface $guzzle the guzzle client instance
-     *
-     * @return void
+     * @deprecated Use {self::NOTIFY_PAYLOAD_VERSION} instead.
+     */
+    const PAYLOAD_VERSION = self::NOTIFY_PAYLOAD_VERSION;
+
+    /**
+     * @param \Bugsnag\Configuration $config
+     * @param \GuzzleHttp\ClientInterface $guzzle
      */
     public function __construct(Configuration $config, ClientInterface $guzzle)
     {
@@ -60,7 +62,7 @@ class HttpClient
     /**
      * Add a report to the queue.
      *
-     * @param \Bugsnag\Report $report the bugsnag report instance
+     * @param \Bugsnag\Report $report
      *
      * @return void
      */
@@ -72,11 +74,11 @@ class HttpClient
     /**
      * Notify Bugsnag of a deployment.
      *
-     * @deprecated This method should no longer be used in favour of sendBuildReport.
-     *
      * @param array $data the deployment information
      *
      * @return void
+     *
+     * @deprecated Use {@see self::sendBuildReport} instead.
      */
     public function deploy(array $data)
     {
@@ -90,7 +92,9 @@ class HttpClient
 
         $data['apiKey'] = $this->config->getApiKey();
 
-        $this->post('deploy', ['json' => $data]);
+        $uri = rtrim($this->config->getNotifyEndpoint(), '/').'/deploy';
+
+        $this->post($uri, ['json' => $data]);
     }
 
     /**
@@ -104,16 +108,15 @@ class HttpClient
     {
         $app = $this->config->getAppData();
 
-        $data = [];
-        $sourceControl = [];
-
-        if (isset($app['version'])) {
-            $data['appVersion'] = $app['version'];
-        } else {
+        if (!isset($app['version'])) {
             error_log('Bugsnag Warning: App version is not set. Unable to send build report.');
 
             return;
         }
+
+        $data = ['appVersion' => $app['version']];
+
+        $sourceControl = [];
 
         if (isset($buildInfo['repository'])) {
             $sourceControl['repository'] = $buildInfo['repository'];
@@ -144,12 +147,21 @@ class HttpClient
         }
 
         $data['releaseStage'] = $app['releaseStage'];
-
         $data['apiKey'] = $this->config->getApiKey();
 
-        $endpoint = $this->config->getBuildEndpoint();
+        $this->post($this->config->getBuildEndpoint(), ['json' => $data]);
+    }
 
-        $this->post($endpoint, ['json' => $data]);
+    /**
+     * Deliver everything on the queue to Bugsnag.
+     *
+     * @return void
+     *
+     * @deprecated Use {HttpClient::sendEvents} instead.
+     */
+    public function send()
+    {
+        $this->sendEvents();
     }
 
     /**
@@ -157,13 +169,16 @@ class HttpClient
      *
      * @return void
      */
-    public function send()
+    public function sendEvents()
     {
         if (!$this->queue) {
             return;
         }
 
-        $this->postJson('', $this->build());
+        $this->deliverEvents(
+            $this->config->getNotifyEndpoint(),
+            $this->getEventPayload()
+        );
 
         $this->queue = [];
     }
@@ -172,8 +187,20 @@ class HttpClient
      * Build the request data to send.
      *
      * @return array
+     *
+     * @deprecated Use {@see HttpClient::getEventPayload} instead.
      */
     protected function build()
+    {
+        return $this->getEventPayload();
+    }
+
+    /**
+     * Get the event payload to send.
+     *
+     * @return array
+     */
+    protected function getEventPayload()
     {
         $events = [];
 
@@ -193,16 +220,39 @@ class HttpClient
     }
 
     /**
+     * Send a session data payload to Bugsnag.
+     *
+     * @param array $payload
+     *
+     * @return void
+     */
+    public function sendSessions(array $payload)
+    {
+        $this->post(
+            $this->config->getSessionEndpoint(),
+            [
+                'json' => $payload,
+                'headers' => $this->getHeaders(self::SESSION_PAYLOAD_VERSION),
+            ]
+        );
+    }
+
+    /**
      * Builds the array of headers to send.
+     *
+     * @param string $version The payload version to use. This defaults to the
+     *                        notify payload version if not given. The default
+     *                        value should not be relied upon and will be removed
+     *                        in the next major release.
      *
      * @return array
      */
-    protected function getHeaders()
+    protected function getHeaders($version = self::NOTIFY_PAYLOAD_VERSION)
     {
         return [
             'Bugsnag-Api-Key' => $this->config->getApiKey(),
             'Bugsnag-Sent-At' => strftime('%Y-%m-%dT%H:%M:%S'),
-            'Bugsnag-Payload-Version' => self::PAYLOAD_VERSION,
+            'Bugsnag-Payload-Version' => $version,
         ];
     }
 
@@ -224,14 +274,29 @@ class HttpClient
     }
 
     /**
-     * Post the given data to Bugsnag in json form.
+     * Deliver the given events to the notification API.
+     *
+     * @param string $uri  the uri to hit
+     * @param array  $data the data send
+     *
+     * @return void
+     *
+     * @deprecated Use {HttpClient::deliverEvents} instead
+     */
+    protected function postJson($uri, array $data)
+    {
+        $this->deliverEvents($uri, $data);
+    }
+
+    /**
+     * Deliver the given events to the notification API.
      *
      * @param string $uri  the uri to hit
      * @param array  $data the data send
      *
      * @return void
      */
-    protected function postJson($uri, array $data)
+    protected function deliverEvents($uri, array $data)
     {
         // Try to send the whole lot, or without the meta data for the first
         // event. If failed, try to send the first event, and then the rest of
@@ -243,8 +308,9 @@ class HttpClient
         } catch (RuntimeException $e) {
             if (count($data['events']) > 1) {
                 $event = array_shift($data['events']);
-                $this->postJson($uri, array_merge($data, ['events' => [$event]]));
-                $this->postJson($uri, $data);
+
+                $this->deliverEvents($uri, array_merge($data, ['events' => [$event]]));
+                $this->deliverEvents($uri, $data);
             } else {
                 error_log('Bugsnag Warning: '.$e->getMessage());
             }
@@ -252,12 +318,14 @@ class HttpClient
             return;
         }
 
-        // Send via guzzle and log any failures
         try {
-            $this->post($uri, [
-                'json' => $normalized,
-                'headers' => $this->getHeaders(),
-            ]);
+            $this->post(
+                $uri,
+                [
+                    'json' => $normalized,
+                    'headers' => $this->getHeaders(self::NOTIFY_PAYLOAD_VERSION),
+                ]
+            );
         } catch (Exception $e) {
             error_log('Bugsnag Warning: Couldn\'t notify. '.$e->getMessage());
         }
@@ -268,7 +336,7 @@ class HttpClient
      *
      * @param array $data the data to normalize
      *
-     * @throws \RuntimeException
+     * @throws RuntimeException
      *
      * @return array
      */

--- a/src/Middleware/SessionData.php
+++ b/src/Middleware/SessionData.php
@@ -4,46 +4,58 @@ namespace Bugsnag\Middleware;
 
 use Bugsnag\Client;
 use Bugsnag\Report;
+use Bugsnag\SessionTracker;
 
 class SessionData
 {
     /**
-     * The client instance.
+     * @var \Bgusnag\Client
      *
-     * @var \Bugsnag\Client
+     * @deprecated This will be removed in the next major version.
+     *             The constructor parameter will also change to {@see SessionTracker}
      */
     protected $client;
 
     /**
-     * Create a new session data middleware instance.
-     *
-     * @param \Bugsnag\Client $client the client instance.
-     *
-     * @return void
+     * @var \Bugsnag\SessionTracker
+     */
+    private $sessionTracker;
+
+    /**
+     * @param \Bugsnag\Client $client
      */
     public function __construct(Client $client)
     {
         $this->client = $client;
+        $this->sessionTracker = $client->getSessionTracker();
     }
 
     /**
-     * Execute the session data middleware.
+     * Attaches session information to the Report, if the SessionTracker has a
+     * current session. Note that this is not the same as the PHP session, but
+     * refers to the current request.
      *
-     * @param \Bugsnag\Report $report the bugsnag report instance
-     * @param callable        $next   the next stage callback
+     * If the SessionTracker does not have a current session, the report will
+     * not be changed.
+     *
+     * @param \Bugsnag\Report $report
+     * @param callable $next
      *
      * @return void
      */
     public function __invoke(Report $report, callable $next)
     {
-        $session = $this->client->getSessionTracker()->getCurrentSession();
-        if (!is_null($session) && isset($session['events'])) {
+        $session = $this->sessionTracker->getCurrentSession();
+
+        if (isset($session['events'])) {
             if ($report->getUnhandled()) {
                 $session['events']['unhandled'] += 1;
             } else {
                 $session['events']['handled'] += 1;
             }
+
             $report->setSessionData($session);
+            $this->sessionTracker->setCurrentSession($session);
         }
 
         $next($report);

--- a/src/Middleware/SessionData.php
+++ b/src/Middleware/SessionData.php
@@ -9,7 +9,7 @@ use Bugsnag\SessionTracker;
 class SessionData
 {
     /**
-     * @var \Bgusnag\Client
+     * @var \Bugsnag\Client
      *
      * @deprecated This will be removed in the next major version.
      *             The constructor parameter will also change to {@see SessionTracker}

--- a/src/Report.php
+++ b/src/Report.php
@@ -10,11 +10,11 @@ use Throwable;
 class Report
 {
     /**
-     * The payload version.
+     * The payload version for the error notification API.
      *
-     * @var string
+     * @deprecated Use {HttpClient::NOTIFY_PAYLOAD_VERSION} instead.
      */
-    const PAYLOAD_VERSION = HttpClient::PAYLOAD_VERSION;
+    const PAYLOAD_VERSION = HttpClient::NOTIFY_PAYLOAD_VERSION;
 
     /**
      * The config object.
@@ -652,7 +652,7 @@ class Report
             'device' => array_merge(['time' => $this->time], $this->config->getDeviceData()),
             'user' => $this->getUser(),
             'context' => $this->getContext(),
-            'payloadVersion' => HttpClient::PAYLOAD_VERSION,
+            'payloadVersion' => HttpClient::NOTIFY_PAYLOAD_VERSION,
             'severity' => $this->getSeverity(),
             'exceptions' => $this->exceptionArray(),
             'breadcrumbs' => $this->breadcrumbs,

--- a/tests/Callbacks/RequestContextTest.php
+++ b/tests/Callbacks/RequestContextTest.php
@@ -9,6 +9,9 @@ use Bugsnag\Request\BasicResolver;
 use Bugsnag\Tests\TestCase;
 use Exception;
 
+/**
+ * @runTestsInSeparateProcesses
+ */
 class RequestContextTest extends TestCase
 {
     /** @var \Bugsnag\Configuration */

--- a/tests/Callbacks/RequestCookiesTest.php
+++ b/tests/Callbacks/RequestCookiesTest.php
@@ -9,6 +9,9 @@ use Bugsnag\Request\BasicResolver;
 use Bugsnag\Tests\TestCase;
 use Exception;
 
+/**
+ * @runTestsInSeparateProcesses
+ */
 class RequestCookiesTest extends TestCase
 {
     /** @var \Bugsnag\Configuration */

--- a/tests/Callbacks/RequestMetaDataTest.php
+++ b/tests/Callbacks/RequestMetaDataTest.php
@@ -9,6 +9,9 @@ use Bugsnag\Request\BasicResolver;
 use Bugsnag\Tests\TestCase;
 use Exception;
 
+/**
+ * @runTestsInSeparateProcesses
+ */
 class RequestMetaDataTest extends TestCase
 {
     /** @var \Bugsnag\Configuration */

--- a/tests/Callbacks/RequestSessionTest.php
+++ b/tests/Callbacks/RequestSessionTest.php
@@ -9,6 +9,9 @@ use Bugsnag\Request\BasicResolver;
 use Bugsnag\Tests\TestCase;
 use Exception;
 
+/**
+ * @runTestsInSeparateProcesses
+ */
 class RequestSessionTest extends TestCase
 {
     /** @var \Bugsnag\Configuration */

--- a/tests/Callbacks/RequestUserTest.php
+++ b/tests/Callbacks/RequestUserTest.php
@@ -9,6 +9,9 @@ use Bugsnag\Request\BasicResolver;
 use Bugsnag\Tests\TestCase;
 use Exception;
 
+/**
+ * @runTestsInSeparateProcesses
+ */
 class RequestUserTest extends TestCase
 {
     /** @var \Bugsnag\Configuration */

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -31,6 +31,14 @@ class ClientTest extends TestCase
                              ->getMock();
     }
 
+    protected function tearDown()
+    {
+        putenv('BUGSNAG_API_KEY');
+        putenv('BUGSNAG_ENDPOINT');
+        unset($_ENV['BUGSNAG_API_KEY']);
+        unset($_ENV['BUGSNAG_ENDPOINT']);
+    }
+
     public function testManualErrorNotification()
     {
         $this->client->expects($this->once())->method('notify');
@@ -77,77 +85,82 @@ class ClientTest extends TestCase
         });
     }
 
-    protected function getGuzzle(Client $client)
+    public function testTheNotifyEndpointHasASensibleDefault()
     {
-        $prop = (new ReflectionClass($client))->getProperty('http');
-        $prop->setAccessible(true);
+        $client = Client::make('123');
+        $expected = 'https://notify.bugsnag.com';
 
-        $http = $prop->getValue($client);
-
-        $prop = (new ReflectionClass($http))->getProperty('guzzle');
-        $prop->setAccessible(true);
-
-        return $prop->getValue($http);
+        $this->assertEquals($expected, $client->getNotifyEndpoint());
     }
 
-    public function testDefaultSetup()
-    {
-        $this->assertEquals(
-            new Uri('https://notify.bugsnag.com'),
-            self::getGuzzleBaseUri($this->getGuzzle(Client::make('123')))
-        );
-    }
-
-    public function testCanMake()
+    public function testTheNotifyEndpointCanBeSetByPassingItToMake()
     {
         $client = Client::make('123', 'https://example.com');
 
-        $this->assertInstanceOf(Client::class, $client);
-
-        $this->assertEquals(
-            new Uri('https://example.com'),
-            self::getGuzzleBaseUri($this->getGuzzle($client))
-        );
+        $this->assertEquals('https://example.com', $client->getNotifyEndpoint());
     }
 
-    public function testCanMakeFromEnv()
+    public function testTheApiKeyAndNotifyEndpointCanBeSetViaEnvironmentVariables()
     {
-        try {
-            putenv('BUGSNAG_API_KEY=foo-baz');
-            putenv('BUGSNAG_ENDPOINT=http://foo.com');
+        putenv('BUGSNAG_API_KEY=foobar');
+        putenv('BUGSNAG_ENDPOINT=http://foo.com');
 
-            $client = Client::make();
+        $client = Client::make();
 
-            $this->assertInstanceOf(Client::class, $client);
-
-            $this->assertEquals(
-                new Uri('http://foo.com'),
-                self::getGuzzleBaseUri($this->getGuzzle($client))
-            );
-        } finally {
-            putenv('BUGSNAG_API_KEY=');
-            putenv('BUGSNAG_ENDPOINT=');
-        }
+        $this->assertEquals('foobar', $client->getApiKey());
+        $this->assertEquals('http://foo.com', $client->getNotifyEndpoint());
     }
 
-    public function testCanMakeFromEnvSuperglobal()
+    public function testTheApiKeyAndNotifyEndpointCanBeSetViaEnvSuperglobal()
     {
-        try {
-            $_ENV['BUGSNAG_API_KEY'] = 'foo-bar';
-            $_ENV['BUGSNAG_ENDPOINT'] = 'http://bar.com';
+        $_ENV['BUGSNAG_API_KEY'] = 'baz';
+        $_ENV['BUGSNAG_ENDPOINT'] = 'http://bar.com';
 
-            $client = Client::make();
+        $client = Client::make();
 
-            $this->assertInstanceOf(Client::class, $client);
+        $this->assertEquals('baz', $client->getApiKey());
+        $this->assertEquals('http://bar.com', $client->getNotifyEndpoint());
+    }
 
-            $this->assertEquals(
-                new Uri('http://bar.com'),
-                self::getGuzzleBaseUri($this->getGuzzle($client))
+    public function testTheNotifyEndpointCanBeSetBySettingItOnAGuzzleInstance()
+    {
+        $guzzle = new Guzzle([
+            $this->getGuzzleBaseOptionName() => 'https://example.com',
+        ]);
+
+        $client = new Client(new Configuration('abc'), null, $guzzle);
+
+        $this->assertEquals('https://example.com', $client->getNotifyEndpoint());
+    }
+
+    public function testTheNotifyEndpointCanBeSetBySettingItOnAGuzzleInstanceWithAnArray()
+    {
+        if (!$this->isUsingGuzzle5()) {
+            $this->markTestSkipped(
+                'This test is not relevant on Guzzle >= 6 as arrays are not allowed'
             );
-        } finally {
-            unset($_ENV['BUGSNAG_API_KEY']);
-            unset($_ENV['BUGSNAG_ENDPOINT']);
         }
+
+        $guzzle = new Guzzle([
+            $this->getGuzzleBaseOptionName() => [
+                'https://example.com/{version}', ['version' => '1.2'],
+            ],
+        ]);
+
+        $client = new Client(new Configuration('abc'), null, $guzzle);
+
+        $this->assertEquals('https://example.com/1.2', $client->getNotifyEndpoint());
+    }
+
+    public function testTheNotifyEndpointCanBeSetBySettingItOnAGuzzleInstanceWithAUriInstance()
+    {
+        $guzzle = new Guzzle([
+            $this->getGuzzleBaseOptionName() => new Uri('https://example.com:8080/hello/world'),
+        ]);
+
+        $client = new Client(new Configuration('abc'), null, $guzzle);
+
+        $this->assertEquals('https://example.com:8080/hello/world', $client->getNotifyEndpoint());
     }
 
     public function testBeforeNotifySkipsError()
@@ -871,12 +884,22 @@ class ClientTest extends TestCase
         $this->assertSame('https://example', $client->getBuildEndpoint());
     }
 
-    public function testSessionClient()
+    public function testTheSessionEndpointHasASensibleDefault()
     {
         $client = Client::make('foo');
-        $this->assertSame($client, $client->setSessionEndpoint('https://example'));
-        $sessionClient = $client->getSessionClient();
-        $this->assertEquals(new Uri('https://example'), self::getGuzzleBaseUri($sessionClient));
+        $expected = 'https://sessions.bugsnag.com';
+
+        $this->assertSame($expected, $client->getSessionEndpoint());
+    }
+
+    public function testTheSessionEndpointCanBeSetIfNecessary()
+    {
+        $client = Client::make('foo');
+        $expected = 'https://example.com';
+
+        $client->setSessionEndpoint($expected);
+
+        $this->assertSame($expected, $client->getSessionEndpoint());
     }
 
     public function testSetAutoCaptureSessions()

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -133,6 +133,42 @@ class ClientTest extends TestCase
         $this->assertEquals('https://example.com', $client->getNotifyEndpoint());
     }
 
+    public function testTheNotifyEndpointWontBeOverwrittenWhenOneIsAlreadySetOnConfiguration()
+    {
+        $config = new Configuration('abc');
+        $config->setNotifyEndpoint('https://foo.com');
+
+        $client = new Client($config);
+
+        $this->assertEquals('https://foo.com', $client->getNotifyEndpoint());
+    }
+
+    public function testTheNotifyEndpointWontBeOverwrittenByGivenGuzzleInstanceWhenOneIsAlreadySetOnConfiguration()
+    {
+        $config = new Configuration('abc');
+        $config->setNotifyEndpoint('https://foo.com');
+
+        $guzzle = new Guzzle([
+            $this->getGuzzleBaseOptionName() => 'https://example.com',
+        ]);
+
+        $client = new Client($config, null, $guzzle);
+
+        $this->assertEquals('https://foo.com', $client->getNotifyEndpoint());
+    }
+
+    public function testTheNotifyEndpointWontBeOverwrittenByMakeGuzzleWhenOneIsAlreadySetOnConfiguration()
+    {
+        $config = new Configuration('abc');
+        $config->setNotifyEndpoint('https://foo.com');
+
+        $guzzle = Client::makeGuzzle();
+
+        $client = new Client($config, null, $guzzle);
+
+        $this->assertEquals('https://foo.com', $client->getNotifyEndpoint());
+    }
+
     public function testTheNotifyEndpointCanBeSetBySettingItOnAGuzzleInstanceWithAnArray()
     {
         if (!$this->isUsingGuzzle5()) {

--- a/tests/ConfigurationTest.php
+++ b/tests/ConfigurationTest.php
@@ -3,8 +3,6 @@
 namespace Bugsnag\Tests;
 
 use Bugsnag\Configuration;
-use GuzzleHttp\Client as GuzzleClient;
-use GuzzleHttp\Psr7\Uri;
 
 class ConfigurationTest extends TestCase
 {
@@ -278,42 +276,31 @@ class ConfigurationTest extends TestCase
         $this->assertSame(['f1' => 1], $this->config->getDeviceData()['assoc_array_field']);
     }
 
-    public function testSessionTrackingDefaults()
+    public function testSessionTrackingIsDisabledByDefault()
     {
         $this->assertFalse($this->config->shouldCaptureSessions());
     }
 
-    public function testSessionTrackingSetTrue()
+    public function testSessionTrackingCanBeEnabled()
     {
-        $this->assertFalse($this->config->shouldCaptureSessions());
-
         $this->config->setAutoCaptureSessions(true);
 
         $this->assertTrue($this->config->shouldCaptureSessions());
-
-        $client = $this->config->getSessionClient();
-
-        $this->assertSame(GuzzleClient::class, get_class($client));
-
-        $this->assertEquals(new Uri(Configuration::SESSION_ENDPOINT), self::getGuzzleBaseUri($client));
     }
 
-    public function testSessionTrackingSetEndpoint()
+    public function testTheSessionEndpointHasASensibleDefault()
     {
-        $testUrl = 'https://testurl.com';
+        $expected = 'https://sessions.bugsnag.com';
 
-        $this->assertFalse($this->config->shouldCaptureSessions());
+        $this->assertSame($expected, $this->config->getSessionEndpoint());
+    }
 
-        $this->config->setAutoCaptureSessions(true);
+    public function testTheSessionEndpointCanBeSetIfNecessary()
+    {
+        $expected = 'https://example.com';
 
-        $this->assertTrue($this->config->shouldCaptureSessions());
+        $this->config->setSessionEndpoint($expected);
 
-        $this->config->setSessionEndpoint($testUrl);
-
-        $client = $this->config->getSessionClient();
-
-        $this->assertSame(GuzzleClient::class, get_class($client));
-
-        $this->assertEquals(new Uri($testUrl), self::getGuzzleBaseUri($client));
+        $this->assertSame($expected, $this->config->getSessionEndpoint());
     }
 }

--- a/tests/HandlerTest.php
+++ b/tests/HandlerTest.php
@@ -22,6 +22,9 @@ namespace Bugsnag\Tests {
     use Bugsnag\Handler;
     use Exception;
 
+    /**
+     * @runTestsInSeparateProcesses
+     */
     class HandlerTest extends TestCase
     {
         protected $client;

--- a/tests/HttpClientTest.php
+++ b/tests/HttpClientTest.php
@@ -46,7 +46,7 @@ class HttpClientTest extends TestCase
         $this->assertCount(1, $invocations = $spy->getInvocations());
         $params = self::getInvocationParameters($invocations[0]);
         $this->assertCount(self::getGuzzleExpectedParamCount(), $params);
-        $this->assertSame('', self::getGuzzlePostUriParam($params));
+        $this->assertSame($this->config->getNotifyEndpoint(), self::getGuzzlePostUriParam($params));
         $options = self::getGuzzlePostOptionsParam($params);
         $this->assertInternalType('array', $options);
         $this->assertInternalType('array', $options['json']['notifier']);
@@ -91,7 +91,7 @@ class HttpClientTest extends TestCase
         $this->assertCount(1, $invocations = $spy->getInvocations());
         $params = self::getInvocationParameters($invocations[0]);
         $this->assertCount(self::getGuzzleExpectedParamCount(), $params);
-        $this->assertSame('', self::getGuzzlePostUriParam($params));
+        $this->assertSame($this->config->getNotifyEndpoint(), self::getGuzzlePostUriParam($params));
         $options = self::getGuzzlePostOptionsParam($params);
         $this->assertInternalType('array', $options);
         $this->assertInternalType('array', $options['json']['notifier']);
@@ -140,7 +140,7 @@ class HttpClientTest extends TestCase
         $this->assertCount(1, $invocations = $spy->getInvocations());
         $params = self::getInvocationParameters($invocations[0]);
         $this->assertCount(self::getGuzzleExpectedParamCount(), $params);
-        $this->assertSame('', self::getGuzzlePostUriParam($params));
+        $this->assertSame($this->config->getNotifyEndpoint(), self::getGuzzlePostUriParam($params));
         $options = self::getGuzzlePostOptionsParam($params);
         $this->assertInternalType('array', $options);
         $this->assertInternalType('array', $options['json']['notifier']);

--- a/tests/ReportTest.php
+++ b/tests/ReportTest.php
@@ -125,11 +125,11 @@ class ReportTest extends TestCase
 
         $this->assertInstanceOf(Stacktrace::class, $trace);
 
-        if (class_exists(\PHPUnit_Framework_TestCase::class)) {
-            $this->assertCount(8, $trace->toArray());
-        } else {
-            $this->assertCount(7, $trace->toArray());
-        }
+        // Before PHPUnit 7 tests were executed via ReflectionMethod::invokeArgs
+        // which adds a line to the stacktrace
+        $expectedCount = $this->isPhpUnit7() ? 11 : 12;
+
+        $this->assertCount($expectedCount, $trace->toArray());
     }
 
     public function testNoticeName()

--- a/tests/RequestTest.php
+++ b/tests/RequestTest.php
@@ -10,6 +10,9 @@ use Bugsnag\Request\RequestInterface;
 use Bugsnag\Request\ResolverInterface;
 use ReflectionClass;
 
+/**
+ * @runTestsInSeparateProcesses
+ */
 class RequestTest extends TestCase
 {
     protected $resolver;

--- a/tests/SessionTrackerTest.php
+++ b/tests/SessionTrackerTest.php
@@ -3,8 +3,9 @@
 namespace Bugsnag\Tests;
 
 use Bugsnag\Configuration;
+use Bugsnag\HttpClient;
 use Bugsnag\SessionTracker;
-use GuzzleHttp\ClientInterface;
+use GuzzleHttp;
 use InvalidArgumentException;
 use PHPUnit\Framework\MockObject\MockObject;
 use RuntimeException;
@@ -16,30 +17,120 @@ class SessionTrackerTest extends TestCase
     private $sessionTracker;
     /** @var Configuration&MockObject */
     private $config;
-    /** @var ClientInterface&MockObject */
-    private $guzzleClient;
+    /** @var HttpClient&MockObject */
+    private $client;
 
     public function setUp()
     {
         /** @var Configuration&MockObject */
-        $this->config = $this->getMockBuilder(Configuration::class)
-            ->setConstructorArgs(['example-api-key'])
+        $this->config = new Configuration('example-api-key');
+
+        /** @var HttpClient&MockObject */
+        $this->client = $this->getMockBuilder(HttpClient::class)
+            ->disableOriginalConstructor()
             ->getMock();
 
-        $this->sessionTracker = new SessionTracker($this->config);
-
-        $this->guzzleClient = $this->getMockBuilder(ClientInterface::class)
-            ->getMock();
+        $this->sessionTracker = new SessionTracker($this->config, $this->client);
     }
 
-    public function testSendSessionsEmpty()
+    public function testSendSessionsDoesNothingWhenThereAreNoSessionsToSend()
     {
-        $this->config->expects($this->never())->method('getSessionClient');
+        $this->client->expects($this->never())->method('sendSessions');
 
         $this->sessionTracker->sendSessions();
     }
 
-    public function testSendSessionsShouldNotNotify()
+    public function testHttpClientCanBeObtainedViaConfig()
+    {
+        /** @var GuzzleHttp\Client&MockObject */
+        $guzzle = $this->getMockBuilder(GuzzleHttp\Client::class)
+            ->disableOriginalConstructor()
+            ->disableProxyingToOriginalMethods()
+            ->getMock();
+
+        /** @var Configuration&MockObject */
+        $config = $this->getMockBuilder(Configuration::class)
+            ->setConstructorArgs(['example-api-key'])
+            ->getMock();
+
+        $config->expects($this->once())
+            ->method('getSessionClient')
+            ->willReturn($guzzle);
+
+        $config->expects($this->once())
+            ->method('getSessionEndpoint')
+            ->willReturn(Configuration::SESSION_ENDPOINT);
+
+        $config->expects($this->once())->method('shouldNotify')->willReturn(true);
+        $config->expects($this->once())->method('getNotifier')->willReturn('test_notifier');
+        $config->expects($this->once())->method('getDeviceData')->willReturn('device_data');
+        $config->expects($this->once())->method('getAppData')->willReturn('app_data');
+
+        $expectCallback = function ($payload) {
+            $this->assertArrayHasKey('json', $payload);
+            $this->assertArrayHasKey('headers', $payload);
+
+            $json = $payload['json'];
+
+            $this->assertArrayHasKey('notifier', $json);
+            $this->assertArrayHasKey('device', $json);
+            $this->assertArrayHasKey('app', $json);
+            $this->assertArrayHasKey('sessionCounts', $json);
+
+            $this->assertSame('test_notifier', $json['notifier']);
+            $this->assertSame('device_data', $json['device']);
+            $this->assertSame('app_data', $json['app']);
+            $this->assertCount(1, $json['sessionCounts']);
+            $this->assertSame('2000-01-01T00:00:00', $json['sessionCounts'][0]['startedAt']);
+            $this->assertSame(1, $json['sessionCounts'][0]['sessionsStarted']);
+
+            return true;
+        };
+
+        $method = self::getGuzzleMethod();
+        $mock = $guzzle->expects($this->once())->method($method);
+
+        if ($method === 'request') {
+            $mock->with('POST', Configuration::SESSION_ENDPOINT, $this->callback($expectCallback));
+        } else {
+            $mock->with(Configuration::SESSION_ENDPOINT, $this->callback($expectCallback));
+        }
+
+        $sessionTracker = new SessionTracker($config);
+
+        $sessionTracker->setStorageFunction(function () {
+            return ['2000-01-01T00:00:00' => 1];
+        });
+
+        $sessionTracker->sendSessions();
+    }
+
+    public function testSessionsShouldNotSendWhenTheReleaseStageIsIgnored()
+    {
+        $this->config->setReleaseStage('development');
+        $this->config->setNotifyReleaseStages(['production']);
+
+        $this->client->expects($this->never())->method('sendSessions');
+
+        $this->sessionTracker->startSession();
+    }
+
+    public function testConfigurationCanBeChanged()
+    {
+        // The 'newConfig' prevents sessions from being sent because of the
+        // release stage (as proven above). If the original config was used here
+        // then the 'sendSessions' call would be made
+        $newConfig = new Configuration('a different api key');
+        $newConfig->setReleaseStage('development');
+        $newConfig->setNotifyReleaseStages(['production']);
+
+        $this->client->expects($this->never())->method('sendSessions');
+
+        $this->sessionTracker->setConfig($newConfig);
+        $this->sessionTracker->startSession();
+    }
+
+    public function testSessionsShouldNotSendWhenTheReleaseStageIsIgnoredWithStorageFunction()
     {
         $numberOfCalls = 0;
 
@@ -56,34 +147,19 @@ class SessionTrackerTest extends TestCase
             $this->assertSame([], $value, 'Expected the second call to be a write ($value === [])');
         });
 
-        $this->config->expects($this->once())->method('shouldNotify')->willReturn(false);
-        $this->config->expects($this->never())->method('getSessionClient');
+        $this->config->setReleaseStage('development');
+        $this->config->setNotifyReleaseStages(['production']);
+
+        $this->client->expects($this->never())->method('sendSessions');
 
         $this->sessionTracker->sendSessions();
 
         $this->assertSame(2, $numberOfCalls, 'Expected there to be two calls to the session storage function');
     }
 
-    /**
-     * @param mixed $returnValue
-     *
-     * @return void
-     *
-     * @dataProvider storageFunctionEmptyReturnValueProvider
-     */
-    public function testSendSessionsReturnsEarlyWhenGetSessionCountsReturnsAValueThatsNotAPopulatedArray($returnValue)
+    public function testSendSessionsDoesNotDeliverSessionsWhenThereAreNoSessions()
     {
-        $this->sessionTracker->setStorageFunction(function () use ($returnValue) {
-            return $returnValue;
-        });
-
-        $this->config->expects($this->never())->method('shouldNotify');
-        $this->config->expects($this->never())->method('getSessionClient');
-        $this->config->expects($this->never())->method('getNotifier');
-        $this->config->expects($this->never())->method('getDeviceData');
-        $this->config->expects($this->never())->method('getAppData');
-        $this->config->expects($this->never())->method('getApiKey');
-        $this->guzzleClient->expects($this->never())->method($this->getGuzzleMethod());
+        $this->client->expects($this->never())->method('sendSessions');
 
         $this->sessionTracker->sendSessions();
     }
@@ -95,7 +171,25 @@ class SessionTrackerTest extends TestCase
      *
      * @dataProvider storageFunctionEmptyReturnValueProvider
      */
-    public function testStartSessionDoesNotDeliverSessionsWhenLastSentIsNotAnInteger($returnValue)
+    public function testSendSessionsDoesNotDeliverSessionsWhenGetSessionCountsReturnsAValueThatsNotAPopulatedArray($returnValue)
+    {
+        $this->sessionTracker->setStorageFunction(function () use ($returnValue) {
+            return $returnValue;
+        });
+
+        $this->client->expects($this->never())->method('sendSessions');
+
+        $this->sessionTracker->sendSessions();
+    }
+
+    /**
+     * @param mixed $returnValue
+     *
+     * @return void
+     *
+     * @dataProvider storageFunctionEmptyReturnValueProvider
+     */
+    public function testStartSessionDoesNotDeliverSessionsWhenLastSentIsNotAnIntegerWithStorageFunction($returnValue)
     {
         $this->sessionTracker->setStorageFunction(function ($key) use ($returnValue) {
             // We only care about the "last sent" value here
@@ -106,13 +200,7 @@ class SessionTrackerTest extends TestCase
             return null;
         });
 
-        $this->config->expects($this->never())->method('shouldNotify');
-        $this->config->expects($this->never())->method('getSessionClient');
-        $this->config->expects($this->never())->method('getNotifier');
-        $this->config->expects($this->never())->method('getDeviceData');
-        $this->config->expects($this->never())->method('getAppData');
-        $this->config->expects($this->never())->method('getApiKey');
-        $this->guzzleClient->expects($this->never())->method($this->getGuzzleMethod());
+        $this->client->expects($this->never())->method('sendSessions');
 
         $this->sessionTracker->startSession();
     }
@@ -124,19 +212,13 @@ class SessionTrackerTest extends TestCase
      *
      * @dataProvider storageFunctionEmptyReturnValueProvider
      */
-    public function testStartSessionDoesNotDeliverSessionsWhenGetSessionCountsReturnsAValueThatsNotAPopulatedArray($returnValue)
+    public function testStartSessionDoesNotDeliverSessionsWhenGetSessionCountsReturnsAValueThatsNotAPopulatedArrayWithStorageFunction($returnValue)
     {
         $this->sessionTracker->setStorageFunction(function ($key) use ($returnValue) {
             return $returnValue;
         });
 
-        $this->config->expects($this->never())->method('shouldNotify');
-        $this->config->expects($this->never())->method('getSessionClient');
-        $this->config->expects($this->never())->method('getNotifier');
-        $this->config->expects($this->never())->method('getDeviceData');
-        $this->config->expects($this->never())->method('getAppData');
-        $this->config->expects($this->never())->method('getApiKey');
-        $this->guzzleClient->expects($this->never())->method($this->getGuzzleMethod());
+        $this->client->expects($this->never())->method('sendSessions');
 
         $this->sessionTracker->startSession();
     }
@@ -154,46 +236,29 @@ class SessionTrackerTest extends TestCase
         ];
     }
 
-    public function testSendSessionsSuccess()
+    public function testSendSessionsSendsSessionsWhenThereAreSessionsToSendFromTheStorageFunction()
     {
         $this->sessionTracker->setStorageFunction(function () {
             return ['2000-01-01T00:00:00' => 1];
         });
 
-        $this->config->expects($this->once())->method('shouldNotify')->willReturn(true);
-        $this->config->expects($this->once())->method('getSessionClient')->willReturn($this->guzzleClient);
-        $this->config->expects($this->once())->method('getNotifier')->willReturn('test_notifier');
-        $this->config->expects($this->once())->method('getDeviceData')->willReturn('device_data');
-        $this->config->expects($this->once())->method('getAppData')->willReturn('app_data');
-        $this->config->expects($this->once())->method('getApiKey')->willReturn('example-api-key');
-
-        $expectCallback = function ($sessionPayload) {
-            return count($sessionPayload) == 2
-                && $sessionPayload['json']['notifier'] === 'test_notifier'
-                && $sessionPayload['json']['device'] === 'device_data'
-                && $sessionPayload['json']['app'] === 'app_data'
-                && count($sessionPayload['json']['sessionCounts']) === 1
-                && $sessionPayload['json']['sessionCounts'][0]['startedAt'] === '2000-01-01T00:00:00'
-                && $sessionPayload['json']['sessionCounts'][0]['sessionsStarted'] === 1
-                && $sessionPayload['headers']['Bugsnag-Api-Key'] == 'example-api-key'
-                && preg_match('/(\d+\.)+/', $sessionPayload['headers']['Bugsnag-Payload-Version'])
-                && preg_match('/\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}/', $sessionPayload['headers']['Bugsnag-Sent-At']);
-        };
-
-        if ($this->getGuzzleMethod() === 'post') {
-            $this->guzzleClient->expects($this->once())
-                ->method($this->getGuzzleMethod())
-                ->with('', $this->callback($expectCallback));
-        } else {
-            $this->guzzleClient->expects($this->once())
-                ->method($this->getGuzzleMethod())
-                ->with('POST', '', $this->callback($expectCallback));
-        }
+        $this->client->expects($this->once())
+            ->method('sendSessions')
+            ->with($this->singleSessionExpectationCallback());
 
         $this->sessionTracker->sendSessions();
     }
 
-    public function testStartSessionsSuccess()
+    public function testStartSessionSendsTheSessionItStartsImmediately()
+    {
+        $this->client->expects($this->once())
+            ->method('sendSessions')
+            ->with($this->singleSessionExpectationCallback());
+
+        $this->sessionTracker->startSession();
+    }
+
+    public function testStartSessionSendsTheSessionItStartsImmediatelyWithStorageFunction()
     {
         $session = [];
 
@@ -209,35 +274,9 @@ class SessionTrackerTest extends TestCase
             $session[$key] = $value;
         });
 
-        $this->config->expects($this->once())->method('shouldNotify')->willReturn(true);
-        $this->config->expects($this->once())->method('getSessionClient')->willReturn($this->guzzleClient);
-        $this->config->expects($this->once())->method('getNotifier')->willReturn('test_notifier');
-        $this->config->expects($this->once())->method('getDeviceData')->willReturn('device_data');
-        $this->config->expects($this->once())->method('getAppData')->willReturn('app_data');
-        $this->config->expects($this->once())->method('getApiKey')->willReturn('example-api-key');
-
-        $expectCallback = function ($sessionPayload) {
-            return count($sessionPayload) == 2
-                && $sessionPayload['json']['notifier'] === 'test_notifier'
-                && $sessionPayload['json']['device'] === 'device_data'
-                && $sessionPayload['json']['app'] === 'app_data'
-                && count($sessionPayload['json']['sessionCounts']) === 1
-                && preg_match('/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}$/', $sessionPayload['json']['sessionCounts'][0]['startedAt'])
-                && $sessionPayload['json']['sessionCounts'][0]['sessionsStarted'] === 1
-                && $sessionPayload['headers']['Bugsnag-Api-Key'] == 'example-api-key'
-                && preg_match('/(\d+\.)+/', $sessionPayload['headers']['Bugsnag-Payload-Version'])
-                && preg_match('/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}$/', $sessionPayload['headers']['Bugsnag-Sent-At']);
-        };
-
-        if ($this->getGuzzleMethod() === 'post') {
-            $this->guzzleClient->expects($this->once())
-                ->method($this->getGuzzleMethod())
-                ->with('', $this->callback($expectCallback));
-        } else {
-            $this->guzzleClient->expects($this->once())
-                ->method($this->getGuzzleMethod())
-                ->with('POST', '', $this->callback($expectCallback));
-        }
+        $this->client->expects($this->once())
+            ->method('sendSessions')
+            ->with($this->singleSessionExpectationCallback());
 
         $this->sessionTracker->startSession();
     }
@@ -263,7 +302,31 @@ class SessionTrackerTest extends TestCase
         $this->sessionTracker->setLockFunctions(function () {}, null);
     }
 
-    public function testSetLockFunctionsSucceedsWhenBothFunctionsAreCallable()
+    public function testLockFunctionsAreCalledWhenStartingSessions()
+    {
+        $locked = false;
+        $lockWasCalled = false;
+        $unlockWasCalled = false;
+
+        $this->sessionTracker->setLockFunctions(
+            function () use (&$locked, &$lockWasCalled) {
+                $locked = true;
+                $lockWasCalled = true;
+            },
+            function () use (&$locked, &$unlockWasCalled) {
+                $locked = false;
+                $unlockWasCalled = true;
+            }
+        );
+
+        $this->sessionTracker->startSession();
+
+        $this->assertFalse($locked, 'Expected not to be locked after sending sessions');
+        $this->assertTrue($lockWasCalled, 'Expected the `lockFunction` to be called');
+        $this->assertTrue($unlockWasCalled, 'Expected the `unlockFunction` to be called');
+    }
+
+    public function testLockFunctionsAreCalledWhenStartingSessionsWithStorageFunction()
     {
         $locked = false;
         $lockWasCalled = false;
@@ -294,10 +357,69 @@ class SessionTrackerTest extends TestCase
             $session[$key] = $value;
         });
 
-        $this->config->expects($this->once())->method('shouldNotify')->willReturn(true);
-        $this->config->expects($this->once())->method('getSessionClient')->willReturn($this->guzzleClient);
-
         $this->sessionTracker->startSession();
+
+        $this->assertFalse($locked, 'Expected not to be locked after sending sessions');
+        $this->assertTrue($lockWasCalled, 'Expected the `lockFunction` to be called');
+        $this->assertTrue($unlockWasCalled, 'Expected the `unlockFunction` to be called');
+    }
+
+    public function testLockFunctionsAreCalledWhenSendingSessions()
+    {
+        $locked = false;
+        $lockWasCalled = false;
+        $unlockWasCalled = false;
+
+        $this->sessionTracker->setLockFunctions(
+            function () use (&$locked, &$lockWasCalled) {
+                $locked = true;
+                $lockWasCalled = true;
+            },
+            function () use (&$locked, &$unlockWasCalled) {
+                $locked = false;
+                $unlockWasCalled = true;
+            }
+        );
+
+        $this->sessionTracker->sendSessions();
+
+        $this->assertFalse($locked, 'Expected not to be locked after sending sessions');
+        $this->assertTrue($lockWasCalled, 'Expected the `lockFunction` to be called');
+        $this->assertTrue($unlockWasCalled, 'Expected the `unlockFunction` to be called');
+    }
+
+    public function testLockFunctionsAreCalledWhenSendingSessionsWithStorageFunction()
+    {
+        $locked = false;
+        $lockWasCalled = false;
+        $unlockWasCalled = false;
+
+        $this->sessionTracker->setLockFunctions(
+            function () use (&$locked, &$lockWasCalled) {
+                $locked = true;
+                $lockWasCalled = true;
+            },
+            function () use (&$locked, &$unlockWasCalled) {
+                $locked = false;
+                $unlockWasCalled = true;
+            }
+        );
+
+        $session = [];
+
+        $this->sessionTracker->setStorageFunction(function ($key, $value = null) use (&$session) {
+            if (!isset($session[$key])) {
+                $session[$key] = null;
+            }
+
+            if ($value === null) {
+                return $session[$key];
+            }
+
+            $session[$key] = $value;
+        });
+
+        $this->sessionTracker->sendSessions();
 
         $this->assertFalse($locked, 'Expected not to be locked after sending sessions');
         $this->assertTrue($lockWasCalled, 'Expected the `lockFunction` to be called');
@@ -325,8 +447,6 @@ class SessionTrackerTest extends TestCase
             throw new RuntimeException('Something went wrong!');
         });
 
-        $this->config->expects($this->never())->method('shouldNotify');
-
         $e = null;
 
         try {
@@ -341,24 +461,148 @@ class SessionTrackerTest extends TestCase
         $this->assertTrue($unlockWasCalled, 'Expected the `unlockFunction` to be called');
     }
 
-    public function testSetRetryFunctionThrowsWhenNotGivenACallable()
+    /**
+     * @return void
+     *
+     * @dataProvider storageFunctionEmptyReturnValueProvider
+     */
+    public function testSetRetryFunctionThrowsWhenNotGivenACallable($value)
     {
         $this->expectedException(InvalidArgumentException::class, 'The retry function must be callable');
 
-        $this->sessionTracker->setRetryFunction(null);
+        $this->sessionTracker->setRetryFunction($value);
     }
 
-    public function testSetStorageFunctionThrowsWhenNotGivenACallable()
+    /**
+     * @return void
+     *
+     * @dataProvider storageFunctionEmptyReturnValueProvider
+     */
+    public function testSetStorageFunctionThrowsWhenNotGivenACallable($value)
     {
         $this->expectedException(InvalidArgumentException::class, 'Storage function must be callable');
 
-        $this->sessionTracker->setStorageFunction(null);
+        $this->sessionTracker->setStorageFunction($value);
     }
 
-    public function testSetSessionFunctionThrowsWhenNotGivenACallable()
+    /**
+     * @return void
+     *
+     * @dataProvider storageFunctionEmptyReturnValueProvider
+     */
+    public function testSetSessionFunctionThrowsWhenNotGivenACallable($value)
     {
         $this->expectedException(InvalidArgumentException::class, 'Session function must be callable');
 
-        $this->sessionTracker->setSessionFunction(null);
+        $this->sessionTracker->setSessionFunction($value);
+    }
+
+    /**
+     * @runInSeparateProcess as we need to mock 'strftime' and 'time'
+     */
+    public function testThereIsAMaximumNumberOfSessionsThatWillBeSent()
+    {
+        // 60 sessions is convenient because they are batched per minute, so we
+        // can pretend to generate one session per minute for an hour
+        $sessionsToGenerate = 60;
+
+        $expectCallback = function ($payload) use ($sessionsToGenerate) {
+            $this->assertArrayHasKey('notifier', $payload);
+            $this->assertArrayHasKey('device', $payload);
+            $this->assertArrayHasKey('app', $payload);
+            $this->assertArrayHasKey('sessionCounts', $payload);
+
+            $this->assertSame($this->config->getNotifier(), $payload['notifier']);
+            $this->assertSame($this->config->getDeviceData(), $payload['device']);
+            $this->assertSame($this->config->getAppData(), $payload['app']);
+
+            $this->assertCount(50, $payload['sessionCounts']);
+            $this->assertLessThan($sessionsToGenerate, count($payload['sessionCounts']));
+
+            // Ensure the dates go in decending order of minutes, starting at 59
+            $expectedMinute = 59;
+
+            foreach ($payload['sessionCounts'] as $session) {
+                $this->assertArrayHasKey('startedAt', $session);
+                $this->assertArrayHasKey('sessionsStarted', $session);
+
+                $date = sprintf('2000-01-01T00:%02s:00', $expectedMinute);
+
+                $this->assertSame($date, $session['startedAt']);
+                $this->assertSame(1, $session['sessionsStarted']);
+
+                $expectedMinute--;
+            }
+
+            return true;
+        };
+
+        $this->client->expects($this->once())
+            ->method('sendSessions')
+            ->with($this->callback($expectCallback));
+
+        $strftimeReturnValues = array_map(
+            function ($minute) {
+                $minute = str_pad($minute, 2, '0', STR_PAD_LEFT);
+
+                return "2000-01-01T00:{$minute}:00";
+            },
+            // range is inclusive but we need to generate 0-59
+            range(0, $sessionsToGenerate - 1)
+        );
+
+        $invocation = 0;
+
+        $strftime = $this->getFunctionMock('Bugsnag', 'strftime');
+        $strftime->expects($this->exactly($sessionsToGenerate))
+            ->withAnyParameters()
+            ->willReturnCallback(function () use ($strftimeReturnValues, &$invocation) {
+                return $strftimeReturnValues[$invocation++];
+            });
+
+        // Mock 'time' to return a negative value, which will stop 'startSession'
+        // from sending sessions. It will be called one more time than the number
+        // of calls to 'startSession', because it's called after sending sessions
+        // successfully too
+        $time = $this->getFunctionMock('Bugsnag', 'time');
+        $time->expects($this->exactly($sessionsToGenerate + 1))->willReturn(-1);
+
+        for ($i = 0; $i < $sessionsToGenerate; $i++) {
+            $this->sessionTracker->startSession();
+        }
+
+        $this->sessionTracker->sendSessions();
+    }
+
+    /**
+     * Get an expectation callback for the typical test case where there is a
+     * single session that is being sent.
+     *
+     * @return \PHPUnit\Framework\Constraint\Callback
+     */
+    private function singleSessionExpectationCallback()
+    {
+        return $this->callback(function ($payload) {
+            $this->assertArrayHasKey('notifier', $payload);
+            $this->assertArrayHasKey('device', $payload);
+            $this->assertArrayHasKey('app', $payload);
+            $this->assertArrayHasKey('sessionCounts', $payload);
+
+            $this->assertSame($this->config->getNotifier(), $payload['notifier']);
+            $this->assertSame($this->config->getDeviceData(), $payload['device']);
+            $this->assertSame($this->config->getAppData(), $payload['app']);
+
+            $this->assertCount(1, $payload['sessionCounts']);
+
+            $session = $payload['sessionCounts'][0];
+
+            $this->assertArrayHasKey('startedAt', $session);
+            $this->assertArrayHasKey('sessionsStarted', $session);
+
+            $this->assertRegExp('/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}$/', $session['startedAt']);
+            $this->assertSame(1, $session['sessionsStarted']);
+
+            return true;
+        });
     }
 }

--- a/tests/Shutdown/PhpShutdownStrategyTest.php
+++ b/tests/Shutdown/PhpShutdownStrategyTest.php
@@ -8,6 +8,9 @@ use Bugsnag\Tests\TestCase;
 use Mockery;
 use phpmock\spy\Spy;
 
+/**
+ * @runTestsInSeparateProcesses
+ */
 class PhpShutdownStrategyTest extends TestCase
 {
     public function testRegisterShutdownFunction()

--- a/tests/StacktraceTest.php
+++ b/tests/StacktraceTest.php
@@ -204,6 +204,9 @@ class StacktraceTest extends TestCase
         }
     }
 
+    /**
+     * @runInSeparateProcess
+     */
     public function testCodeBadFile()
     {
         // Ensure we deal with race conditions ok


### PR DESCRIPTION
## 3.22.0 (2020-08-20)

### Enhancements

* Include all HTTP headers in request metadata
  [#588](https://github.com/bugsnag/bugsnag-php/pull/588)

* The `Client` and `SessionTracker` now share a single Guzzle instance
  [#587](https://github.com/bugsnag/bugsnag-php/pull/587)

### Deprecations

* `Client::ENDPOINT`
  This is ambiguous as we have three separate endpoints
  Use `Configuration::NOTIFY_ENDPOINT` instead

* `HttpClient::PAYLOAD_VERSION`
  This is ambiguous as there is a session payload version too
  Use `HttpClient::NOTIFY_PAYLOAD_VERSION` instead

* `Report::PAYLOAD_VERSION`
  As above. This was also unused by the notifier
  Use `HttpClient::NOTIFY_PAYLOAD_VERSION` instead

* `SessionTracker::$SESSION_PAYLOAD_VERSION`
  Use `HttpClient::SESSION_PAYLOAD_VERSION` instead

* `HttpClient::send`
  Use `HttpClient::sendEvents` instead
  
* `HttpClient::build`
  Use `HttpClient::getEventPayload` instead

* `HttpClient::postJson`
  Use `HttpClient::deliverEvents` instead

* Using the `base_uri`/`base_url` on a Guzzle instance
  The base URI is ambiguous as there are three separate endpoints which could be used, therefore all Guzzle requests now use absolute URIs. We will extract the `base_uri`/`base_url` Guzzle option if one is set and use it as the notification endpoint URI, however this will be removed in the next major version
  Set the notification endpoint manually with `Configuration::setNotifyEndpoint` instead

* Calling `HttpClient::getHeaders` without providing a payload version
  This is deprecated as the version is ambiguous between the notification payload version and session payload version
  Call this with the correct `HttpClient` payload version constants instead

* `Client::getSessionClient` and `Configuration::getSessionClient`
  This method is dangerous to use as there is now only one Guzzle instance used across every request, so changing this client would also affect the notification client. Changes to this Guzzle client will now be ignored
  Use the `$guzzle` parameter of the `Client` constructor to customise the Guzzle client instead

* `SessionData::$client`
  The `SessionData` class will be passed a `SessionTracker` instead of a `Client` instance in its constructor in the next major version

* `SessionTracker` should be constructed with a `HttpClient`
  The `SessionTracker` class should now always be passed a `HttpClient`
  In this version it will construct its own `HttpClient` if one is not provided
  In the next major version, this fallback will be removed and passing a `HttpClient` will be mandatory