### PR TITLE
Apply metadata filters case insensitively

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 Changelog
 =========
 
+## TBD
+
+### Enhancements
+
+* Filters are now applied case insensitively, e.g. 'password' will now also match 'PASSWORD'
+  [#595](https://github.com/bugsnag/bugsnag-php/pull/595)
+
 ## 3.22.0 (2020-08-20)
 
 ### Enhancements

--- a/src/Report.php
+++ b/src/Report.php
@@ -750,7 +750,7 @@ class Report
     {
         if ($isMetaData) {
             foreach ($this->config->getFilters() as $filter) {
-                if (strpos($key, $filter) !== false) {
+                if (stripos($key, $filter) !== false) {
                     return true;
                 }
             }

--- a/tests/ReportTest.php
+++ b/tests/ReportTest.php
@@ -117,6 +117,32 @@ class ReportTest extends TestCase
         $this->assertInternalType('array', $event['exceptions'][0]['stacktrace'][0]['code']);
     }
 
+    public function testFiltersAreCaseInsensitive()
+    {
+        $this->report->setMetaData([
+            'Testing' => [
+                'PASSWORD' => 'a',
+                'Password' => 'b',
+                'passworD' => 'c',
+                'PaSsWoRd' => 'd',
+                'password2' => 'e',
+                '2PASSWORD2POROUS' => 'f',
+            ],
+        ]);
+
+        $this->assertSame(
+            [
+                'PASSWORD' => '[FILTERED]',
+                'Password' => '[FILTERED]',
+                'passworD' => '[FILTERED]',
+                'PaSsWoRd' => '[FILTERED]',
+                'password2' => '[FILTERED]',
+                '2PASSWORD2POROUS' => '[FILTERED]',
+            ],
+            $this->report->toArray()['metaData']['Testing']
+        );
+    }
+
     public function testCanGetStacktrace()
     {
         $this->report->setPHPError(E_NOTICE, 'Broken', 'file', 123);


### PR DESCRIPTION
## Goal

In most of our notifiers, string filters are applied case insensitively as usually you'd always want to filter both 'password' and 'Password' — the casing doesn't matter

In the PHP library, filters have always been case sensitive, which caused issues when filtering cookies by default — the `getallheaders` PHP function (and our own fallback) use an uppercase first letter for header names (`Cookie`), but Laravel uses lowercase headers (`cookie`)

We _could_ decide that headers should always be lowercased (or uppercased, or aLtErNaTe case) but this seems like a good excuse to bring PHP more inline with our other libraries

NB: PHP applies filters if a string contains the filter, rather than exactly matching. I think changing that would be considered a breaking change as it could result in us recording data that should have been filtered, whereas this change could only filter _more_ data than before

## Changeset

- Use `stripos` rather than `strpos` when checking if filters match
- Added more tests for filter matching