### PR TITLE
Filter cookies from events by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ Changelog
 * Filters are now applied case insensitively, e.g. 'password' will now also match 'PASSWORD'
   [#595](https://github.com/bugsnag/bugsnag-php/pull/595)
 
+* Cookies are now filtered from events by default
+  [#596](https://github.com/bugsnag/bugsnag-php/pull/596)
+
 ## 3.22.0 (2020-08-20)
 
 ### Enhancements

--- a/src/Client.php
+++ b/src/Client.php
@@ -6,7 +6,6 @@ use Bugsnag\Breadcrumbs\Breadcrumb;
 use Bugsnag\Breadcrumbs\Recorder;
 use Bugsnag\Callbacks\GlobalMetaData;
 use Bugsnag\Callbacks\RequestContext;
-use Bugsnag\Callbacks\RequestCookies;
 use Bugsnag\Callbacks\RequestMetaData;
 use Bugsnag\Callbacks\RequestSession;
 use Bugsnag\Callbacks\RequestUser;
@@ -264,7 +263,6 @@ class Client
     {
         $this->registerCallback(new GlobalMetaData($this->config))
              ->registerCallback(new RequestMetaData($this->resolver))
-             ->registerCallback(new RequestCookies($this->resolver))
              ->registerCallback(new RequestSession($this->resolver))
              ->registerCallback(new RequestUser($this->resolver))
              ->registerCallback(new RequestContext($this->resolver));

--- a/src/Configuration.php
+++ b/src/Configuration.php
@@ -45,7 +45,7 @@ class Configuration
      *
      * @var string[]
      */
-    protected $filters = ['password'];
+    protected $filters = ['password', 'cookie'];
 
     /**
      * The project root regex.

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -418,6 +418,17 @@ class ClientTest extends TestCase
                 $this->assertSame($expectedMetadata, $report->getMetaData());
                 $this->assertSame(['id' => '8.76.54.321'], $report->getUser());
                 $this->assertSame('GET /abc/xyz', $report->getContext());
+
+                $payload = $report->toArray();
+
+                $this->assertSame(
+                    [
+                        'Host' => 'example.com',
+                        'Cookie' => '[FILTERED]',
+                        'X-Forwarded-For' => '8.76.54.321',
+                    ],
+                    $payload['metaData']['request']['headers']
+                );
             }
         );
 

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -13,6 +13,9 @@ use GuzzleHttp\Psr7\Uri;
 use Mockery;
 use ReflectionClass;
 
+/**
+ * @backupGlobals enabled
+ */
 class ClientTest extends TestCase
 {
     protected $guzzle;
@@ -21,22 +24,21 @@ class ClientTest extends TestCase
 
     protected function setUp()
     {
+        $this->config = new Configuration('example-api-key');
         $this->guzzle = $this->getMockBuilder(Guzzle::class)
-                             ->setMethods([self::getGuzzleMethod()])
-                             ->getMock();
+            ->setMethods([self::getGuzzleMethod()])
+            ->getMock();
 
         $this->client = $this->getMockBuilder(Client::class)
-                             ->setMethods(['notify'])
-                             ->setConstructorArgs([$this->config = new Configuration('example-api-key'), null, $this->guzzle])
-                             ->getMock();
+            ->setMethods(['notify'])
+            ->setConstructorArgs([$this->config, null, $this->guzzle])
+            ->getMock();
     }
 
     protected function tearDown()
     {
         putenv('BUGSNAG_API_KEY');
         putenv('BUGSNAG_ENDPOINT');
-        unset($_ENV['BUGSNAG_API_KEY']);
-        unset($_ENV['BUGSNAG_ENDPOINT']);
     }
 
     public function testManualErrorNotification()
@@ -360,6 +362,69 @@ class ClientTest extends TestCase
 
         $this->assertSame(['type' => 'right'], $report->getSeverityReason());
         $this->assertSame(true, $report->getUnhandled());
+    }
+
+    public function testItAddsADefaultSetOfMiddlewares()
+    {
+        $_SERVER['REQUEST_METHOD'] = 'GET';
+        $_SERVER['REMOTE_ADDR'] = '123.45.67.8';
+        $_SERVER['HTTP_HOST'] = 'example.com';
+        $_SERVER['HTTP_COOKIE'] = 'tastes=delicious';
+        $_SERVER['HTTP_X_FORWARDED_FOR'] = '8.76.54.321';
+        $_SERVER['REQUEST_URI'] = '/abc/xyz?abc=1&xyz=2';
+        $_GET['abc'] = '1';
+        $_GET['xyz'] = '2';
+        $_COOKIE['tastes'] = 'delicious';
+        $_SESSION['abcde'] = '12345';
+
+        $client = Client::make('foo');
+        $config = $client->getConfig();
+        $report = Report::fromPHPThrowable(
+            $config,
+            new Exception('oh no')
+        );
+
+        $config->setMetaData(['abc' => 'xyz']);
+
+        $pipelineCompleted = false;
+        $pipeline = $client->getPipeline();
+
+        $pipeline->execute(
+            $report,
+            function (Report $report) use (&$pipelineCompleted) {
+                $pipelineCompleted = true;
+
+                $expectedMetadata = [
+                    'abc' => 'xyz',
+                    'request' => [
+                        'url' => 'http://example.com/abc/xyz?abc=1&xyz=2',
+                        'httpMethod' => 'GET',
+                        'params' => [
+                            'abc' => '1',
+                            'xyz' => '2',
+                        ],
+                        'clientIp' => '8.76.54.321',
+                        'headers' => [
+                            'Host' => 'example.com',
+                            'Cookie' => 'tastes=delicious',
+                            'X-Forwarded-For' => '8.76.54.321',
+                        ],
+                    ],
+                    'cookies' => [
+                        'tastes' => 'delicious',
+                    ],
+                    'session' => [
+                        'abcde' => '12345',
+                    ],
+                ];
+
+                $this->assertSame($expectedMetadata, $report->getMetaData());
+                $this->assertSame(['id' => '8.76.54.321'], $report->getUser());
+                $this->assertSame('GET /abc/xyz', $report->getContext());
+            }
+        );
+
+        $this->assertTrue($pipelineCompleted);
     }
 
     public function testBreadcrumbsWorks()

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -410,9 +410,6 @@ class ClientTest extends TestCase
                             'X-Forwarded-For' => '8.76.54.321',
                         ],
                     ],
-                    'cookies' => [
-                        'tastes' => 'delicious',
-                    ],
                     'session' => [
                         'abcde' => '12345',
                     ],

--- a/tests/ReportTest.php
+++ b/tests/ReportTest.php
@@ -100,11 +100,16 @@ class ReportTest extends TestCase
         $this->assertSame(['foo' => 'bar'], $this->report->toArray()['user']);
     }
 
-    public function testFiltering()
+    public function testDefaultFilters()
     {
-        $this->report->setMetaData(['Testing' => ['password' => '123456']]);
+        $this->report->setMetaData([
+            'Testing' => ['password' => '123456', 'Cookie' => 'abc=xyz'],
+        ]);
 
-        $this->assertSame(['password' => '[FILTERED]'], $this->report->toArray()['metaData']['Testing']);
+        $this->assertSame(
+            ['password' => '[FILTERED]', 'Cookie' => '[FILTERED]'],
+            $this->report->toArray()['metaData']['Testing']
+        );
     }
 
     public function testExceptionsNotFiltered()


### PR DESCRIPTION
## Goal

In other notifiers, the cookies header is filtered by default and we don't collect a 'Cookies' tab — this PR brings PHP inline

Cookies can still be recorded by a user by removing it as a filtered value and adding the cookie callback. The filter controls whether it shows in 'Request &rarr; Headers' and the callback adds the 'Cookies' tab

```php
$bugsnag = \Bugsnag\Client::make();

$bugsnag->setFilters(['password']);
$bugsnag->registerCallback(
    new \Bugsnag\Callbacks\RequestCookies(
        new \Bugsnag\Request\BasicResolver()
    )
);
```

## Changeset

- No longer register the `RequestCookies` callback by default
- `Configuration::$filters` now contains `cookie`, to filter the cookie header
- Added a test for the default callbacks, which also ensures cookies aren't collected as a separate tab and the cookie header is filtered