### PR TITLE
Add HTTP basic auth headers to default filters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ Changelog
 * Cookies are now filtered from events by default
   [#596](https://github.com/bugsnag/bugsnag-php/pull/596)
 
+* HTTP basic auth headers are filtered from events by default
+  [#597](https://github.com/bugsnag/bugsnag-php/pull/597)
+
 ## 3.22.0 (2020-08-20)
 
 ### Enhancements

--- a/src/Configuration.php
+++ b/src/Configuration.php
@@ -45,7 +45,14 @@ class Configuration
      *
      * @var string[]
      */
-    protected $filters = ['password', 'cookie'];
+    protected $filters = [
+        'password',
+        'cookie',
+        'authorization',
+        'php-auth-user',
+        'php-auth-pw',
+        'php-auth-digest',
+    ];
 
     /**
      * The project root regex.

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -372,6 +372,7 @@ class ClientTest extends TestCase
         $_SERVER['HTTP_COOKIE'] = 'tastes=delicious';
         $_SERVER['HTTP_X_FORWARDED_FOR'] = '8.76.54.321';
         $_SERVER['REQUEST_URI'] = '/abc/xyz?abc=1&xyz=2';
+        $_SERVER['HTTP_AUTHORIZATION'] = 'Basic YTpi';
         $_GET['abc'] = '1';
         $_GET['xyz'] = '2';
         $_COOKIE['tastes'] = 'delicious';
@@ -408,6 +409,7 @@ class ClientTest extends TestCase
                             'Host' => 'example.com',
                             'Cookie' => 'tastes=delicious',
                             'X-Forwarded-For' => '8.76.54.321',
+                            'Authorization' => 'Basic YTpi',
                         ],
                     ],
                     'session' => [
@@ -426,6 +428,7 @@ class ClientTest extends TestCase
                         'Host' => 'example.com',
                         'Cookie' => '[FILTERED]',
                         'X-Forwarded-For' => '8.76.54.321',
+                        'Authorization' => '[FILTERED]',
                     ],
                     $payload['metaData']['request']['headers']
                 );

--- a/tests/ReportTest.php
+++ b/tests/ReportTest.php
@@ -102,12 +102,27 @@ class ReportTest extends TestCase
 
     public function testDefaultFilters()
     {
-        $this->report->setMetaData([
-            'Testing' => ['password' => '123456', 'Cookie' => 'abc=xyz'],
-        ]);
+        $metadata = array_reduce(
+            $this->config->getFilters(),
+            function ($metadata, $filter) {
+                $metadata[$filter] = "abc {$filter} xyz";
+
+                return $metadata;
+            },
+            []
+        );
+
+        $this->report->setMetaData(['Testing' => $metadata]);
 
         $this->assertSame(
-            ['password' => '[FILTERED]', 'Cookie' => '[FILTERED]'],
+            [
+                'password' => '[FILTERED]',
+                'cookie' => '[FILTERED]',
+                'authorization' => '[FILTERED]',
+                'php-auth-user' => '[FILTERED]',
+                'php-auth-pw' => '[FILTERED]',
+                'php-auth-digest' => '[FILTERED]',
+            ],
             $this->report->toArray()['metaData']['Testing']
         );
     }


### PR DESCRIPTION
## Goal

This PR adds the "authorization" header and related PHP auth headers to the default list of filters. This matches the behaviour of our other server notifiers (e.g. Ruby & Python)

## Design

Technically only "authorization" is used as a header, but PHP will parse the username & password (or digest) too when using HTTP basic/digest auth

These aren't counted as headers by PHP (or by bugsnag-php), but Symfony's HTTP Foundation library treats them as headers. Since a lot of other projects also use Symfony's HTTP Foundation (e.g. Laravel), it makes sense to add them as default filters too

## Testing

Built on tests added in #596 and manually tested with vanilla PHP, Laravel and Symfony