### PR TITLE
Release v3.23.0

### DIFF
--- a/.styleci.yml
+++ b/.styleci.yml
@@ -9,3 +9,4 @@ enabled:
 finder:
   exclude: Bugsnag
   not-name: catchall.php
+  not-path: tests/phpt/fixtures

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 Changelog
 =========
 
-## TBD
+## 3.23.0 (2020-09-14)
 
 ### Enhancements
 
@@ -43,7 +43,7 @@ Changelog
 
 * `HttpClient::send`
   Use `HttpClient::sendEvents` instead
-  
+
 * `HttpClient::build`
   Use `HttpClient::getEventPayload` instead
 
@@ -68,7 +68,7 @@ Changelog
 * `SessionTracker` should be constructed with a `HttpClient`
   The `SessionTracker` class should now always be passed a `HttpClient`
   In this version it will construct its own `HttpClient` if one is not provided
-  In the next major version, this fallback will be removed and passing a `HttpClient` will be mandatory 
+  In the next major version, this fallback will be removed and passing a `HttpClient` will be mandatory
 
 ## 3.21.0 (2020-04-29)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ Changelog
 * Cookies are now filtered from events by default
   [#596](https://github.com/bugsnag/bugsnag-php/pull/596)
 
+* HTTP basic auth headers are filtered from events by default
+  [#597](https://github.com/bugsnag/bugsnag-php/pull/597)
+
 ## 3.22.0 (2020-08-20)
 
 ### Enhancements

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ Changelog
 * Filters are now applied case insensitively, e.g. 'password' will now also match 'PASSWORD'
   [#595](https://github.com/bugsnag/bugsnag-php/pull/595)
 
+* Cookies are now filtered from events by default
+  [#596](https://github.com/bugsnag/bugsnag-php/pull/596)
+
 ## 3.22.0 (2020-08-20)
 
 ### Enhancements

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 Changelog
 =========
 
+## TBD
+
+### Enhancements
+
+* Filters are now applied case insensitively, e.g. 'password' will now also match 'PASSWORD'
+  [#595](https://github.com/bugsnag/bugsnag-php/pull/595)
+
 ## 3.22.0 (2020-08-20)
 
 ### Enhancements

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -18,6 +18,7 @@
     <testsuites>
         <testsuite name="Bugsnag PHP Test Suite">
             <directory suffix="Test.php">./tests</directory>
+            <directory suffix=".phpt">./tests/phpt</directory>
         </testsuite>
     </testsuites>
     <filter>

--- a/src/Client.php
+++ b/src/Client.php
@@ -6,7 +6,6 @@ use Bugsnag\Breadcrumbs\Breadcrumb;
 use Bugsnag\Breadcrumbs\Recorder;
 use Bugsnag\Callbacks\GlobalMetaData;
 use Bugsnag\Callbacks\RequestContext;
-use Bugsnag\Callbacks\RequestCookies;
 use Bugsnag\Callbacks\RequestMetaData;
 use Bugsnag\Callbacks\RequestSession;
 use Bugsnag\Callbacks\RequestUser;
@@ -264,7 +263,6 @@ class Client
     {
         $this->registerCallback(new GlobalMetaData($this->config))
              ->registerCallback(new RequestMetaData($this->resolver))
-             ->registerCallback(new RequestCookies($this->resolver))
              ->registerCallback(new RequestSession($this->resolver))
              ->registerCallback(new RequestUser($this->resolver))
              ->registerCallback(new RequestContext($this->resolver));

--- a/src/Configuration.php
+++ b/src/Configuration.php
@@ -45,7 +45,7 @@ class Configuration
      *
      * @var string[]
      */
-    protected $filters = ['password'];
+    protected $filters = ['password', 'cookie'];
 
     /**
      * The project root regex.

--- a/src/Configuration.php
+++ b/src/Configuration.php
@@ -82,7 +82,7 @@ class Configuration
      */
     protected $notifier = [
         'name' => 'Bugsnag PHP (Official)',
-        'version' => '3.22.0',
+        'version' => '3.23.0',
         'url' => 'https://bugsnag.com',
     ];
 

--- a/src/Configuration.php
+++ b/src/Configuration.php
@@ -45,7 +45,14 @@ class Configuration
      *
      * @var string[]
      */
-    protected $filters = ['password', 'cookie'];
+    protected $filters = [
+        'password',
+        'cookie',
+        'authorization',
+        'php-auth-user',
+        'php-auth-pw',
+        'php-auth-digest',
+    ];
 
     /**
      * The project root regex.

--- a/src/Report.php
+++ b/src/Report.php
@@ -750,7 +750,7 @@ class Report
     {
         if ($isMetaData) {
             foreach ($this->config->getFilters() as $filter) {
-                if (strpos($key, $filter) !== false) {
+                if (stripos($key, $filter) !== false) {
                     return true;
                 }
             }

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -372,6 +372,7 @@ class ClientTest extends TestCase
         $_SERVER['HTTP_COOKIE'] = 'tastes=delicious';
         $_SERVER['HTTP_X_FORWARDED_FOR'] = '8.76.54.321';
         $_SERVER['REQUEST_URI'] = '/abc/xyz?abc=1&xyz=2';
+        $_SERVER['HTTP_AUTHORIZATION'] = 'Basic YTpi';
         $_GET['abc'] = '1';
         $_GET['xyz'] = '2';
         $_COOKIE['tastes'] = 'delicious';
@@ -408,6 +409,7 @@ class ClientTest extends TestCase
                             'Host' => 'example.com',
                             'Cookie' => 'tastes=delicious',
                             'X-Forwarded-For' => '8.76.54.321',
+                            'Authorization' => 'Basic YTpi',
                         ],
                     ],
                     'session' => [
@@ -426,6 +428,7 @@ class ClientTest extends TestCase
                         'Host' => 'example.com',
                         'Cookie' => '[FILTERED]',
                         'X-Forwarded-For' => '8.76.54.321',
+                        'Authorization' => '[FILTERED]',
                     ],
                     $payload['metaData']['request']['headers']
                 );

--- a/tests/ReportTest.php
+++ b/tests/ReportTest.php
@@ -117,6 +117,32 @@ class ReportTest extends TestCase
         $this->assertInternalType('array', $event['exceptions'][0]['stacktrace'][0]['code']);
     }
 
+    public function testFiltersAreCaseInsensitive()
+    {
+        $this->report->setMetaData([
+            'Testing' => [
+                'PASSWORD' => 'a',
+                'Password' => 'b',
+                'passworD' => 'c',
+                'PaSsWoRd' => 'd',
+                'password2' => 'e',
+                '2PASSWORD2POROUS' => 'f',
+            ],
+        ]);
+
+        $this->assertSame(
+            [
+                'PASSWORD' => '[FILTERED]',
+                'Password' => '[FILTERED]',
+                'passworD' => '[FILTERED]',
+                'PaSsWoRd' => '[FILTERED]',
+                'password2' => '[FILTERED]',
+                '2PASSWORD2POROUS' => '[FILTERED]',
+            ],
+            $this->report->toArray()['metaData']['Testing']
+        );
+    }
+
     public function testCanGetStacktrace()
     {
         $this->report->setPHPError(E_NOTICE, 'Broken', 'file', 123);

--- a/tests/ReportTest.php
+++ b/tests/ReportTest.php
@@ -100,11 +100,16 @@ class ReportTest extends TestCase
         $this->assertSame(['foo' => 'bar'], $this->report->toArray()['user']);
     }
 
-    public function testFiltering()
+    public function testDefaultFilters()
     {
-        $this->report->setMetaData(['Testing' => ['password' => '123456']]);
+        $this->report->setMetaData([
+            'Testing' => ['password' => '123456', 'Cookie' => 'abc=xyz'],
+        ]);
 
-        $this->assertSame(['password' => '[FILTERED]'], $this->report->toArray()['metaData']['Testing']);
+        $this->assertSame(
+            ['password' => '[FILTERED]', 'Cookie' => '[FILTERED]'],
+            $this->report->toArray()['metaData']['Testing']
+        );
     }
 
     public function testExceptionsNotFiltered()

--- a/tests/ReportTest.php
+++ b/tests/ReportTest.php
@@ -102,12 +102,27 @@ class ReportTest extends TestCase
 
     public function testDefaultFilters()
     {
-        $this->report->setMetaData([
-            'Testing' => ['password' => '123456', 'Cookie' => 'abc=xyz'],
-        ]);
+        $metadata = array_reduce(
+            $this->config->getFilters(),
+            function ($metadata, $filter) {
+                $metadata[$filter] = "abc {$filter} xyz";
+
+                return $metadata;
+            },
+            []
+        );
+
+        $this->report->setMetaData(['Testing' => $metadata]);
 
         $this->assertSame(
-            ['password' => '[FILTERED]', 'Cookie' => '[FILTERED]'],
+            [
+                'password' => '[FILTERED]',
+                'cookie' => '[FILTERED]',
+                'authorization' => '[FILTERED]',
+                'php-auth-user' => '[FILTERED]',
+                'php-auth-pw' => '[FILTERED]',
+                'php-auth-digest' => '[FILTERED]',
+            ],
             $this->report->toArray()['metaData']['Testing']
         );
     }

--- a/tests/phpt/Utilities/FakeGuzzle.php
+++ b/tests/phpt/Utilities/FakeGuzzle.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace Bugsnag\Tests\phpt\Utilities;
+
+/**
+ * This file creates a 'FakeGuzzle' class, which is actually an alias of a
+ * different class to allow us to be compatible with the Guzzle ClientInterface
+ * across major versions.
+ *
+ * The implementations should never be used directly, instead always refer to
+ * 'FakeGuzzle'. Otherwise tests will only work on one Guzzle version
+ */
+
+use GuzzleHttp\ClientInterface;
+use RuntimeException;
+
+$fakeGuzzleMapping = [
+    5 => FakeGuzzle5::class,
+    6 => FakeGuzzle6::class,
+    7 => FakeGuzzle7::class,
+];
+
+// Parse a version number like '1.0.0' into the major version only (1)
+$parseFullVersionNumber = function ($version) {
+    return (int) explode('.', $version, 1)[0];
+};
+
+$guzzleMajorVersion = null;
+
+if (defined(ClientInterface::class.'::MAJOR_VERSION')) {
+    // Guzzle 7 defines 'MAJOR_VERSION' (as an integer)
+    $guzzleMajorVersion = constant(ClientInterface::class.'::MAJOR_VERSION');
+} elseif (defined(ClientInterface::class.'::VERSION')) {
+    // Guzzle 5 & 6 define 'VERSION', e.g. '5.0.0'
+    $version = constant(ClientInterface::class.'::VERSION');
+
+    $guzzleMajorVersion = $parseFullVersionNumber($version);
+}
+
+if ($guzzleMajorVersion === null) {
+    throw new RuntimeException('Unable to determine Guzzle major version!');
+}
+
+if (!isset($fakeGuzzleMapping[$guzzleMajorVersion])) {
+    throw new RuntimeException(sprintf(
+        "Unsupported Guzzle major version '%s'. Supported versions are: %s",
+        $guzzleMajorVersion,
+        implode(', ', array_keys($fakeGuzzleMapping))
+    ));
+}
+
+function reportRequest($method, $uri, $options)
+{
+    $numberOfEvents = 0;
+
+    if (isset($options['json']['events'])) {
+        $numberOfEvents = count($options['json']['events']);
+    }
+
+    $events = $numberOfEvents === 1 ? 'event' : 'events';
+
+    echo "Guzzle request made ({$numberOfEvents} {$events})!\n";
+    echo "* Method: '{$method}'\n";
+    echo "* URI: '{$uri}'\n";
+}
+
+// Create the 'FakeGuzzle' class as an alias of the correct implementation,
+// based on the installed Guzzle version
+class_alias($fakeGuzzleMapping[$guzzleMajorVersion], FakeGuzzle::class, true);

--- a/tests/phpt/Utilities/FakeGuzzle5.php
+++ b/tests/phpt/Utilities/FakeGuzzle5.php
@@ -1,0 +1,83 @@
+<?php
+
+namespace Bugsnag\Tests\phpt\Utilities;
+
+use BadMethodCallException;
+use GuzzleHttp\ClientInterface;
+use GuzzleHttp\Message\RequestInterface;
+use GuzzleHttp\Message\Response;
+
+/**
+ * A Guzzle 5 compatible implementation of ClientInterface for use in PHPT tests.
+ *
+ * This should never be used directly; use 'FakeGuzzle' instead!
+ */
+class FakeGuzzle5 implements ClientInterface
+{
+    public function post($url = null, array $options = [])
+    {
+        reportRequest('POST', $url, $options);
+
+        return new Response(200);
+    }
+
+    public function createRequest($method, $url = null, array $options = [])
+    {
+        throw new BadMethodCallException(__METHOD__.' is not implemented!');
+    }
+
+    public function get($url = null, $options = [])
+    {
+        throw new BadMethodCallException(__METHOD__.' is not implemented!');
+    }
+
+    public function head($url = null, array $options = [])
+    {
+        throw new BadMethodCallException(__METHOD__.' is not implemented!');
+    }
+
+    public function delete($url = null, array $options = [])
+    {
+        throw new BadMethodCallException(__METHOD__.' is not implemented!');
+    }
+
+    public function put($url = null, array $options = [])
+    {
+        throw new BadMethodCallException(__METHOD__.' is not implemented!');
+    }
+
+    public function patch($url = null, array $options = [])
+    {
+        throw new BadMethodCallException(__METHOD__.' is not implemented!');
+    }
+
+    public function options($url = null, array $options = [])
+    {
+        throw new BadMethodCallException(__METHOD__.' is not implemented!');
+    }
+
+    public function send(RequestInterface $request)
+    {
+        throw new BadMethodCallException(__METHOD__.' is not implemented!');
+    }
+
+    public function getDefaultOption($keyOrPath = null)
+    {
+        throw new BadMethodCallException(__METHOD__.' is not implemented!');
+    }
+
+    public function setDefaultOption($keyOrPath, $value)
+    {
+        throw new BadMethodCallException(__METHOD__.' is not implemented!');
+    }
+
+    public function getBaseUrl()
+    {
+        throw new BadMethodCallException(__METHOD__.' is not implemented!');
+    }
+
+    public function getEmitter()
+    {
+        throw new BadMethodCallException(__METHOD__.' is not implemented!');
+    }
+}

--- a/tests/phpt/Utilities/FakeGuzzle6.php
+++ b/tests/phpt/Utilities/FakeGuzzle6.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace Bugsnag\Tests\phpt\Utilities;
+
+use BadMethodCallException;
+use GuzzleHttp\ClientInterface;
+use GuzzleHttp\Psr7\Response;
+use Psr\Http\Message\RequestInterface;
+
+/**
+ * A Guzzle 6 compatible implementation of ClientInterface for use in PHPT tests.
+ *
+ * This should never be used directly; use 'FakeGuzzle' instead!
+ */
+class FakeGuzzle6 implements ClientInterface
+{
+    public function request($method, $uri, array $options = [])
+    {
+        reportRequest($method, $uri, $options);
+
+        return new Response();
+    }
+
+    public function send(RequestInterface $request, array $options = [])
+    {
+        throw new BadMethodCallException(__METHOD__.' is not implemented!');
+    }
+
+    public function sendAsync(RequestInterface $request, array $options = [])
+    {
+        throw new BadMethodCallException(__METHOD__.' is not implemented!');
+    }
+
+    public function requestAsync($method, $uri, array $options = [])
+    {
+        throw new BadMethodCallException(__METHOD__.' is not implemented!');
+    }
+
+    public function getConfig($option = null)
+    {
+        throw new BadMethodCallException(__METHOD__.' is not implemented!');
+    }
+}

--- a/tests/phpt/Utilities/FakeGuzzle7.php
+++ b/tests/phpt/Utilities/FakeGuzzle7.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace Bugsnag\Tests\phpt\Utilities;
+
+use BadMethodCallException;
+use GuzzleHttp\ClientInterface;
+use GuzzleHttp\Promise\PromiseInterface;
+use GuzzleHttp\Psr7\Response;
+use Psr\Http\Message\RequestInterface;
+use Psr\Http\Message\ResponseInterface;
+
+/**
+ * A Guzzle 7 compatible implementation of ClientInterface for use in PHPT tests.
+ *
+ * This should never be used directly; use 'FakeGuzzle' instead!
+ */
+class FakeGuzzle7 implements ClientInterface
+{
+    public function request($method, $uri, array $options = []): ResponseInterface
+    {
+        reportRequest($method, $uri, $options);
+
+        return new Response();
+    }
+
+    public function send(RequestInterface $request, array $options = []): ResponseInterface
+    {
+        throw new BadMethodCallException(__METHOD__.' is not implemented!');
+    }
+
+    public function sendAsync(RequestInterface $request, array $options = []): PromiseInterface
+    {
+        throw new BadMethodCallException(__METHOD__.' is not implemented!');
+    }
+
+    public function requestAsync($method, $uri, array $options = []): PromiseInterface
+    {
+        throw new BadMethodCallException(__METHOD__.' is not implemented!');
+    }
+
+    public function getConfig(?string $option = null)
+    {
+        throw new BadMethodCallException(__METHOD__.' is not implemented!');
+    }
+}

--- a/tests/phpt/_prelude.php
+++ b/tests/phpt/_prelude.php
@@ -1,0 +1,19 @@
+<?php
+
+require __DIR__.'/../../vendor/autoload.php';
+
+use Bugsnag\Client;
+use Bugsnag\Configuration;
+use Bugsnag\Tests\phpt\Utilities\FakeGuzzle;
+
+$config = new Configuration('11111111111111111111111111111111');
+$config->setNotifyEndpoint('http://localhost/notify');
+$config->setSessionEndpoint('http://localhost/sessions');
+
+$guzzle = new FakeGuzzle();
+
+return new Client(
+    $config,
+    null,
+    $guzzle
+);

--- a/tests/phpt/fixtures/parse_error.php
+++ b/tests/phpt/fixtures/parse_error.php
@@ -1,0 +1,3 @@
+<?php
+
+Abc { } Xyz

--- a/tests/phpt/handler_should_call_the_previous_error_handler.phpt
+++ b/tests/phpt/handler_should_call_the_previous_error_handler.phpt
@@ -1,0 +1,60 @@
+--TEST--
+Bugsnag\Handler should call the previous error handler
+--FILE--
+<?php
+$client = require __DIR__ . '/_prelude.php';
+
+set_error_handler(function () {
+    var_dump(func_get_args());
+    return false;
+});
+
+Bugsnag\Handler::registerWithPrevious($client);
+
+$a = $b;
+
+var_dump('Hello!');
+
+include __DIR__ . '/abc/xyz.php';
+?>
+--EXPECTF--
+array(4) {
+  [0]=>
+  int(8)
+  [1]=>
+  string(21) "Undefined variable: b"
+  [2]=>
+  string(%d) "%s"
+  [3]=>
+  int(11)
+}
+
+Notice: Undefined variable: b in %s on line 11
+string(6) "Hello!"
+array(4) {
+  [0]=>
+  int(2)
+  [1]=>
+  string(%d) "include(%s/abc/xyz.php): failed to open stream: No such file or directory"
+  [2]=>
+  string(%d) "%s"
+  [3]=>
+  int(15)
+}
+
+Warning: include(%s/abc/xyz.php): failed to open stream: No such file or directory in %s on line 15
+array(4) {
+  [0]=>
+  int(2)
+  [1]=>
+  string(%d) "include(): Failed opening '%s/abc/xyz.php' for inclusion (include_path='%s')"
+  [2]=>
+  string(%d) "%s"
+  [3]=>
+  int(15)
+}
+
+Warning: include(): Failed opening '%s/abc/xyz.php' for inclusion (include_path='%s') in %s on line 15
+Guzzle request made (3 events)!
+* Method: 'POST'
+* URI: 'http://localhost/notify'

--- a/tests/phpt/handler_should_call_the_previous_exception_handler.phpt
+++ b/tests/phpt/handler_should_call_the_previous_exception_handler.phpt
@@ -1,0 +1,48 @@
+--TEST--
+Bugsnag\Handler should call the previous exception handler
+
+TODO this is currently reported twice! Once in the exceptionhandler and once on shutdown
+--FILE--
+<?php
+$client = require __DIR__ . '/_prelude.php';
+
+set_exception_handler(function ($throwable) {
+    var_dump($throwable);
+    throw $throwable;
+});
+
+Bugsnag\Handler::registerWithPrevious($client);
+
+throw new RuntimeException('abc xyz');
+
+var_dump('I should not be reached');
+?>
+--EXPECTF--
+object(RuntimeException)#15 (7) {
+  ["message":protected]=>
+  string(7) "abc xyz"
+  ["string":"Exception":private]=>
+  string(0) ""
+  ["code":protected]=>
+  int(0)
+  ["file":protected]=>
+  string(%d) "%s"
+  ["line":protected]=>
+  int(11)
+  ["trace":"Exception":private]=>
+  array(0) {
+  }
+  ["previous":"Exception":private]=>
+  NULL
+}
+
+Fatal error: Uncaught %SRuntimeException%S %Sabc xyz%S in %s:11
+Stack trace:
+#0 {main}
+  thrown in %s on line 11
+Guzzle request made (1 event)!
+* Method: 'POST'
+* URI: 'http://localhost/notify'
+Guzzle request made (1 event)!
+* Method: 'POST'
+* URI: 'http://localhost/notify'

--- a/tests/phpt/handler_should_report_notices.phpt
+++ b/tests/phpt/handler_should_report_notices.phpt
@@ -1,0 +1,18 @@
+--TEST--
+Bugsnag\Handler should report notices
+--FILE--
+<?php
+$client = require __DIR__ . '/_prelude.php';
+
+Bugsnag\Handler::register($client);
+
+$a = $b;
+
+var_dump('Hello!');
+?>
+--EXPECTF--
+Notice: Undefined variable: b in %s on line 6
+string(6) "Hello!"
+Guzzle request made (1 event)!
+* Method: 'POST'
+* URI: 'http://localhost/notify'

--- a/tests/phpt/handler_should_report_parse_errors.phpt
+++ b/tests/phpt/handler_should_report_parse_errors.phpt
@@ -1,0 +1,25 @@
+--TEST--
+Bugsnag\Handler should report parse errors
+
+TODO this should also run in PHP 7!
+--FILE--
+<?php
+$client = require __DIR__ . '/_prelude.php';
+
+Bugsnag\Handler::register($client);
+
+include __DIR__ . '/fixtures/parse_error.php';
+
+var_dump('I should not be reached');
+?>
+--SKIPIF--
+<?php
+if (PHP_MAJOR_VERSION > 5) {
+    echo 'SKIP - PHP 7 does not output the parse error';
+}
+?>
+--EXPECTF--
+Parse error: syntax error, unexpected '{' in %s/parse_error.php on line 3
+Guzzle request made (1 event)!
+* Method: 'POST'
+* URI: 'http://localhost/notify'

--- a/tests/phpt/handler_should_report_uncaught_exceptions.phpt
+++ b/tests/phpt/handler_should_report_uncaught_exceptions.phpt
@@ -1,0 +1,22 @@
+--TEST--
+Bugsnag\Handler should report uncaught exceptions
+
+TODO this should also result in:
+> Fatal error: Uncaught Exception: abcxyz in %s:6
+> Stack trace:
+> #0 {main}
+>   thrown in %s on line 6
+--FILE--
+<?php
+$client = require __DIR__ . '/_prelude.php';
+
+Bugsnag\Handler::register($client);
+
+throw new Exception('abcxyz');
+
+var_dump("I should never be reached!");
+?>
+--EXPECTF--
+Guzzle request made (1 event)!
+* Method: 'POST'
+* URI: 'http://localhost/notify'

--- a/tests/phpt/handler_should_report_user_deprecations.phpt
+++ b/tests/phpt/handler_should_report_user_deprecations.phpt
@@ -1,0 +1,18 @@
+--TEST--
+Bugsnag\Handler should report user deprecations
+--FILE--
+<?php
+$client = require __DIR__ . '/_prelude.php';
+
+Bugsnag\Handler::register($client);
+
+trigger_error('abc', E_USER_DEPRECATED);
+
+var_dump('Hello!');
+?>
+--EXPECTF--
+Deprecated: abc in %s on line 6
+string(6) "Hello!"
+Guzzle request made (1 event)!
+* Method: 'POST'
+* URI: 'http://localhost/notify'

--- a/tests/phpt/handler_should_report_user_errors.phpt
+++ b/tests/phpt/handler_should_report_user_errors.phpt
@@ -1,0 +1,22 @@
+--TEST--
+Bugsnag\Handler should report user errors
+
+TODO this is currently reported twice! Once in the error handler and once on shutdown
+--FILE--
+<?php
+$client = require __DIR__ . '/_prelude.php';
+
+Bugsnag\Handler::register($client);
+
+trigger_error('abc', E_USER_ERROR);
+
+var_dump('I should not be reached');
+?>
+--EXPECTF--
+Fatal error: abc in %s on line 6
+Guzzle request made (1 event)!
+* Method: 'POST'
+* URI: 'http://localhost/notify'
+Guzzle request made (1 event)!
+* Method: 'POST'
+* URI: 'http://localhost/notify'

--- a/tests/phpt/handler_should_report_user_notices.phpt
+++ b/tests/phpt/handler_should_report_user_notices.phpt
@@ -1,0 +1,18 @@
+--TEST--
+Bugsnag\Handler should report user notices
+--FILE--
+<?php
+$client = require __DIR__ . '/_prelude.php';
+
+Bugsnag\Handler::register($client);
+
+trigger_error('abc', E_USER_NOTICE);
+
+var_dump('Hello!');
+?>
+--EXPECTF--
+Notice: abc in %s on line 6
+string(6) "Hello!"
+Guzzle request made (1 event)!
+* Method: 'POST'
+* URI: 'http://localhost/notify'

--- a/tests/phpt/handler_should_report_user_warnings.phpt
+++ b/tests/phpt/handler_should_report_user_warnings.phpt
@@ -1,0 +1,18 @@
+--TEST--
+Bugsnag\Handler should report user warnings
+--FILE--
+<?php
+$client = require __DIR__ . '/_prelude.php';
+
+Bugsnag\Handler::register($client);
+
+trigger_error('abc', E_USER_WARNING);
+
+var_dump('Hello!');
+?>
+--EXPECTF--
+Warning: abc in %s on line 6
+string(6) "Hello!"
+Guzzle request made (1 event)!
+* Method: 'POST'
+* URI: 'http://localhost/notify'

--- a/tests/phpt/handler_should_report_warnings.phpt
+++ b/tests/phpt/handler_should_report_warnings.phpt
@@ -1,0 +1,20 @@
+--TEST--
+Bugsnag\Handler should report warnings
+--FILE--
+<?php
+$client = require __DIR__ . '/_prelude.php';
+
+Bugsnag\Handler::register($client);
+
+include __DIR__ . '/abc/xyz.php';
+
+var_dump('Hello!');
+?>
+--EXPECTF--
+Warning: include(%s/abc/xyz.php): failed to open stream: No such file or directory in %s on line 6
+
+Warning: include(): Failed opening '%s/abc/xyz.php' for inclusion (include_path='%s') in %s on line 6
+string(6) "Hello!"
+Guzzle request made (2 events)!
+* Method: 'POST'
+* URI: 'http://localhost/notify'

--- a/tests/phpt/handler_should_respect_error_reporting_level.phpt
+++ b/tests/phpt/handler_should_respect_error_reporting_level.phpt
@@ -1,0 +1,28 @@
+--TEST--
+Bugsnag\Handler should respect the error_reporting level
+--FILE--
+<?php
+$client = require __DIR__ . '/_prelude.php';
+
+Bugsnag\Handler::register($client);
+
+error_reporting(E_ALL & ~E_USER_NOTICE);
+
+trigger_error('hello E_USER_NOTICE', E_USER_NOTICE); // should not be reported
+trigger_error('hello E_USER_DEPRECATED', E_USER_DEPRECATED);
+
+error_reporting(E_ALL);
+
+trigger_error('hello E_USER_NOTICE 2', E_USER_NOTICE);
+trigger_error('hello E_USER_DEPRECATED 2', E_USER_DEPRECATED);
+
+?>
+--EXPECTF--
+Deprecated: hello E_USER_DEPRECATED in %s on line 9
+
+Notice: hello E_USER_NOTICE 2 in %s on line 13
+
+Deprecated: hello E_USER_DEPRECATED 2 in %s on line 14
+Guzzle request made (3 events)!
+* Method: 'POST'
+* URI: 'http://localhost/notify'

--- a/tests/phpt/handler_should_respect_error_reporting_level_when_set_in_php_ini.phpt
+++ b/tests/phpt/handler_should_respect_error_reporting_level_when_set_in_php_ini.phpt
@@ -1,0 +1,28 @@
+--TEST--
+Bugsnag\Handler should respect the error_reporting level when set in php.ini
+--FILE--
+<?php
+$client = require __DIR__ . '/_prelude.php';
+
+Bugsnag\Handler::register($client);
+
+ini_set('error_reporting', E_ALL & ~E_USER_NOTICE);
+
+trigger_error('hello E_USER_NOTICE', E_USER_NOTICE); // should not be reported
+trigger_error('hello E_USER_DEPRECATED', E_USER_DEPRECATED);
+
+ini_set('error_reporting', E_ALL);
+
+trigger_error('hello E_USER_NOTICE 2', E_USER_NOTICE);
+trigger_error('hello E_USER_DEPRECATED 2', E_USER_DEPRECATED);
+
+?>
+--EXPECTF--
+Deprecated: hello E_USER_DEPRECATED in %s on line 9
+
+Notice: hello E_USER_NOTICE 2 in %s on line 13
+
+Deprecated: hello E_USER_DEPRECATED 2 in %s on line 14
+Guzzle request made (3 events)!
+* Method: 'POST'
+* URI: 'http://localhost/notify'

--- a/tests/phpt/handler_should_respect_error_suppression_operator.phpt
+++ b/tests/phpt/handler_should_respect_error_suppression_operator.phpt
@@ -1,0 +1,17 @@
+--TEST--
+Bugsnag\Handler should respect the error suppression operator level
+--FILE--
+<?php
+$client = require __DIR__ . '/_prelude.php';
+
+Bugsnag\Handler::register($client);
+
+@$a = $b; // should not be reported
+$c = $d;
+
+?>
+--EXPECTF--
+Notice: Undefined variable: d in %s on line 7
+Guzzle request made (1 event)!
+* Method: 'POST'
+* URI: 'http://localhost/notify'

--- a/tests/phpt/handler_should_use_the_previous_error_handler_return_value.phpt
+++ b/tests/phpt/handler_should_use_the_previous_error_handler_return_value.phpt
@@ -1,0 +1,31 @@
+--TEST--
+Bugsnag\Handler should use the previous error handler's return value
+--FILE--
+<?php
+$client = require __DIR__ . '/_prelude.php';
+
+$hideError = true;
+
+set_error_handler(function ()use (&$hideError) {
+    return $hideError;
+});
+
+Bugsnag\Handler::registerWithPrevious($client);
+
+var_dump('Triggering notice with hide error:', $hideError);
+$a = $b;
+
+$hideError = false;
+var_dump('Triggering notice with hide error:', $hideError);
+$a = $b;
+?>
+--EXPECTF--
+string(34) "Triggering notice with hide error:"
+bool(true)
+string(34) "Triggering notice with hide error:"
+bool(false)
+
+Notice: Undefined variable: b in %s on line 17
+Guzzle request made (2 events)!
+* Method: 'POST'
+* URI: 'http://localhost/notify'


### PR DESCRIPTION
## 3.23.0 (2020-09-14)

### Enhancements

* Filters are now applied case insensitively, e.g. 'password' will now also match 'PASSWORD'
  [#595](https://github.com/bugsnag/bugsnag-php/pull/595)

* Cookies are now filtered from events by default
  [#596](https://github.com/bugsnag/bugsnag-php/pull/596)

* HTTP basic auth headers are filtered from events by default
  [#597](https://github.com/bugsnag/bugsnag-php/pull/597)