### PR TITLE
Assert against error messages in PHPT tests

### DIFF
--- a/tests/phpt/Utilities/FakeGuzzle.php
+++ b/tests/phpt/Utilities/FakeGuzzle.php
@@ -52,16 +52,26 @@ if (!isset($fakeGuzzleMapping[$guzzleMajorVersion])) {
 function reportRequest($method, $uri, $options)
 {
     $numberOfEvents = 0;
+    $errors = [];
 
     if (isset($options['json']['events'])) {
         $numberOfEvents = count($options['json']['events']);
+        $errors = array_map(
+            function ($event) {
+                return strtok($event['exceptions'][0]['message'], "\n");
+            },
+            $options['json']['events']
+        );
     }
 
+    $errors = implode("\n    - ", $errors);
     $events = $numberOfEvents === 1 ? 'event' : 'events';
 
     echo "Guzzle request made ({$numberOfEvents} {$events})!\n";
     echo "* Method: '{$method}'\n";
     echo "* URI: '{$uri}'\n";
+    echo "* Events:\n";
+    echo "    - {$errors}\n";
 }
 
 // Create the 'FakeGuzzle' class as an alias of the correct implementation,

--- a/tests/phpt/handler_should_call_the_previous_error_handler.phpt
+++ b/tests/phpt/handler_should_call_the_previous_error_handler.phpt
@@ -58,3 +58,7 @@ Warning: include(): Failed opening '%s/abc/xyz.php' for inclusion (include_path=
 Guzzle request made (3 events)!
 * Method: 'POST'
 * URI: 'http://localhost/notify'
+* Events:
+    - Undefined variable: b
+    - include(%s/abc/xyz.php): failed to open stream: No such file or directory
+    - include(): Failed opening '%s/abc/xyz.php' for inclusion (include_path='%s')

--- a/tests/phpt/handler_should_call_the_previous_exception_handler.phpt
+++ b/tests/phpt/handler_should_call_the_previous_exception_handler.phpt
@@ -43,6 +43,10 @@ Stack trace:
 Guzzle request made (1 event)!
 * Method: 'POST'
 * URI: 'http://localhost/notify'
+* Events:
+    - abc xyz
 Guzzle request made (1 event)!
 * Method: 'POST'
 * URI: 'http://localhost/notify'
+* Events:
+    - Uncaught %SRuntimeException%S %Sabc xyz%S in %s:11

--- a/tests/phpt/handler_should_report_notices.phpt
+++ b/tests/phpt/handler_should_report_notices.phpt
@@ -16,3 +16,5 @@ string(6) "Hello!"
 Guzzle request made (1 event)!
 * Method: 'POST'
 * URI: 'http://localhost/notify'
+* Events:
+    - Undefined variable: b

--- a/tests/phpt/handler_should_report_parse_errors.phpt
+++ b/tests/phpt/handler_should_report_parse_errors.phpt
@@ -23,3 +23,5 @@ Parse error: syntax error, unexpected '{' in %s/parse_error.php on line 3
 Guzzle request made (1 event)!
 * Method: 'POST'
 * URI: 'http://localhost/notify'
+* Events:
+    - syntax error, unexpected '{'

--- a/tests/phpt/handler_should_report_uncaught_exceptions.phpt
+++ b/tests/phpt/handler_should_report_uncaught_exceptions.phpt
@@ -20,3 +20,5 @@ var_dump("I should never be reached!");
 Guzzle request made (1 event)!
 * Method: 'POST'
 * URI: 'http://localhost/notify'
+* Events:
+    - abcxyz

--- a/tests/phpt/handler_should_report_user_deprecations.phpt
+++ b/tests/phpt/handler_should_report_user_deprecations.phpt
@@ -16,3 +16,5 @@ string(6) "Hello!"
 Guzzle request made (1 event)!
 * Method: 'POST'
 * URI: 'http://localhost/notify'
+* Events:
+    - abc

--- a/tests/phpt/handler_should_report_user_errors.phpt
+++ b/tests/phpt/handler_should_report_user_errors.phpt
@@ -17,6 +17,10 @@ Fatal error: abc in %s on line 6
 Guzzle request made (1 event)!
 * Method: 'POST'
 * URI: 'http://localhost/notify'
+* Events:
+    - abc
 Guzzle request made (1 event)!
 * Method: 'POST'
 * URI: 'http://localhost/notify'
+* Events:
+    - abc

--- a/tests/phpt/handler_should_report_user_notices.phpt
+++ b/tests/phpt/handler_should_report_user_notices.phpt
@@ -16,3 +16,5 @@ string(6) "Hello!"
 Guzzle request made (1 event)!
 * Method: 'POST'
 * URI: 'http://localhost/notify'
+* Events:
+    - abc

--- a/tests/phpt/handler_should_report_user_warnings.phpt
+++ b/tests/phpt/handler_should_report_user_warnings.phpt
@@ -16,3 +16,5 @@ string(6) "Hello!"
 Guzzle request made (1 event)!
 * Method: 'POST'
 * URI: 'http://localhost/notify'
+* Events:
+    - abc

--- a/tests/phpt/handler_should_report_warnings.phpt
+++ b/tests/phpt/handler_should_report_warnings.phpt
@@ -18,3 +18,6 @@ string(6) "Hello!"
 Guzzle request made (2 events)!
 * Method: 'POST'
 * URI: 'http://localhost/notify'
+* Events:
+    - include(%s/abc/xyz.php): failed to open stream: No such file or directory
+    - include(): Failed opening '%s/abc/xyz.php' for inclusion (include_path='%s')

--- a/tests/phpt/handler_should_respect_error_reporting_level.phpt
+++ b/tests/phpt/handler_should_respect_error_reporting_level.phpt
@@ -26,3 +26,7 @@ Deprecated: hello E_USER_DEPRECATED 2 in %s on line 14
 Guzzle request made (3 events)!
 * Method: 'POST'
 * URI: 'http://localhost/notify'
+* Events:
+    - hello E_USER_DEPRECATED
+    - hello E_USER_NOTICE 2
+    - hello E_USER_DEPRECATED 2

--- a/tests/phpt/handler_should_respect_error_reporting_level_when_set_in_php_ini.phpt
+++ b/tests/phpt/handler_should_respect_error_reporting_level_when_set_in_php_ini.phpt
@@ -26,3 +26,7 @@ Deprecated: hello E_USER_DEPRECATED 2 in %s on line 14
 Guzzle request made (3 events)!
 * Method: 'POST'
 * URI: 'http://localhost/notify'
+* Events:
+    - hello E_USER_DEPRECATED
+    - hello E_USER_NOTICE 2
+    - hello E_USER_DEPRECATED 2

--- a/tests/phpt/handler_should_respect_error_suppression_operator.phpt
+++ b/tests/phpt/handler_should_respect_error_suppression_operator.phpt
@@ -1,5 +1,5 @@
 --TEST--
-Bugsnag\Handler should respect the error suppression operator level
+Bugsnag\Handler should respect the error suppression operator
 --FILE--
 <?php
 $client = require __DIR__ . '/_prelude.php';
@@ -15,3 +15,5 @@ Notice: Undefined variable: d in %s on line 7
 Guzzle request made (1 event)!
 * Method: 'POST'
 * URI: 'http://localhost/notify'
+* Events:
+    - Undefined variable: d

--- a/tests/phpt/handler_should_respect_error_suppression_operator_with_custom_reporting_level.phpt
+++ b/tests/phpt/handler_should_respect_error_suppression_operator_with_custom_reporting_level.phpt
@@ -1,0 +1,34 @@
+--TEST--
+Bugsnag\Handler should respect the error suppression operator with a custom reporting level
+--FILE--
+<?php
+$client = require __DIR__ . '/_prelude.php';
+$client->getConfig()->setErrorReportingLevel(E_ALL & ~E_USER_NOTICE);
+error_reporting(E_ALL & ~E_USER_WARNING);
+
+Bugsnag\Handler::register($client);
+
+echo "Triggering a user notice that should be reported by PHP and ignored by Bugsnag\n";
+trigger_error('abc notice', E_USER_NOTICE);
+
+echo "Triggering a suppressed user notice that should be ignored by PHP and ignored by Bugsnag\n";
+@trigger_error('xyz notice', E_USER_NOTICE);
+
+echo "Triggering a user warning that should be ignored by PHP and reported by Bugsnag\n";
+trigger_error('abc warning', E_USER_WARNING);
+
+echo "Triggering a suppressed user warning that should be ignored by PHP and ignored by Bugsnag\n";
+@trigger_error('xyz warning', E_USER_WARNING);
+?>
+--EXPECTF--
+Triggering a user notice that should be reported by PHP and ignored by Bugsnag
+
+Notice: abc notice in %s on line 9
+Triggering a suppressed user notice that should be ignored by PHP and ignored by Bugsnag
+Triggering a user warning that should be ignored by PHP and reported by Bugsnag
+Triggering a suppressed user warning that should be ignored by PHP and ignored by Bugsnag
+Guzzle request made (1 event)!
+* Method: 'POST'
+* URI: 'http://localhost/notify'
+* Events:
+    - abc warning

--- a/tests/phpt/handler_should_use_the_previous_error_handler_return_value.phpt
+++ b/tests/phpt/handler_should_use_the_previous_error_handler_return_value.phpt
@@ -29,3 +29,6 @@ Notice: Undefined variable: b in %s on line 17
 Guzzle request made (2 events)!
 * Method: 'POST'
 * URI: 'http://localhost/notify'
+* Events:
+    - Undefined variable: b
+    - Undefined variable: b


### PR DESCRIPTION
## Goal

This is a small update to the PHPT tests while investigating another issue

This PR makes the PHPT tests assert against the error message(s) in the events that were sent. This is useful when testing that events are suppressed (to check _which_ events were sent). I also added a test for the error suppression operator, which is what motivated the change in the first place