### PR TITLE
Error handler improvements

### DIFF
--- a/src/Handler.php
+++ b/src/Handler.php
@@ -63,6 +63,8 @@ class Handler
      * @param \Bugsnag\Client|string|null $client client instance or api key
      *
      * @return static
+     *
+     * @deprecated Use {@see Handler::register} instead.
      */
     public static function registerWithPrevious($client = null)
     {

--- a/src/Handler.php
+++ b/src/Handler.php
@@ -47,9 +47,12 @@ class Handler
      */
     public static function register($client = null)
     {
-        $handler = new static($client instanceof Client ? $client : Client::make($client));
+        if (!$client instanceof Client) {
+            $client = Client::make($client);
+        }
 
-        $handler->registerBugsnagHandlers(false); // don't preserve previous handlers
+        $handler = new static($client);
+        $handler->registerBugsnagHandlers(true);
 
         return $handler;
     }
@@ -63,11 +66,7 @@ class Handler
      */
     public static function registerWithPrevious($client = null)
     {
-        $handler = new static($client instanceof Client ? $client : Client::make($client));
-
-        $handler->registerBugsnagHandlers(true); // preserve previous handlers
-
-        return $handler;
+        return self::register($client);
     }
 
     /**

--- a/tests/HandlerTest.php
+++ b/tests/HandlerTest.php
@@ -69,7 +69,7 @@ class HandlerTest extends TestCase
             });
 
             $this->client->expects($this->once())->method('notify');
-            $handler = Handler::registerWithPrevious($this->client);
+            $handler = Handler::register($this->client);
 
             $this->assertSame(
                 '123',
@@ -224,6 +224,11 @@ class HandlerTest extends TestCase
             );
 
             $test();
+
+            $this->assertTrue(
+                $handlerWasCalled,
+                'Expected the previous handler to be called after running the test'
+            );
         } finally {
             $restoreHandler();
         }

--- a/tests/HandlerTest.php
+++ b/tests/HandlerTest.php
@@ -1,207 +1,231 @@
 <?php
 
-namespace Bugsnag {
+namespace Bugsnag\Tests;
 
-    // Mock error_reporting global function, to be controlled by global switches in the tests
-    function error_reporting()
-    {
-        global $mockErrorReporting, $mockErrorReportingLevel;
-        if (isset($mockErrorReporting) && $mockErrorReporting == true) {
-            return $mockErrorReportingLevel;
-        } else {
-            return call_user_func_array('\error_reporting', func_get_args());
-        }
-    }
+use Bugsnag\Client;
+use Bugsnag\Configuration;
+use Bugsnag\Handler;
+use Closure;
+use Exception;
+use PHPUnit\Framework\MockObject\MockObject;
 
-}
-
-namespace Bugsnag\Tests {
-
-    use Bugsnag\Client;
-    use Bugsnag\Configuration;
-    use Bugsnag\Handler;
-    use Exception;
+class HandlerTest extends TestCase
+{
+    /**
+     * @var Client&MockObject
+     */
+    protected $client;
 
     /**
-     * @runTestsInSeparateProcesses
+     * The original error reporting level before each test run. This is used to
+     * restore the error reporting level after each test.
+     *
+     * @var int
      */
-    class HandlerTest extends TestCase
+    protected $originalErrorReporting;
+
+    protected function setUp()
     {
-        protected $client;
+        $this->client = $this->getMockBuilder(Client::class)
+            ->setMethods(['notify', 'flush'])
+            ->setConstructorArgs([new Configuration('example-api-key')])
+            ->getMock();
 
-        protected function setUp()
-        {
-            global $mockErrorReporting, $mockErrorReportingLevel;
-            $mockErrorReporting = false;
-            $mockErrorReportingLevel = null;
+        $this->originalErrorReporting = error_reporting();
+    }
 
-            $this->client = $this->getMockBuilder(Client::class)
-                                ->setMethods(['notify', 'flush'])
-                                ->setConstructorArgs([new Configuration('example-api-key')])
-                                ->getMock();
-        }
+    protected function tearDown()
+    {
+        error_reporting($this->originalErrorReporting);
+    }
 
-        public function testErrorHandler()
-        {
+    public function testErrorHandler()
+    {
+        $this->runErrorHandlerTest(function () {
             $this->client->expects($this->once())->method('notify');
 
-            Handler::register($this->client)->errorHandler(E_WARNING, 'Something broke', 'somefile.php', 123);
-        }
+            $handler = Handler::register($this->client);
+            $handler->errorHandler(E_WARNING, 'Something broke', 'somefile.php', 123);
+        });
+    }
 
-        public function testErrorHandlerWithPrevious()
-        {
-            if (class_exists(\PHPUnit_Framework_Error_Warning::class)) {
-                $this->expectedException(\PHPUnit_Framework_Error_Warning::class);
-            } else {
-                $this->expectedException(\PHPUnit\Framework\Error\Warning::class);
-            }
-
-            Handler::registerWithPrevious($this->client)->errorHandler(E_WARNING, 'Something broke', 'somefile.php', 123);
-        }
-
-        public function testExceptionHandler()
-        {
+    public function testErrorHandlerWithPrevious()
+    {
+        $this->runErrorHandlerTest(function () {
             $this->client->expects($this->once())->method('notify');
 
-            Handler::register($this->client)->exceptionHandler(new Exception('Something broke'));
-        }
+            $handler = Handler::registerWithPrevious($this->client);
+            $handler->errorHandler(E_WARNING, 'Something broke', 'somefile.php', 123);
+        });
+    }
 
-        public function testExceptionHandlerWithPrevious()
-        {
-            // Register a custom exception handler that stores it's parameter in the
-            // parent's scope so we can assert that it was correctly called.
-            $previous_exception_handler_arg = null;
-            set_exception_handler(
-                function ($e) use (&$previous_exception_handler_arg) {
-                    $previous_exception_handler_arg = $e;
-                }
-            );
+    public function testItReturnsThePreviousErrorHandlerReturnValue()
+    {
+        $this->runErrorHandlerTest(function () {
+            $previousHandler = set_error_handler(function () use (&$previousHandler) {
+                $previousHandler();
 
-            $e_to_throw = new Exception('Something broke');
+                return '123';
+            });
 
-            Handler::registerWithPrevious($this->client)->exceptionHandler($e_to_throw);
-
-            $this->assertSame($e_to_throw, $previous_exception_handler_arg);
-        }
-
-        public function testExceptionHandlerWithoutPrevious()
-        {
-            $previous_exception_handler_called = false;
-            set_exception_handler(
-                function ($e) use (&$previous_exception_handler_called) {
-                    $previous_exception_handler_called = true;
-                }
-            );
-
-            Handler::register($this->client)->exceptionHandler(new Exception());
-
-            $this->assertFalse($previous_exception_handler_called);
-        }
-
-        public function testCustomErrorHandlerValueReturned()
-        {
-            set_error_handler(
-                function () {
-                    return '123';
-                }
-            );
+            $this->client->expects($this->once())->method('notify');
+            $handler = Handler::registerWithPrevious($this->client);
 
             $this->assertSame(
                 '123',
-                Handler::registerWithPrevious($this->client)->errorHandler(E_WARNING, 'Something broke')
+                $handler->errorHandler(E_WARNING, 'Something broke')
             );
-        }
+        });
+    }
 
-        public function testErrorReportingLevel()
-        {
+    public function testErrorReportingLevel()
+    {
+        $this->runErrorHandlerTest(function () {
             $this->client->expects($this->once())->method('notify');
-
             $this->client->setErrorReportingLevel(E_NOTICE);
 
-            Handler::register($this->client)->errorHandler(E_NOTICE, 'Something broke', 'somefile.php', 123);
-        }
+            $handler = Handler::register($this->client);
+            $handler->errorHandler(E_NOTICE, 'Something broke', 'somefile.php', 123);
+        });
+    }
 
-        public function testErrorReportingLevelFails()
-        {
+    public function testErrorReportingLevelFails()
+    {
+        $this->runErrorHandlerTest(function () {
             $this->client->expects($this->never())->method('notify');
+            $this->client->setErrorReportingLevel(E_ALL & ~E_WARNING);
+
+            $handler = Handler::register($this->client);
+            $handler->errorHandler(E_WARNING, 'Something broke', 'somefile.php', 123);
+        });
+    }
+
+    public function testErrorReportingDefaultFails()
+    {
+        $this->runErrorHandlerTest(function () {
+            error_reporting(E_NOTICE);
+
+            $this->client->expects($this->never())->method('notify');
+
+            $handler = Handler::register($this->client);
+            $handler->errorHandler(E_WARNING, 'Something broke', 'somefile.php', 123);
+        });
+    }
+
+    public function testErrorReportingSuppressed()
+    {
+        $this->runErrorHandlerTest(function () {
+            error_reporting(0);
 
             $this->client->setErrorReportingLevel(E_NOTICE);
-
-            Handler::register($this->client)->errorHandler(E_WARNING, 'Something broke', 'somefile.php', 123);
-        }
-
-        public function testErrorReportingWithoutNotice()
-        {
             $this->client->expects($this->never())->method('notify');
 
-            $this->client->setErrorReportingLevel(E_ALL & ~E_NOTICE);
+            $handler = Handler::register($this->client);
+            $handler->errorHandler(E_NOTICE, 'Something broke', 'somefile.php', 123);
+        });
+    }
 
-            Handler::register($this->client)->errorHandler(E_NOTICE, 'Something broke', 'somefile.php', 123);
-        }
+    public function testErrorReportingDefaultSuppressed()
+    {
+        $this->runErrorHandlerTest(function () {
+            error_reporting(0);
 
-        public function testErrorReportingDefault()
-        {
-            global $mockErrorReporting, $mockErrorReportingLevel;
-            $mockErrorReporting = true;
-            $mockErrorReportingLevel = E_NOTICE;
+            $this->client->expects($this->never())->method('notify');
 
+            $handler = Handler::register($this->client);
+            $handler->errorHandler(E_NOTICE, 'Something broke', 'somefile.php', 123);
+        });
+    }
+
+    public function testExceptionHandler()
+    {
+        $this->runExceptionHandlerTest(function () {
             $this->client->expects($this->once())->method('notify');
 
-            Handler::register($this->client)->errorHandler(E_NOTICE, 'Something broke', 'somefile.php', 123);
-        }
+            $handler = Handler::register($this->client);
+            $handler->exceptionHandler(new Exception('Something broke'));
+        });
+    }
 
-        public function testErrorReportingDefaultFails()
-        {
-            global $mockErrorReporting, $mockErrorReportingLevel;
-            $mockErrorReporting = true;
-            $mockErrorReportingLevel = E_NOTICE;
+    public function testCanShutdown()
+    {
+        $this->client->expects($this->never())->method('notify');
+        $this->client->expects($this->once())->method('flush');
 
-            $this->client->expects($this->never())->method('notify');
+        $handler = Handler::register($this->client);
+        $handler->shutdownHandler();
+    }
 
-            Handler::register($this->client)->errorHandler(E_WARNING, 'Something broke', 'somefile.php', 123);
-        }
+    /**
+     * @runInSeparateProcess
+     */
+    public function testCanFatalShutdown()
+    {
+        $report = $this->getFunctionMock('Bugsnag', 'error_get_last');
+        $report->expects($this->once())->will($this->returnValue(['type' => E_ERROR, 'message' => 'Undefined variable: a', 'file' => '/foo/index.php', 'line' => 2]));
 
-        public function testErrorReportingSuppressed()
-        {
-            global $mockErrorReporting, $mockErrorReportingLevel;
-            $mockErrorReporting = true;
-            $mockErrorReportingLevel = 0;
+        $this->client->expects($this->once())->method('notify');
+        $this->client->expects($this->once())->method('flush');
 
-            $this->client->setErrorReportingLevel(E_NOTICE);
+        $handler = Handler::register($this->client);
+        $handler->shutdownHandler();
+    }
 
-            $this->client->expects($this->never())->method('notify');
+    /**
+     * @param Closure $test
+     *
+     * @return void
+     */
+    private function runErrorHandlerTest($test)
+    {
+        $this->runHandlerTest(
+            $test,
+            'set_error_handler',
+            'restore_error_handler'
+        );
+    }
 
-            Handler::register($this->client)->errorHandler(E_NOTICE, 'Something broke', 'somefile.php', 123);
-        }
+    /**
+     * @param Closure $test
+     *
+     * @return void
+     */
+    private function runExceptionHandlerTest($test)
+    {
+        $this->runHandlerTest(
+            $test,
+            'set_exception_handler',
+            'restore_exception_handler'
+        );
+    }
 
-        public function testErrorReportingDefaultSuppressed()
-        {
-            global $mockErrorReporting, $mockErrorReportingLevel;
-            $mockErrorReporting = true;
-            $mockErrorReportingLevel = 0;
+    /**
+     * Don't call this directly! Use {@see runErrorHandlerTest} or
+     * {@see runExceptionHandlerTest} instead.
+     *
+     * @param Closure $test
+     * @param callable $setHandler
+     * @param callable $restoreHandler
+     *
+     * @return void
+     */
+    private function runHandlerTest($test, $setHandler, $restoreHandler)
+    {
+        try {
+            $handlerWasCalled = false;
 
-            $this->client->expects($this->never())->method('notify');
+            $setHandler(function () use (&$handlerWasCalled) {
+                $handlerWasCalled = true;
+            });
 
-            Handler::register($this->client)->errorHandler(E_NOTICE, 'Something broke', 'somefile.php', 123);
-        }
+            $this->assertFalse(
+                $handlerWasCalled,
+                'Expected the previous handler not to be called before running the test'
+            );
 
-        public function testCanShutdown()
-        {
-            $this->client->expects($this->never())->method('notify');
-            $this->client->expects($this->once())->method('flush');
-
-            Handler::register($this->client)->shutdownHandler();
-        }
-
-        public function testCanFatalShutdown()
-        {
-            $report = $this->getFunctionMock('Bugsnag', 'error_get_last');
-            $report->expects($this->once())->will($this->returnValue(['type' => E_ERROR, 'message' => 'Undefined variable: a', 'file' => '/foo/index.php', 'line' => 2]));
-
-            $this->client->expects($this->once())->method('notify');
-            $this->client->expects($this->once())->method('flush');
-
-            Handler::register($this->client)->shutdownHandler();
+            $test();
+        } finally {
+            $restoreHandler();
         }
     }
 }

--- a/tests/phpt/handler_can_avoid_calling_the_previous_error_handler.phpt
+++ b/tests/phpt/handler_can_avoid_calling_the_previous_error_handler.phpt
@@ -1,0 +1,34 @@
+--TEST--
+Bugsnag\Handler can avoid calling the previous error handler
+--FILE--
+<?php
+$client = require __DIR__ . '/_prelude.php';
+
+set_error_handler(function () {
+    var_dump(func_get_args());
+    return false;
+});
+
+$handler = new Bugsnag\Handler($client);
+$handler->registerErrorHandler(false);
+
+$a = $b;
+
+var_dump('Hello!');
+
+include __DIR__ . '/abc/xyz.php';
+?>
+--EXPECTF--
+Notice: Undefined variable: b in %s on line 12
+string(6) "Hello!"
+
+Warning: include(%s/abc/xyz.php): failed to open stream: No such file or directory in %s on line 16
+
+Warning: include(): Failed opening '%s/abc/xyz.php' for inclusion (include_path='%s') in %s on line 16
+Guzzle request made (3 events)!
+* Method: 'POST'
+* URI: 'http://localhost/notify'
+* Events:
+    - Undefined variable: b
+    - include(%s/abc/xyz.php): failed to open stream: No such file or directory
+    - include(): Failed opening '%s/abc/xyz.php' for inclusion (include_path='%s')

--- a/tests/phpt/handler_can_avoid_calling_the_previous_exception_handler.phpt
+++ b/tests/phpt/handler_can_avoid_calling_the_previous_exception_handler.phpt
@@ -1,0 +1,23 @@
+--TEST--
+Bugsnag\Handler can avoid calling the previous exception handler
+--FILE--
+<?php
+$client = require __DIR__ . '/_prelude.php';
+
+set_exception_handler(function ($throwable) {
+    var_dump($throwable);
+});
+
+$handler = new Bugsnag\Handler($client);
+$handler->registerExceptionHandler(false);
+
+throw new RuntimeException('abc xyz');
+
+var_dump('I should not be reached');
+?>
+--EXPECTF--
+Guzzle request made (1 event)!
+* Method: 'POST'
+* URI: 'http://localhost/notify'
+* Events:
+    - abc xyz

--- a/tests/phpt/handler_should_call_the_previous_error_handler.phpt
+++ b/tests/phpt/handler_should_call_the_previous_error_handler.phpt
@@ -9,7 +9,7 @@ set_error_handler(function () {
     return false;
 });
 
-Bugsnag\Handler::registerWithPrevious($client);
+Bugsnag\Handler::register($client);
 
 $a = $b;
 

--- a/tests/phpt/handler_should_call_the_previous_exception_handler.phpt
+++ b/tests/phpt/handler_should_call_the_previous_exception_handler.phpt
@@ -8,7 +8,7 @@ set_exception_handler(function ($throwable) {
     var_dump($throwable);
 });
 
-Bugsnag\Handler::registerWithPrevious($client);
+Bugsnag\Handler::register($client);
 
 throw new RuntimeException('abc xyz');
 

--- a/tests/phpt/handler_should_handle_all_throwables.phpt
+++ b/tests/phpt/handler_should_handle_all_throwables.phpt
@@ -1,0 +1,45 @@
+--TEST--
+Bugsnag\Handler should handle all throwables
+--FILE--
+<?php
+$client = require __DIR__ . '/_prelude.php';
+
+set_exception_handler(function ($throwable) {
+    var_dump($throwable);
+});
+
+Bugsnag\Handler::register($client);
+
+throw new DivisionByZeroError('22 / 0 = ???');
+
+var_dump('I should not be reached');
+?>
+--SKIPIF--
+<?php
+if (PHP_MAJOR_VERSION < 7) {
+    echo 'SKIP - the Error type does not exist until PHP 7';
+}
+?>
+--EXPECTF--
+object(DivisionByZeroError)#15 (7) {
+  ["message":protected]=>
+  string(12) "22 / 0 = ???"
+  ["string":"Error":private]=>
+  string(0) ""
+  ["code":protected]=>
+  int(0)
+  ["file":protected]=>
+  string(%d) "%s"
+  ["line":protected]=>
+  int(10)
+  ["trace":"Error":private]=>
+  array(0) {
+  }
+  ["previous":"Error":private]=>
+  NULL
+}
+Guzzle request made (1 event)!
+* Method: 'POST'
+* URI: 'http://localhost/notify'
+* Events:
+    - 22 / 0 = ???

--- a/tests/phpt/handler_should_handle_all_throwables_being_reraised.phpt
+++ b/tests/phpt/handler_should_handle_all_throwables_being_reraised.phpt
@@ -1,0 +1,51 @@
+--TEST--
+Bugsnag\Handler should handle all throwables being reraised
+--FILE--
+<?php
+$client = require __DIR__ . '/_prelude.php';
+
+set_exception_handler(function ($throwable) {
+    var_dump($throwable);
+    throw $throwable;
+});
+
+Bugsnag\Handler::register($client);
+
+throw new DivisionByZeroError('22 / 0 = ???');
+
+var_dump('I should not be reached');
+?>
+--SKIPIF--
+<?php
+if (PHP_MAJOR_VERSION < 7) {
+    echo 'SKIP - the Error type does not exist until PHP 7';
+}
+?>
+--EXPECTF--
+object(DivisionByZeroError)#15 (7) {
+  ["message":protected]=>
+  string(12) "22 / 0 = ???"
+  ["string":"Error":private]=>
+  string(0) ""
+  ["code":protected]=>
+  int(0)
+  ["file":protected]=>
+  string(%d) "%s"
+  ["line":protected]=>
+  int(11)
+  ["trace":"Error":private]=>
+  array(0) {
+  }
+  ["previous":"Error":private]=>
+  NULL
+}
+
+Fatal error: Uncaught DivisionByZeroError: 22 / 0 = ??? in %s:11
+Stack trace:
+#0 {main}
+  thrown in %s on line 11
+Guzzle request made (1 event)!
+* Method: 'POST'
+* URI: 'http://localhost/notify'
+* Events:
+    - 22 / 0 = ???

--- a/tests/phpt/handler_should_handle_exceptions_caused_by_previous_exception_handler.phpt
+++ b/tests/phpt/handler_should_handle_exceptions_caused_by_previous_exception_handler.phpt
@@ -9,7 +9,7 @@ set_exception_handler(function ($throwable) {
     throw new BadMethodCallException('oh dear');
 });
 
-Bugsnag\Handler::registerWithPrevious($client);
+Bugsnag\Handler::register($client);
 
 throw new RuntimeException('abc xyz');
 

--- a/tests/phpt/handler_should_handle_exceptions_caused_by_previous_exception_handler.phpt
+++ b/tests/phpt/handler_should_handle_exceptions_caused_by_previous_exception_handler.phpt
@@ -1,11 +1,12 @@
 --TEST--
-Bugsnag\Handler should call the previous exception handler
+Bugsnag\Handler should handle exceptions caused by the previous exception handler
 --FILE--
 <?php
 $client = require __DIR__ . '/_prelude.php';
 
 set_exception_handler(function ($throwable) {
     var_dump($throwable);
+    throw new BadMethodCallException('oh dear');
 });
 
 Bugsnag\Handler::registerWithPrevious($client);
@@ -25,15 +26,16 @@ object(RuntimeException)#15 (7) {
   ["file":protected]=>
   string(%d) "%s"
   ["line":protected]=>
-  int(10)
+  int(11)
   ["trace":"Exception":private]=>
   array(0) {
   }
   ["previous":"Exception":private]=>
   NULL
 }
-Guzzle request made (1 event)!
+Guzzle request made (2 events)!
 * Method: 'POST'
 * URI: 'http://localhost/notify'
 * Events:
     - abc xyz
+    - oh dear

--- a/tests/phpt/handler_should_handle_previous_exception_handler_reraising.phpt
+++ b/tests/phpt/handler_should_handle_previous_exception_handler_reraising.phpt
@@ -9,7 +9,7 @@ set_exception_handler(function ($throwable) {
     throw $throwable;
 });
 
-Bugsnag\Handler::registerWithPrevious($client);
+Bugsnag\Handler::register($client);
 
 throw new RuntimeException('abc xyz');
 

--- a/tests/phpt/handler_should_handle_previous_exception_handler_reraising.phpt
+++ b/tests/phpt/handler_should_handle_previous_exception_handler_reraising.phpt
@@ -1,11 +1,12 @@
 --TEST--
-Bugsnag\Handler should call the previous exception handler
+Bugsnag\Handler should handle the previous exception handler reraising the exception
 --FILE--
 <?php
 $client = require __DIR__ . '/_prelude.php';
 
 set_exception_handler(function ($throwable) {
     var_dump($throwable);
+    throw $throwable;
 });
 
 Bugsnag\Handler::registerWithPrevious($client);
@@ -25,13 +26,18 @@ object(RuntimeException)#15 (7) {
   ["file":protected]=>
   string(%d) "%s"
   ["line":protected]=>
-  int(10)
+  int(11)
   ["trace":"Exception":private]=>
   array(0) {
   }
   ["previous":"Exception":private]=>
   NULL
 }
+
+Fatal error: Uncaught %SRuntimeException%S %Sabc xyz%S in %s:11
+Stack trace:
+#0 {main}
+  thrown in %s on line 11
 Guzzle request made (1 event)!
 * Method: 'POST'
 * URI: 'http://localhost/notify'

--- a/tests/phpt/handler_should_handle_throwables_caused_by_previous_exception_handler.phpt
+++ b/tests/phpt/handler_should_handle_throwables_caused_by_previous_exception_handler.phpt
@@ -1,0 +1,47 @@
+--TEST--
+Bugsnag\Handler should handle throwables caused by the previous exception handler
+--FILE--
+<?php
+$client = require __DIR__ . '/_prelude.php';
+
+set_exception_handler(function ($throwable) {
+    var_dump($throwable);
+    throw new TypeError('oopsie');
+});
+
+Bugsnag\Handler::register($client);
+
+throw new RuntimeException('abc xyz');
+
+var_dump('I should not be reached');
+?>
+--SKIPIF--
+<?php
+if (PHP_MAJOR_VERSION < 7) {
+    echo 'SKIP - the Error type does not exist until PHP 7';
+}
+?>
+--EXPECTF--
+object(RuntimeException)#15 (7) {
+  ["message":protected]=>
+  string(7) "abc xyz"
+  ["string":"Exception":private]=>
+  string(0) ""
+  ["code":protected]=>
+  int(0)
+  ["file":protected]=>
+  string(%d) "%s"
+  ["line":protected]=>
+  int(11)
+  ["trace":"Exception":private]=>
+  array(0) {
+  }
+  ["previous":"Exception":private]=>
+  NULL
+}
+Guzzle request made (2 events)!
+* Method: 'POST'
+* URI: 'http://localhost/notify'
+* Events:
+    - abc xyz
+    - oopsie

--- a/tests/phpt/handler_should_use_the_previous_error_handler_return_value.phpt
+++ b/tests/phpt/handler_should_use_the_previous_error_handler_return_value.phpt
@@ -10,7 +10,7 @@ set_error_handler(function ()use (&$hideError) {
     return $hideError;
 });
 
-Bugsnag\Handler::registerWithPrevious($client);
+Bugsnag\Handler::register($client);
 
 var_dump('Triggering notice with hide error:', $hideError);
 $a = $b;


### PR DESCRIPTION
## Goal

This PR adds a number of improvements to the error handler:

1. Report new exceptions raised by the previous error handler
2. Allow the default PHP exception handler to run if the previous handler wants it to (by re-raising the exception that's being handled)
3. Avoid double reporting exceptions if the previous handler re-raises them (currently this will report once in the exception handler and once in the shutdown handler)

Because of these improvements we've also decided to always call the previous handlers, regardless of if `register` or `registerWithPrevious` is used

It's still possible to prevent Bugsnag from calling the previous handlers like this:

```php
// Assuming $client is an instance of \Bugsnag\Client
$handler = new \Bugsnag\Handler($client);

$handler->registerErrorHandler(false);
$handler->registerExceptionHandler(false);
$handler->registerShutdownHandler();
```

Or the "chain" of error/exception handlers can be broken by creating handlers that do nothing:

```php
set_error_handler(function () {});
set_exception_handler(function () {});

\Bugsnag\Handler::register();
```

## Design

Some of the changes are a bit unintuitive, but the PHPT tests should show why they are necessary. The technique of re-throwing the exception inside the exception handler especially, but it's important to solve issues like #523 — this PR doesn't entirely fix that issue as we also need to re-raise exceptions when there is no previous handler, which will be done separately

## Testing

Mostly tested through the PHPT tests and manually

The unit test has been re-written to use much less global mocking by setting/restoring error/exception handlers in the tests (one test still has a mocked global function). Unfortunately git tried too hard to diff the old & new file, so the diff is useless for reviewing ☹️ 