### PR TITLE
PHPUnit 9 support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ vendor
 /composer.lock
 /composer.phar
 /.idea
+.phpunit.result.cache

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
         "guzzlehttp/psr7": "^1.3",
         "mockery/mockery": "^0.9.4|^1.3.1",
         "mtdowling/burgomaster": "dev-master#72151eddf5f0cf101502b94bf5031f9c53501a04",
-        "phpunit/phpunit": "^4.8.36|^7.5.15",
+        "phpunit/phpunit": "^4.8.36|^7.5.15|^9.3.10",
         "php-mock/php-mock-phpunit": "^1.1|^2.1",
         "sebastian/version": ">=1.0.3"
     },

--- a/tests/Assert.php
+++ b/tests/Assert.php
@@ -13,6 +13,30 @@ use PHPUnit\Framework\Assert as PhpUnitAssert;
 final class Assert
 {
     /**
+     * A PHPUnit 4, 7 & 9 compatible version of 'assertRegExp' and its replacement,
+     * 'assertMatchesRegularExpression'.
+     *
+     * This is necessary to avoid warnings - PHPUnit 9 deprecated 'assertRegExp'
+     * in favour of 'assertMatchesRegularExpression' and outputs a warning if
+     * the former is used
+     *
+     * @param string $regex
+     * @param string $value
+     *
+     * @return void
+     */
+    public static function matchesRegularExpression($regex, $value)
+    {
+        if (method_exists(PhpUnitAssert::class, 'assertMatchesRegularExpression')) {
+            PhpUnitAssert::assertMatchesRegularExpression($regex, $value);
+
+            return;
+        }
+
+        PhpUnitAssert::assertRegExp($regex, $value);
+    }
+
+    /**
      * A replacement for 'assertInternalType', which was removed in PHPUnit 9.
      *
      * @param string $type

--- a/tests/Assert.php
+++ b/tests/Assert.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace Bugsnag\Tests;
+
+use InvalidArgumentException;
+use PHPUnit\Framework\Assert as PhpUnitAssert;
+
+/**
+ * This class holds assertions that were removed/renamed/changed in various
+ * PHPUnit versions, so that our test suite can be compatible with as many
+ * versions as possible.
+ */
+final class Assert
+{
+    /**
+     * A replacement for 'assertInternalType', which was removed in PHPUnit 9.
+     *
+     * @param string $type
+     * @param mixed $value
+     *
+     * @return void
+     */
+    public static function isType($type, $value)
+    {
+        if (method_exists(PhpUnitAssert::class, 'assertInternalType')) {
+            PhpUnitAssert::assertInternalType($type, $value);
+
+            return;
+        }
+
+        $typeToAssertion = [
+            'array' => [PhpUnitAssert::class, 'assertIsArray'],
+            'bool' => [PhpUnitAssert::class, 'assertIsBool'],
+            'callable' => [PhpUnitAssert::class, 'assertIsCallable'],
+            'float' => [PhpUnitAssert::class, 'assertIsFloat'],
+            'int' => [PhpUnitAssert::class, 'assertIsInt'],
+            'iterable' => [PhpUnitAssert::class, 'assertIsIterable'],
+            'numeric' => [PhpUnitAssert::class, 'assertIsNumeric'],
+            'object' => [PhpUnitAssert::class, 'assertIsObject'],
+            'resource' => [PhpUnitAssert::class, 'assertIsResource'],
+            'scalar' => [PhpUnitAssert::class, 'assertIsScalar'],
+            'string' => [PhpUnitAssert::class, 'assertIsString'],
+        ];
+
+        if (!isset($typeToAssertion[$type])) {
+            throw new InvalidArgumentException("Unknown type '{$type}' given");
+        }
+
+        $typeToAssertion[$type]($value);
+    }
+}

--- a/tests/Breadcrumbs/BreadcrumbTest.php
+++ b/tests/Breadcrumbs/BreadcrumbTest.php
@@ -3,6 +3,7 @@
 namespace Bugsnag\Tests\Breadcrumbs;
 
 use Bugsnag\Breadcrumbs\Breadcrumb;
+use Bugsnag\Tests\Assert;
 use Bugsnag\Tests\TestCase;
 
 class BreadcrumbTest extends TestCase
@@ -63,9 +64,9 @@ class BreadcrumbTest extends TestCase
     {
         $breadcrumb = new Breadcrumb('Foo', 'request', ['foo' => 'bar']);
 
-        $this->assertInternalType('array', $breadcrumb->toArray());
+        Assert::isType('array', $breadcrumb->toArray());
         $this->assertCount(3, $breadcrumb->toArray());
-        $this->assertInternalType('string', $breadcrumb->toArray()['timestamp']);
+        Assert::isType('string', $breadcrumb->toArray()['timestamp']);
         $this->assertSame('Foo', $breadcrumb->toArray()['name']);
         $this->assertSame('request', $breadcrumb->toArray()['type']);
     }

--- a/tests/Callbacks/CustomUserTest.php
+++ b/tests/Callbacks/CustomUserTest.php
@@ -13,7 +13,10 @@ class CustomUserTest extends TestCase
     /** @var \Bugsnag\Configuration */
     protected $config;
 
-    protected function setUp()
+    /**
+     * @before
+     */
+    protected function beforeEach()
     {
         $this->config = new Configuration('API-KEY');
     }

--- a/tests/Callbacks/EnvironmentDataTest.php
+++ b/tests/Callbacks/EnvironmentDataTest.php
@@ -13,7 +13,10 @@ class EnvironmentDataTest extends TestCase
     /** @var \Bugsnag\Configuration */
     protected $config;
 
-    protected function setUp()
+    /**
+     * @before
+     */
+    protected function beforeEach()
     {
         $this->config = new Configuration('API-KEY');
     }

--- a/tests/Callbacks/GlobalMetaDataTest.php
+++ b/tests/Callbacks/GlobalMetaDataTest.php
@@ -13,7 +13,10 @@ class GlobalMetaDataTest extends TestCase
     /** @var \Bugsnag\Configuration */
     protected $config;
 
-    protected function setUp()
+    /**
+     * @before
+     */
+    protected function beforeEach()
     {
         $this->config = new Configuration('API-KEY');
     }

--- a/tests/Callbacks/RequestContextTest.php
+++ b/tests/Callbacks/RequestContextTest.php
@@ -19,7 +19,10 @@ class RequestContextTest extends TestCase
     /** @var \Bugsnag\Request\ResolverInterface */
     protected $resolver;
 
-    protected function setUp()
+    /**
+     * @before
+     */
+    protected function beforeEach()
     {
         $this->config = new Configuration('API-KEY');
         $this->resolver = new BasicResolver();

--- a/tests/Callbacks/RequestCookiesTest.php
+++ b/tests/Callbacks/RequestCookiesTest.php
@@ -19,7 +19,10 @@ class RequestCookiesTest extends TestCase
     /** @var \Bugsnag\Request\ResolverInterface */
     protected $resolver;
 
-    protected function setUp()
+    /**
+     * @before
+     */
+    protected function beforeEach()
     {
         $this->config = new Configuration('API-KEY');
         $this->resolver = new BasicResolver();

--- a/tests/Callbacks/RequestMetaDataTest.php
+++ b/tests/Callbacks/RequestMetaDataTest.php
@@ -19,7 +19,10 @@ class RequestMetaDataTest extends TestCase
     /** @var \Bugsnag\Request\ResolverInterface */
     protected $resolver;
 
-    protected function setUp()
+    /**
+     * @before
+     */
+    protected function beforeEach()
     {
         $this->config = new Configuration('API-KEY');
         $this->resolver = new BasicResolver();

--- a/tests/Callbacks/RequestSessionTest.php
+++ b/tests/Callbacks/RequestSessionTest.php
@@ -19,7 +19,10 @@ class RequestSessionTest extends TestCase
     /** @var \Bugsnag\Request\ResolverInterface */
     protected $resolver;
 
-    protected function setUp()
+    /**
+     * @before
+     */
+    protected function beforeEach()
     {
         $this->config = new Configuration('API-KEY');
         $this->resolver = new BasicResolver();

--- a/tests/Callbacks/RequestUserTest.php
+++ b/tests/Callbacks/RequestUserTest.php
@@ -19,7 +19,10 @@ class RequestUserTest extends TestCase
     /** @var \Bugsnag\Request\ResolverInterface */
     protected $resolver;
 
-    protected function setUp()
+    /**
+     * @before
+     */
+    protected function beforeEach()
     {
         $this->config = new Configuration('API-KEY');
         $this->resolver = new BasicResolver();

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -451,7 +451,7 @@ class ClientTest extends TestCase
         $this->assertCount(1, $breadcrumbs);
 
         $this->assertCount(4, $breadcrumbs[0]);
-        $this->assertInternalType('string', $breadcrumbs[0]['timestamp']);
+        Assert::isType('string', $breadcrumbs[0]['timestamp']);
         $this->assertSame('Test', $breadcrumbs[0]['name']);
         $this->assertSame('user', $breadcrumbs[0]['type']);
         $this->assertSame(['foo' => 'bar'], $breadcrumbs[0]['metaData']);
@@ -470,7 +470,7 @@ class ClientTest extends TestCase
         $this->assertCount(1, $breadcrumbs);
 
         $this->assertCount(3, $breadcrumbs[0]);
-        $this->assertInternalType('string', $breadcrumbs[0]['timestamp']);
+        Assert::isType('string', $breadcrumbs[0]['timestamp']);
         $this->assertSame('Foo Bar Baz', $breadcrumbs[0]['name']);
         $this->assertSame('manual', $breadcrumbs[0]['type']);
         $this->assertFalse(isset($breadcrumbs[0]['metaData']));
@@ -491,7 +491,7 @@ class ClientTest extends TestCase
         $this->assertCount(1, $breadcrumbs);
 
         $this->assertCount(4, $breadcrumbs[0]);
-        $this->assertInternalType('string', $breadcrumbs[0]['timestamp']);
+        Assert::isType('string', $breadcrumbs[0]['timestamp']);
         $this->assertSame('Error', $breadcrumbs[0]['name']);
         $this->assertSame('error', $breadcrumbs[0]['type']);
         $this->assertTrue(isset($breadcrumbs[0]['metaData']));
@@ -510,7 +510,7 @@ class ClientTest extends TestCase
         $this->assertCount(1, $breadcrumbs);
 
         $this->assertCount(3, $breadcrumbs[0]);
-        $this->assertInternalType('string', $breadcrumbs[0]['timestamp']);
+        Assert::isType('string', $breadcrumbs[0]['timestamp']);
         $this->assertSame('Bugsnag\Client', $breadcrumbs[0]['name']);
         $this->assertSame('state', $breadcrumbs[0]['type']);
         $this->assertFalse(isset($breadcrumbs[0]['metaData']));
@@ -529,7 +529,7 @@ class ClientTest extends TestCase
         $this->assertCount(1, $breadcrumbs);
 
         $this->assertCount(3, $breadcrumbs[0]);
-        $this->assertInternalType('string', $breadcrumbs[0]['timestamp']);
+        Assert::isType('string', $breadcrumbs[0]['timestamp']);
         $this->assertSame('Test', $breadcrumbs[0]['name']);
         $this->assertSame('user', $breadcrumbs[0]['type']);
         $this->assertFalse(isset($breadcrumbs[0]['metaData']));
@@ -548,7 +548,7 @@ class ClientTest extends TestCase
         $this->assertCount(1, $breadcrumbs);
 
         $this->assertCount(4, $breadcrumbs[0]);
-        $this->assertInternalType('string', $breadcrumbs[0]['timestamp']);
+        Assert::isType('string', $breadcrumbs[0]['timestamp']);
         $this->assertSame('Test', $breadcrumbs[0]['name']);
         $this->assertSame('user', $breadcrumbs[0]['type']);
         $this->assertSame(['foo' => 'bar'], $breadcrumbs[0]['metaData']);
@@ -560,13 +560,13 @@ class ClientTest extends TestCase
         $this->assertCount(2, $breadcrumbs);
 
         $this->assertCount(4, $breadcrumbs[0]);
-        $this->assertInternalType('string', $breadcrumbs[0]['timestamp']);
+        Assert::isType('string', $breadcrumbs[0]['timestamp']);
         $this->assertSame('Test', $breadcrumbs[0]['name']);
         $this->assertSame('user', $breadcrumbs[0]['type']);
         $this->assertSame(['foo' => 'bar'], $breadcrumbs[0]['metaData']);
 
         $this->assertCount(4, $breadcrumbs[1]);
-        $this->assertInternalType('string', $breadcrumbs[1]['timestamp']);
+        Assert::isType('string', $breadcrumbs[1]['timestamp']);
         $this->assertSame('Name', $breadcrumbs[1]['name']);
         $this->assertSame('error', $breadcrumbs[1]['type']);
         $this->assertSame(['name' => 'Name', 'severity' => 'warning'], $breadcrumbs[1]['metaData']);

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -22,7 +22,10 @@ class ClientTest extends TestCase
     protected $config;
     protected $client;
 
-    protected function setUp()
+    /**
+     * @before
+     */
+    protected function beforeEach()
     {
         $this->config = new Configuration('example-api-key');
         $this->guzzle = $this->getMockBuilder(Guzzle::class)
@@ -35,7 +38,10 @@ class ClientTest extends TestCase
             ->getMock();
     }
 
-    protected function tearDown()
+    /**
+     * @after
+     */
+    protected function afterEach()
     {
         putenv('BUGSNAG_API_KEY');
         putenv('BUGSNAG_ENDPOINT');

--- a/tests/ConfigurationTest.php
+++ b/tests/ConfigurationTest.php
@@ -8,7 +8,10 @@ class ConfigurationTest extends TestCase
 {
     protected $config;
 
-    protected function setUp()
+    /**
+     * @before
+     */
+    protected function beforeEach()
     {
         $this->config = new Configuration('API-KEY');
     }

--- a/tests/HandlerTest.php
+++ b/tests/HandlerTest.php
@@ -29,7 +29,10 @@ namespace Bugsnag\Tests {
     {
         protected $client;
 
-        protected function setUp()
+        /**
+         * @before
+         */
+        protected function beforeEach()
         {
             global $mockErrorReporting, $mockErrorReportingLevel;
             $mockErrorReporting = false;

--- a/tests/HandlerTest.php
+++ b/tests/HandlerTest.php
@@ -53,13 +53,16 @@ namespace Bugsnag\Tests {
 
         public function testErrorHandlerWithPrevious()
         {
-            if (class_exists(\PHPUnit_Framework_Error_Warning::class)) {
-                $this->expectedException(\PHPUnit_Framework_Error_Warning::class);
-            } else {
-                $this->expectedException(\PHPUnit\Framework\Error\Warning::class);
-            }
+            $wasCalled = false;
+            set_error_handler(function () use (&$wasCalled) {
+                $wasCalled = true;
+            });
+
+            $this->assertFalse($wasCalled);
 
             Handler::registerWithPrevious($this->client)->errorHandler(E_WARNING, 'Something broke', 'somefile.php', 123);
+
+            $this->assertTrue($wasCalled);
         }
 
         public function testExceptionHandler()

--- a/tests/HttpClientTest.php
+++ b/tests/HttpClientTest.php
@@ -48,9 +48,9 @@ class HttpClientTest extends TestCase
         $this->assertCount(self::getGuzzleExpectedParamCount(), $params);
         $this->assertSame($this->config->getNotifyEndpoint(), self::getGuzzlePostUriParam($params));
         $options = self::getGuzzlePostOptionsParam($params);
-        $this->assertInternalType('array', $options);
-        $this->assertInternalType('array', $options['json']['notifier']);
-        $this->assertInternalType('array', $options['json']['events']);
+        Assert::isType('array', $options);
+        Assert::isType('array', $options['json']['notifier']);
+        Assert::isType('array', $options['json']['events']);
         $this->assertSame([], $options['json']['events'][0]['user']);
         $this->assertSame(['foo' => 'bar'], $options['json']['events'][0]['metaData']);
         $this->assertSame('6015a72ff14038114c3d12623dfb018f', $options['json']['apiKey']);
@@ -93,9 +93,9 @@ class HttpClientTest extends TestCase
         $this->assertCount(self::getGuzzleExpectedParamCount(), $params);
         $this->assertSame($this->config->getNotifyEndpoint(), self::getGuzzlePostUriParam($params));
         $options = self::getGuzzlePostOptionsParam($params);
-        $this->assertInternalType('array', $options);
-        $this->assertInternalType('array', $options['json']['notifier']);
-        $this->assertInternalType('array', $options['json']['events']);
+        Assert::isType('array', $options);
+        Assert::isType('array', $options['json']['notifier']);
+        Assert::isType('array', $options['json']['events']);
         $this->assertSame([], $options['json']['events'][0]['user']);
         $this->assertArrayNotHasKey('metaData', $options['json']['events'][0]);
         $this->assertSame('6015a72ff14038114c3d12623dfb018f', $options['json']['apiKey']);
@@ -142,9 +142,9 @@ class HttpClientTest extends TestCase
         $this->assertCount(self::getGuzzleExpectedParamCount(), $params);
         $this->assertSame($this->config->getNotifyEndpoint(), self::getGuzzlePostUriParam($params));
         $options = self::getGuzzlePostOptionsParam($params);
-        $this->assertInternalType('array', $options);
-        $this->assertInternalType('array', $options['json']['notifier']);
-        $this->assertInternalType('array', $options['json']['events']);
+        Assert::isType('array', $options);
+        Assert::isType('array', $options['json']['notifier']);
+        Assert::isType('array', $options['json']['events']);
         $this->assertSame(['foo' => 'bar'], $options['json']['events'][0]['user']);
         $this->assertSame([], $options['json']['events'][0]['metaData']);
         $this->assertSame('6015a72ff14038114c3d12623dfb018f', $options['json']['apiKey']);

--- a/tests/HttpClientTest.php
+++ b/tests/HttpClientTest.php
@@ -7,11 +7,23 @@ use Bugsnag\HttpClient;
 use Bugsnag\Report;
 use Exception;
 use GuzzleHttp\Client;
+use PHPUnit\Framework\MockObject\MockObject;
 
 class HttpClientTest extends TestCase
 {
+    /**
+     * @var Configuration
+     */
     protected $config;
+
+    /**
+     * @var MockObject&Client
+     */
     protected $guzzle;
+
+    /**
+     * @var HttpClient
+     */
     protected $http;
 
     /**
@@ -21,170 +33,177 @@ class HttpClientTest extends TestCase
     {
         $this->config = new Configuration('6015a72ff14038114c3d12623dfb018f');
 
+        /** @var MockObject&Client */
         $this->guzzle = $this->getMockBuilder(Client::class)
-                             ->setMethods([self::getGuzzleMethod()])
-                             ->getMock();
+            ->setMethods([self::getGuzzleMethod()])
+            ->getMock();
 
         $this->http = new HttpClient($this->config, $this->guzzle);
     }
 
-    private static function getInvocationParameters($invocation)
+    private function setExpectedGuzzleParameters($expectation, $callback)
     {
-        if (is_callable([$invocation, 'getParameters'])) {
-            return $invocation->getParameters();
+        if ($this->isUsingGuzzle5()) {
+            $expectation->with(
+                $this->config->getNotifyEndpoint(),
+                $this->callback($callback)
+            );
+        } else {
+            $expectation->with(
+                'POST',
+                $this->config->getNotifyEndpoint(),
+                $this->callback($callback)
+            );
         }
-
-        return $invocation->parameters;
     }
 
     public function testHttpClient()
     {
-        // Expect request to be called
-        $this->guzzle->expects($spy = $this->any())->method(self::getGuzzleMethod());
+        $verifyGuzzleParameters = function ($options) {
+            Assert::isType('array', $options);
+            Assert::isType('array', $options['json']['notifier']);
+            Assert::isType('array', $options['json']['events']);
+            $this->assertSame([], $options['json']['events'][0]['user']);
+            $this->assertSame(['foo' => 'bar'], $options['json']['events'][0]['metaData']);
+            $this->assertSame('6015a72ff14038114c3d12623dfb018f', $options['json']['apiKey']);
+            $this->assertSame('4.0', $options['json']['events'][0]['payloadVersion']);
 
-        // Add a report to the http and deliver it
+            $headers = $options['headers'];
+
+            $this->assertSame('6015a72ff14038114c3d12623dfb018f', $headers['Bugsnag-Api-Key']);
+            $this->assertArrayHasKey('Bugsnag-Sent-At', $headers);
+            $this->assertSame('4.0', $headers['Bugsnag-Payload-Version']);
+
+            return true;
+        };
+
+        $expectation = $this->guzzle->expects($this->once())
+            ->method(self::getGuzzleMethod());
+
+        $this->setExpectedGuzzleParameters($expectation, $verifyGuzzleParameters);
+
         $this->http->queue(Report::fromNamedError($this->config, 'Name')->setMetaData(['foo' => 'bar']));
         $this->http->send();
-
-        $this->assertCount(1, $invocations = $spy->getInvocations());
-        $params = self::getInvocationParameters($invocations[0]);
-        $this->assertCount(self::getGuzzleExpectedParamCount(), $params);
-        $this->assertSame($this->config->getNotifyEndpoint(), self::getGuzzlePostUriParam($params));
-        $options = self::getGuzzlePostOptionsParam($params);
-        Assert::isType('array', $options);
-        Assert::isType('array', $options['json']['notifier']);
-        Assert::isType('array', $options['json']['events']);
-        $this->assertSame([], $options['json']['events'][0]['user']);
-        $this->assertSame(['foo' => 'bar'], $options['json']['events'][0]['metaData']);
-        $this->assertSame('6015a72ff14038114c3d12623dfb018f', $options['json']['apiKey']);
-        $this->assertSame('4.0', $options['json']['events'][0]['payloadVersion']);
-
-        $headers = $options['headers'];
-        $this->assertSame('6015a72ff14038114c3d12623dfb018f', $headers['Bugsnag-Api-Key']);
-        $this->assertArrayHasKey('Bugsnag-Sent-At', $headers);
-        $this->assertSame('4.0', $headers['Bugsnag-Payload-Version']);
     }
 
     public function testHttpClientMultipleSend()
     {
-        // Expect request to be called
-        $this->guzzle->expects($spy = $this->any())->method(self::getGuzzleMethod());
+        $verifyGuzzleParameters = function ($options) {
+            Assert::isType('array', $options);
+            Assert::isType('array', $options['json']['notifier']);
+            Assert::isType('array', $options['json']['events']);
+            $this->assertSame([], $options['json']['events'][0]['user']);
+            $this->assertSame(['foo' => 'bar'], $options['json']['events'][0]['metaData']);
+            $this->assertSame('6015a72ff14038114c3d12623dfb018f', $options['json']['apiKey']);
+            $this->assertSame('4.0', $options['json']['events'][0]['payloadVersion']);
 
-        // Add a report to the http and deliver it
+            $headers = $options['headers'];
+
+            $this->assertSame('6015a72ff14038114c3d12623dfb018f', $headers['Bugsnag-Api-Key']);
+            $this->assertArrayHasKey('Bugsnag-Sent-At', $headers);
+            $this->assertSame('4.0', $headers['Bugsnag-Payload-Version']);
+
+            return true;
+        };
+
+        $expectation = $this->guzzle->expects($this->once())
+            ->method(self::getGuzzleMethod());
+
+        $this->setExpectedGuzzleParameters($expectation, $verifyGuzzleParameters);
+
         $this->http->queue(Report::fromNamedError($this->config, 'Name')->setMetaData(['foo' => 'bar']));
         $this->http->send();
-
-        // Make sure these do nothing
         $this->http->send();
-        $this->http->send();
-
-        // Check we only sent once
-        $this->assertCount(1, $invocations = $spy->getInvocations());
     }
 
     public function testMassiveMetaDataHttpClient()
     {
-        // Expect request to be called
-        $this->guzzle->expects($spy = $this->any())->method(self::getGuzzleMethod());
+        $verifyGuzzleParameters = function ($options) {
+            Assert::isType('array', $options);
+            Assert::isType('array', $options['json']['notifier']);
+            Assert::isType('array', $options['json']['events']);
+            $this->assertSame([], $options['json']['events'][0]['user']);
+            $this->assertArrayNotHasKey('metaData', $options['json']['events'][0]);
+            $this->assertSame('6015a72ff14038114c3d12623dfb018f', $options['json']['apiKey']);
+            $this->assertSame('4.0', $options['json']['events'][0]['payloadVersion']);
 
-        // Add a report to the http and deliver it
+            $headers = $options['headers'];
+
+            $this->assertSame('6015a72ff14038114c3d12623dfb018f', $headers['Bugsnag-Api-Key']);
+            $this->assertArrayHasKey('Bugsnag-Sent-At', $headers);
+            $this->assertSame('4.0', $headers['Bugsnag-Payload-Version']);
+
+            return true;
+        };
+
+        $expectation = $this->guzzle->expects($this->once())
+            ->method(self::getGuzzleMethod());
+
+        $this->setExpectedGuzzleParameters($expectation, $verifyGuzzleParameters);
+
         $this->http->queue(Report::fromNamedError($this->config, 'Name')->setMetaData(['foo' => str_repeat('A', 1500000)]));
         $this->http->send();
-
-        $this->assertCount(1, $invocations = $spy->getInvocations());
-        $params = self::getInvocationParameters($invocations[0]);
-        $this->assertCount(self::getGuzzleExpectedParamCount(), $params);
-        $this->assertSame($this->config->getNotifyEndpoint(), self::getGuzzlePostUriParam($params));
-        $options = self::getGuzzlePostOptionsParam($params);
-        Assert::isType('array', $options);
-        Assert::isType('array', $options['json']['notifier']);
-        Assert::isType('array', $options['json']['events']);
-        $this->assertSame([], $options['json']['events'][0]['user']);
-        $this->assertArrayNotHasKey('metaData', $options['json']['events'][0]);
-        $this->assertSame('6015a72ff14038114c3d12623dfb018f', $options['json']['apiKey']);
-        $this->assertSame('4.0', $options['json']['events'][0]['payloadVersion']);
-
-        $headers = $options['headers'];
-        $this->assertSame('6015a72ff14038114c3d12623dfb018f', $headers['Bugsnag-Api-Key']);
-        $this->assertArrayHasKey('Bugsnag-Sent-At', $headers);
-        $this->assertSame('4.0', $headers['Bugsnag-Payload-Version']);
     }
 
     public function testMassiveUserHttpClient()
     {
-        // Setup error_log mocking
         $log = $this->getFunctionMock('Bugsnag', 'error_log');
-        $log->expects($this->once())->with($this->equalTo('Bugsnag Warning: Payload too large'));
+        $log->expects($this->once())
+            ->with($this->equalTo('Bugsnag Warning: Payload too large'));
 
-        // Expect request to be called
-        $this->guzzle->expects($spy = $this->any())->method(self::getGuzzleMethod());
+        $this->guzzle->expects($this->never())
+            ->method(self::getGuzzleMethod())
+            ->withAnyParameters();
 
-        // Add a report to the http and deliver it
         $this->http->queue(Report::fromNamedError($this->config, 'Name')->setUser(['foo' => str_repeat('A', 1500000)]));
         $this->http->send();
-
-        $this->assertCount(0, $spy->getInvocations());
     }
 
     public function testPartialHttpClient()
     {
-        // Setup error_log mocking
         $log = $this->getFunctionMock('Bugsnag', 'error_log');
         $log->expects($this->once())->with($this->equalTo('Bugsnag Warning: Payload too large'));
 
-        // Expect request to be called
-        $this->guzzle->expects($spy = $this->any())->method(self::getGuzzleMethod());
+        $verifyGuzzleParameters = function ($options) {
+            Assert::isType('array', $options);
+            Assert::isType('array', $options['json']['notifier']);
+            Assert::isType('array', $options['json']['events']);
+            $this->assertSame(['foo' => 'bar'], $options['json']['events'][0]['user']);
+            $this->assertSame([], $options['json']['events'][0]['metaData']);
+            $this->assertSame('6015a72ff14038114c3d12623dfb018f', $options['json']['apiKey']);
+            $this->assertSame('4.0', $options['json']['events'][0]['payloadVersion']);
 
-        // Add two errors to the http and deliver them
+            $headers = $options['headers'];
+            $this->assertSame('6015a72ff14038114c3d12623dfb018f', $headers['Bugsnag-Api-Key']);
+            $this->assertArrayHasKey('Bugsnag-Sent-At', $headers);
+            $this->assertSame('4.0', $headers['Bugsnag-Payload-Version']);
+
+            return true;
+        };
+
+        $expectation = $this->guzzle->expects($this->once())
+            ->method(self::getGuzzleMethod());
+
+        $this->setExpectedGuzzleParameters($expectation, $verifyGuzzleParameters);
+
         $this->http->queue(Report::fromNamedError($this->config, 'Name')->setUser(['foo' => str_repeat('A', 1500000)]));
         $this->http->queue(Report::fromNamedError($this->config, 'Name')->setUser(['foo' => 'bar']));
         $this->http->send();
-
-        $this->assertCount(1, $invocations = $spy->getInvocations());
-        $params = self::getInvocationParameters($invocations[0]);
-        $this->assertCount(self::getGuzzleExpectedParamCount(), $params);
-        $this->assertSame($this->config->getNotifyEndpoint(), self::getGuzzlePostUriParam($params));
-        $options = self::getGuzzlePostOptionsParam($params);
-        Assert::isType('array', $options);
-        Assert::isType('array', $options['json']['notifier']);
-        Assert::isType('array', $options['json']['events']);
-        $this->assertSame(['foo' => 'bar'], $options['json']['events'][0]['user']);
-        $this->assertSame([], $options['json']['events'][0]['metaData']);
-        $this->assertSame('6015a72ff14038114c3d12623dfb018f', $options['json']['apiKey']);
-        $this->assertSame('4.0', $options['json']['events'][0]['payloadVersion']);
-
-        $headers = $options['headers'];
-        $this->assertSame('6015a72ff14038114c3d12623dfb018f', $headers['Bugsnag-Api-Key']);
-        $this->assertArrayHasKey('Bugsnag-Sent-At', $headers);
-        $this->assertSame('4.0', $headers['Bugsnag-Payload-Version']);
     }
 
     public function testHttpClientFails()
     {
-        // Setup error_log mocking
         $log = $this->getFunctionMock('Bugsnag', 'error_log');
-        $log->expects($this->once())->with($this->equalTo('Bugsnag Warning: Couldn\'t notify. Guzzle exception thrown!'));
+        $log->expects($this->once())
+            ->with($this->equalTo(
+                "Bugsnag Warning: Couldn't notify. Guzzle exception thrown!"
+            ));
 
-        // Expect request to be called
-        $this->guzzle->method(self::getGuzzleMethod())->will($this->throwException(new Exception('Guzzle exception thrown!')));
+        $this->guzzle->expects($this->once())
+            ->method(self::getGuzzleMethod())
+            ->will($this->throwException(new Exception('Guzzle exception thrown!')));
 
-        // Add a report to the http and deliver it
         $this->http->queue(Report::fromNamedError($this->config, 'Name')->setMetaData(['foo' => 'bar']));
         $this->http->send();
-    }
-
-    private function getGuzzleExpectedParamCount()
-    {
-        return self::getGuzzleMethod() === 'request' ? 3 : 2;
-    }
-
-    private function getGuzzlePostUriParam(array $params)
-    {
-        return $params[self::getGuzzleMethod() === 'request' ? 1 : 0];
-    }
-
-    private function getGuzzlePostOptionsParam(array $params)
-    {
-        return $params[self::getGuzzleMethod() === 'request' ? 2 : 1];
     }
 }

--- a/tests/HttpClientTest.php
+++ b/tests/HttpClientTest.php
@@ -14,7 +14,10 @@ class HttpClientTest extends TestCase
     protected $guzzle;
     protected $http;
 
-    protected function setUp()
+    /**
+     * @before
+     */
+    protected function beforeEach()
     {
         $this->config = new Configuration('6015a72ff14038114c3d12623dfb018f');
 

--- a/tests/Middleware/BreadcrumbsDataTest.php
+++ b/tests/Middleware/BreadcrumbsDataTest.php
@@ -19,7 +19,10 @@ class BreadcrumbsDataTest extends TestCase
     /** @var \Bugsnag\Breadcrumbs\Recorder */
     protected $recorder;
 
-    protected function setUp()
+    /**
+     * @before
+     */
+    protected function beforeEach()
     {
         $this->config = new Configuration('API-KEY');
         $this->recorder = new Recorder();

--- a/tests/Middleware/BreadcrumbsDataTest.php
+++ b/tests/Middleware/BreadcrumbsDataTest.php
@@ -7,6 +7,7 @@ use Bugsnag\Breadcrumbs\Recorder;
 use Bugsnag\Configuration;
 use Bugsnag\Middleware\BreadcrumbData;
 use Bugsnag\Report;
+use Bugsnag\Tests\Assert;
 use Bugsnag\Tests\TestCase;
 use Exception;
 
@@ -50,7 +51,7 @@ class BreadcrumbsDataTest extends TestCase
         $this->assertCount(1, $breadcrumbs);
 
         $this->assertCount(3, $breadcrumbs[0]);
-        $this->assertInternalType('string', $breadcrumbs[0]['timestamp']);
+        Assert::isType('string', $breadcrumbs[0]['timestamp']);
         $this->assertSame('Foo', $breadcrumbs[0]['name']);
         $this->assertSame('error', $breadcrumbs[0]['type']);
         $this->assertFalse(isset($breadcrumbs[0]['metaData']));
@@ -70,7 +71,7 @@ class BreadcrumbsDataTest extends TestCase
         $this->assertCount(1, $breadcrumbs);
 
         $this->assertCount(4, $breadcrumbs[0]);
-        $this->assertInternalType('string', $breadcrumbs[0]['timestamp']);
+        Assert::isType('string', $breadcrumbs[0]['timestamp']);
         $this->assertSame('Foo', $breadcrumbs[0]['name']);
         $this->assertSame('error', $breadcrumbs[0]['type']);
         $this->assertSame(['foo' => 'bar'], $breadcrumbs[0]['metaData']);
@@ -91,13 +92,13 @@ class BreadcrumbsDataTest extends TestCase
         $this->assertCount(2, $breadcrumbs);
 
         $this->assertCount(4, $breadcrumbs[0]);
-        $this->assertInternalType('string', $breadcrumbs[0]['timestamp']);
+        Assert::isType('string', $breadcrumbs[0]['timestamp']);
         $this->assertSame('Foo', $breadcrumbs[0]['name']);
         $this->assertSame('error', $breadcrumbs[0]['type']);
         $this->assertSame(['foo' => 'bar'], $breadcrumbs[0]['metaData']);
 
         $this->assertCount(3, $breadcrumbs[1]);
-        $this->assertInternalType('string', $breadcrumbs[1]['timestamp']);
+        Assert::isType('string', $breadcrumbs[1]['timestamp']);
         $this->assertSame('Bar', $breadcrumbs[1]['name']);
         $this->assertSame('log', $breadcrumbs[1]['type']);
         $this->assertFalse(isset($breadcrumbs[1]['metaData']));
@@ -123,13 +124,13 @@ class BreadcrumbsDataTest extends TestCase
         $this->assertCount(25, $breadcrumbs);
 
         $this->assertCount(3, $breadcrumbs[0]);
-        $this->assertInternalType('string', $breadcrumbs[0]['timestamp']);
+        Assert::isType('string', $breadcrumbs[0]['timestamp']);
         $this->assertSame('Bar', $breadcrumbs[0]['name']);
         $this->assertSame('log', $breadcrumbs[0]['type']);
         $this->assertFalse(isset($breadcrumbs[0]['metaData']));
 
         $this->assertCount(4, $breadcrumbs[24]);
-        $this->assertInternalType('string', $breadcrumbs[24]['timestamp']);
+        Assert::isType('string', $breadcrumbs[24]['timestamp']);
         $this->assertSame('Baz', $breadcrumbs[24]['name']);
         $this->assertSame('navigation', $breadcrumbs[24]['type']);
         $this->assertSame(['baz' => 'bar'], $breadcrumbs[24]['metaData']);

--- a/tests/Middleware/CallbackBridgeTest.php
+++ b/tests/Middleware/CallbackBridgeTest.php
@@ -13,7 +13,10 @@ class CallbackBridgeTest extends TestCase
     /** @var \Bugsnag\Configuration */
     protected $config;
 
-    protected function setUp()
+    /**
+     * @before
+     */
+    protected function beforeEach()
     {
         $this->config = new Configuration('API-KEY');
     }

--- a/tests/Middleware/NotificationSkipperTest.php
+++ b/tests/Middleware/NotificationSkipperTest.php
@@ -13,7 +13,10 @@ class NotificationSkipperTest extends TestCase
     /** @var \Bugsnag\Configuration */
     protected $config;
 
-    protected function setUp()
+    /**
+     * @before
+     */
+    protected function beforeEach()
     {
         $this->config = new Configuration('API-KEY');
     }

--- a/tests/Middleware/SessionDataTest.php
+++ b/tests/Middleware/SessionDataTest.php
@@ -28,7 +28,10 @@ class SessionDataTest extends TestCase
      */
     private $report;
 
-    protected function setUp()
+    /**
+     * @before
+     */
+    protected function beforeEach()
     {
         $config = new Configuration('api-key');
 

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,0 +1,26 @@
+# Bugsnag PHP test suite
+
+## Writing tests
+
+Bugsnag PHP is currently compatible with PHP 5.5 - 7.4. This places restrictions on our test suite, as we have to support PHPUnit 4, 7 and 9 in order to run tests against all of our supported PHP versions.
+
+All unit tests must extend `Bugsnag\Tests\TestCase`.
+
+In order to support a wide range of PHP and PHPUnit versions, there are some constraints that our tests must obey. Some of these are listed below, but others may not have been encountered yet — our CI will fail if an unsupported feature is used.
+
+### Assertions
+
+Some assertions have been replaced in PHPUnit and so are not usable in our test suite. Replacement assertions that are compatible across PHPUnit versions are available on the `Bugsnag\Tests\Assert` class. This affects:
+
+- `assertRegExp`/`assertMatchesRegularExpression` — use `Assert::matchesRegularExpression` instead
+- `assertInternalType`/`assertIs<Type>` — use `Assert::isType` instead
+
+### Set up and tear down
+
+PHPUnit's `setUp` and `tearDown` methods aren't usable because they require a `void` return type in newer versions of PHPUnit. This isn't possible to add while also being compatible with PHP 5.
+
+Therefore we have to use [`@before`](https://phpunit.readthedocs.io/en/9.3/annotations.html#before) and [`@after`](https://phpunit.readthedocs.io/en/9.3/annotations.html#after) annotations instead. By convention, these are placed on methods named `beforeEach` and `afterEach`.
+
+### Expecting exceptions
+
+PHPUnit has different methods to expect exceptions in different versions. Instead of using PHPUnit methods, `Bugsnag\Tests\TestCase` has an `expectedException` method, which is compatible with all supported versions of PHPUnit.

--- a/tests/ReportTest.php
+++ b/tests/ReportTest.php
@@ -26,7 +26,7 @@ class ReportTest extends TestCase
         $data = $this->report->toArray();
 
         $this->assertCount(3, $data['device']);
-        $this->assertInternalType('string', $data['device']['time']);
+        Assert::isType('string', $data['device']['time']);
         $this->assertSame(php_uname('n'), $data['device']['hostname']);
         $this->assertSame(phpversion(), $data['device']['runtimeVersions']['php']);
     }
@@ -134,7 +134,7 @@ class ReportTest extends TestCase
 
         $event = $this->report->toArray();
         // 'Code' should not be filtered so should remain still be an array
-        $this->assertInternalType('array', $event['exceptions'][0]['stacktrace'][0]['code']);
+        Assert::isType('array', $event['exceptions'][0]['stacktrace'][0]['code']);
     }
 
     public function testFiltersAreCaseInsensitive()

--- a/tests/ReportTest.php
+++ b/tests/ReportTest.php
@@ -12,7 +12,14 @@ use stdClass;
 
 class ReportTest extends TestCase
 {
+    /**
+     * @var Configuration
+     */
     protected $config;
+
+    /**
+     * @var Report
+     */
     protected $report;
 
     /**
@@ -168,17 +175,91 @@ class ReportTest extends TestCase
 
     public function testCanGetStacktrace()
     {
-        $this->report->setPHPError(E_NOTICE, 'Broken', 'file', 123);
+        $beginningOfTest = __LINE__;
+
+        // Generate a small backtrace to test with
+        $this->generateBacktrace(4);
 
         $trace = $this->report->getStacktrace();
-
         $this->assertInstanceOf(Stacktrace::class, $trace);
 
-        // Before PHPUnit 7 tests were executed via ReflectionMethod::invokeArgs
-        // which adds a line to the stacktrace
-        $expectedCount = $this->isPhpUnit7() ? 11 : 12;
+        $trace = $trace->toArray();
+        $this->assertGreaterThan(4, count($trace));
 
-        $this->assertCount($expectedCount, $trace->toArray());
+        // Strip out frames that weren't generated in this file, so that changes
+        // in how PHPUnit executes tests don't cause this test to fail (some
+        // versions of PHPUnit will generate more/less frames than others)
+        $trace = array_filter($trace, function ($frame) {
+            return $frame['file'] === __FILE__;
+        });
+
+        $this->assertNotEmpty($trace);
+
+        $lineNumber = __LINE__;
+
+        $generatedFrame = [
+            'lineNumber' => $lineNumber + 61,
+            'method' => __CLASS__.'::generateBacktrace',
+            'code' => [
+                $lineNumber + 58 => '    private function generateBacktrace($depth)',
+                $lineNumber + 59 => '    {',
+                $lineNumber + 60 => '        if ($depth > 0) {',
+                $lineNumber + 61 => '            return $this->generateBacktrace($depth - 1);',
+                $lineNumber + 62 => '        }',
+                $lineNumber + 63 => '',
+                $lineNumber + 64 => '        $this->report->setPHPError(E_NOTICE, \'Broken\', \'file\', 123);',
+            ],
+            'inProject' => false,
+            'file' => __FILE__,
+        ];
+
+        $expected = [
+            [
+                'lineNumber' => $lineNumber + 64,
+                'method' => __CLASS__.'::generateBacktrace',
+                'code' => [
+                    $lineNumber + 61 => '            return $this->generateBacktrace($depth - 1);',
+                    $lineNumber + 62 => '        }',
+                    $lineNumber + 63 => '',
+                    $lineNumber + 64 => '        $this->report->setPHPError(E_NOTICE, \'Broken\', \'file\', 123);',
+                    $lineNumber + 65 => '    }',
+                    $lineNumber + 66 => '',
+                    $lineNumber + 67 => '    public function testNoticeName()',
+                ],
+                'inProject' => false,
+                'file' => __FILE__,
+            ],
+            $generatedFrame,
+            $generatedFrame,
+            $generatedFrame,
+            $generatedFrame,
+            [
+                'lineNumber' => $beginningOfTest + 3,
+                'method' => __METHOD__,
+                'code' => [
+                    $beginningOfTest + 0 => '        $beginningOfTest = __LINE__;',
+                    $beginningOfTest + 1 => '',
+                    $beginningOfTest + 2 => '        // Generate a small backtrace to test with',
+                    $beginningOfTest + 3 => '        $this->generateBacktrace(4);',
+                    $beginningOfTest + 4 => '',
+                    $beginningOfTest + 5 => '        $trace = $this->report->getStacktrace();',
+                    $beginningOfTest + 6 => '        $this->assertInstanceOf(Stacktrace::class, $trace);',
+                ],
+                'inProject' => false,
+                'file' => __FILE__,
+            ],
+        ];
+
+        $this->assertSame($expected, $trace);
+    }
+
+    private function generateBacktrace($depth)
+    {
+        if ($depth > 0) {
+            return $this->generateBacktrace($depth - 1);
+        }
+
+        $this->report->setPHPError(E_NOTICE, 'Broken', 'file', 123);
     }
 
     public function testNoticeName()

--- a/tests/ReportTest.php
+++ b/tests/ReportTest.php
@@ -15,7 +15,10 @@ class ReportTest extends TestCase
     protected $config;
     protected $report;
 
-    protected function setUp()
+    /**
+     * @before
+     */
+    protected function beforeEach()
     {
         $this->config = new Configuration('example-key');
         $this->report = Report::fromNamedError($this->config, 'Name', 'Message');

--- a/tests/RequestTest.php
+++ b/tests/RequestTest.php
@@ -17,7 +17,10 @@ class RequestTest extends TestCase
 {
     protected $resolver;
 
-    protected function setUp()
+    /**
+     * @before
+     */
+    protected function beforeEach()
     {
         $_SERVER['REQUEST_METHOD'] = 'PUT';
         $_SERVER['REQUEST_URI'] = '/blah/blah.php?some=param';

--- a/tests/SessionTrackerTest.php
+++ b/tests/SessionTrackerTest.php
@@ -20,7 +20,10 @@ class SessionTrackerTest extends TestCase
     /** @var HttpClient&MockObject */
     private $client;
 
-    public function setUp()
+    /**
+     * @before
+     */
+    protected function beforeEach()
     {
         /** @var Configuration&MockObject */
         $this->config = new Configuration('example-api-key');

--- a/tests/SessionTrackerTest.php
+++ b/tests/SessionTrackerTest.php
@@ -599,7 +599,7 @@ class SessionTrackerTest extends TestCase
             $this->assertArrayHasKey('startedAt', $session);
             $this->assertArrayHasKey('sessionsStarted', $session);
 
-            $this->assertRegExp('/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}$/', $session['startedAt']);
+            Assert::matchesRegularExpression('/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}$/', $session['startedAt']);
             $this->assertSame(1, $session['sessionsStarted']);
 
             return true;

--- a/tests/StacktraceTest.php
+++ b/tests/StacktraceTest.php
@@ -9,7 +9,10 @@ class StacktraceTest extends TestCase
 {
     protected $config;
 
-    protected function setUp()
+    /**
+     * @before
+     */
+    protected function beforeEach()
     {
         $this->config = new Configuration('key');
     }


### PR DESCRIPTION
## Goal

This PR adds support for PHPUnit 9 in our test suite. This is important as it's the earliest version of PHPUnit that will have PHP 8 support

This required some workarounds to keep our suite compatible with PHPUnit 4 (!) and 7, which are no longer supported

Each commit is self contained, so it may be easier to review them separately

## Changeset

- Deprecated/removed assertions have been replaced with assertions in a new `Assert` class. This doesn't feel great, but I think the alternatives are worse:
    - putting assertions in `TestCase` with the same name as PHPUnit assertions doesn't work because we have to match the signatures exactly — PHPUnit added return types so this is impossible for us
    - putting assertions in `TestCase` with different names to PHPUnit works but is confusing — do I use `assertRegExp`, `assertMatchesRegularExpression` or `assertMatchesRegex`? I think delineating our custom assertions is less confusing, if a little clunky
    - switching all assertions to call either PHPUnit's `Assert` or our own `Assert` statically would be a big diff and not usually how PHPUnit is used
    - switching all assertions to `Assert` would be an even bigger diff and definitely not how PHPUnit is used, though it has a nice consistency and would make adding more BC methods easier in future
- `setUp` and `tearDown` are no longer possible for us to use, because they now have return types and PHP 5 doesn't support that. These have been replaced with `@before` and `@after` annotations on `beforeEach` and `afterEach` methods (the method names aren't important but are the same for consistency)
- The `HttpClient` test has been rewritten to avoid using removed features. This test relied heavily on internal PHPUnit features which aren't covered by its BC policy, so now it uses mocking with callbacks to assert against the expected parameters. This is functionally the same but will be better supported with changes to PHPUnit in the future
- One of the tests in the `Stacktrace` test has been rewritten to avoid changes in PHPUnit from causing it to fail. Previously this relied on the number of stacktrace frames caused by how PHPUnit calls tests. This breaks in PHPUnit 9 because it has a different number of frames when running using the config file vs pointing it at a specific directory/file. It now filters out frames from outside of the test file, so changes in PHPUnit shouldn't be able to break it
- PHPUnit 9 no longer likes you using `expectException` with a warning/notice/etc&hellip but the only test that did this wasn't really testing what it was supposed to anyway. This has been rewritten so it avoids the deprecation and tests more thoroughly