### PR TITLE
Phpunit 9 deprecations

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,9 +16,7 @@
         "guzzlehttp/guzzle": "^5.0|^6.0|^7.0"
     },
     "require-dev": {
-        "graham-campbell/testbench-core": "^1.1",
         "guzzlehttp/psr7": "^1.3",
-        "mockery/mockery": "^0.9.4|^1.3.1",
         "mtdowling/burgomaster": "dev-master#72151eddf5f0cf101502b94bf5031f9c53501a04",
         "phpunit/phpunit": "^4.8.36|^7.5.15|^9.3.10",
         "php-mock/php-mock-phpunit": "^1.1|^2.1",

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,29 +1,32 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit backupGlobals="false"
-         backupStaticAttributes="false"
-         beStrictAboutTestsThatDoNotTestAnything="true"
-         beStrictAboutOutputDuringTests="true"
-         bootstrap="vendor/autoload.php"
-         colors="true"
-         convertErrorsToExceptions="true"
-         convertNoticesToExceptions="true"
-         convertWarningsToExceptions="true"
-         failOnRisky="true"
-         failOnWarning="true"
-         processIsolation="false"
-         stopOnError="false"
-         stopOnFailure="false"
-         verbose="true"
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd"
+    backupGlobals="false"
+    backupStaticAttributes="false"
+    beStrictAboutTestsThatDoNotTestAnything="true"
+    beStrictAboutOutputDuringTests="true"
+    bootstrap="vendor/autoload.php"
+    colors="true"
+    convertErrorsToExceptions="true"
+    convertNoticesToExceptions="true"
+    convertWarningsToExceptions="true"
+    failOnRisky="true"
+    failOnWarning="true"
+    processIsolation="false"
+    stopOnError="false"
+    stopOnFailure="false"
+    verbose="true"
 >
+    <coverage processUncoveredFiles="true">
+        <include>
+            <directory suffix=".php">./src</directory>
+        </include>
+    </coverage>
+
     <testsuites>
         <testsuite name="Bugsnag PHP Test Suite">
             <directory suffix="Test.php">./tests</directory>
             <directory suffix=".phpt">./tests/phpt</directory>
         </testsuite>
     </testsuites>
-    <filter>
-        <whitelist processUncoveredFilesFromWhitelist="true">
-            <directory suffix=".php">./src</directory>
-        </whitelist>
-    </filter>
 </phpunit>

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -4,15 +4,12 @@ namespace Bugsnag\Tests;
 
 use Bugsnag\Client;
 use Bugsnag\Configuration;
-use Bugsnag\HttpClient;
 use Bugsnag\Report;
-use Bugsnag\Shutdown\PhpShutdownStrategy;
+use Bugsnag\Tests\Fakes\FakeShutdownStrategy;
 use Exception;
 use GuzzleHttp\Client as Guzzle;
 use GuzzleHttp\Psr7\Uri;
-use Mockery;
 use PHPUnit\Framework\MockObject\MockObject;
-use ReflectionClass;
 
 /**
  * @backupGlobals enabled
@@ -1081,9 +1078,13 @@ class ClientTest extends TestCase
 
     public function testShutdownStrategyIsCalledWithinConstructor()
     {
-        $mockShutdown = Mockery::mock(PhpShutdownStrategy::class);
-        $mockShutdown->shouldReceive('registerShutdownStrategy')->once();
-        new Client($this->config, null, null, $mockShutdown);
+        $shutdownStrategy = new FakeShutdownStrategy();
+
+        $this->assertFalse($shutdownStrategy->wasRegistered());
+
+        new Client($this->config, null, null, $shutdownStrategy);
+
+        $this->assertTrue($shutdownStrategy->wasRegistered());
     }
 
     private function expectGuzzlePostWith($uri, array $options = [])

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -11,6 +11,7 @@ use Exception;
 use GuzzleHttp\Client as Guzzle;
 use GuzzleHttp\Psr7\Uri;
 use Mockery;
+use PHPUnit\Framework\MockObject\MockObject;
 use ReflectionClass;
 
 /**
@@ -18,9 +19,20 @@ use ReflectionClass;
  */
 class ClientTest extends TestCase
 {
-    protected $guzzle;
-    protected $config;
-    protected $client;
+    /**
+     * @var Configuration
+     */
+    private $config;
+
+    /**
+     * @var MockObject&Guzzle
+     */
+    private $guzzle;
+
+    /**
+     * @var Client
+     */
+    private $client;
 
     /**
      * @before
@@ -28,14 +40,13 @@ class ClientTest extends TestCase
     protected function beforeEach()
     {
         $this->config = new Configuration('example-api-key');
+
+        /** @var MockObject&Guzzle */
         $this->guzzle = $this->getMockBuilder(Guzzle::class)
             ->setMethods([self::getGuzzleMethod()])
             ->getMock();
 
-        $this->client = $this->getMockBuilder(Client::class)
-            ->setMethods(['notify'])
-            ->setConstructorArgs([$this->config, null, $this->guzzle])
-            ->getMock();
+        $this->client = new Client($this->config, null, $this->guzzle);
     }
 
     /**
@@ -49,48 +60,56 @@ class ClientTest extends TestCase
 
     public function testManualErrorNotification()
     {
-        $this->client->expects($this->once())->method('notify');
+        $this->guzzle->expects($this->once())->method(self::getGuzzleMethod());
 
         $this->client->notifyError('SomeError', 'Some message');
+        $this->client->flush();
     }
 
     public function testManualErrorNotificationWithSeverity()
     {
-        $client = new Client($this->config, null, $this->guzzle);
-        $prop = (new ReflectionClass($client))->getProperty('http');
-        $prop->setAccessible(true);
+        $this->expectGuzzlePostWithCallback(
+            $this->client->getNotifyEndpoint(),
+            function ($options) {
+                $this->assertTrue(isset($options['json']['events'][0]['severity']));
+                $this->assertSame('info', $options['json']['events'][0]['severity']);
 
-        $http = $this->getMockBuilder(HttpClient::class)
-                     ->setMethods(['queue'])
-                     ->setConstructorArgs([$this->config, $this->guzzle])
-                     ->getMock();
-        $prop->setValue($client, $http);
+                return true;
+            }
+        );
 
-        $http->expects($this->once())
-             ->method('queue')
-             ->with($this->callback(function ($subject) {
-                 return $subject->getSeverity() === 'info';
-             }));
-
-        $client->notifyError('SomeError', 'Some message', function ($report) {
+        $this->client->notifyError('SomeError', 'Some message', function ($report) {
             $report->setSeverity('info');
         });
+
+        $this->client->flush();
     }
 
     public function testManualExceptionNotification()
     {
-        $this->client->expects($this->once())->method('notify');
+        $this->guzzle->expects($this->once())->method(self::getGuzzleMethod());
 
         $this->client->notifyException(new Exception('Something broke'));
+        $this->client->flush();
     }
 
     public function testManualExceptionNotificationWithSeverity()
     {
-        $this->client->expects($this->once())->method('notify');
+        $this->expectGuzzlePostWithCallback(
+            $this->client->getNotifyEndpoint(),
+            function ($options) {
+                $this->assertTrue(isset($options['json']['events'][0]['severity']));
+                $this->assertSame('info', $options['json']['events'][0]['severity']);
+
+                return true;
+            }
+        );
 
         $this->client->notifyException(new Exception('Something broke'), function ($report) {
             $report->setSeverity('info');
         });
+
+        $this->client->flush();
     }
 
     public function testTheNotifyEndpointHasASensibleDefault()
@@ -601,39 +620,27 @@ class ClientTest extends TestCase
 
     public function testBatchingDoesNotFlush()
     {
-        $this->client = $this->getMockBuilder(Client::class)
-                             ->setMethods(['flush'])
-                             ->setConstructorArgs([$this->config, null, $this->guzzle])
-                             ->getMock();
+        $this->guzzle->expects($this->never())->method(self::getGuzzleMethod());
 
-        $this->client->expects($this->never())->method('flush');
-
-        $this->client->notify($report = Report::fromNamedError($this->config, 'Name'));
+        $this->client->notify(Report::fromNamedError($this->config, 'Name'));
     }
 
     public function testFlushesWhenNotBatching()
     {
-        $this->client = $this->getMockBuilder(Client::class)
-                             ->setMethods(['flush'])
-                             ->setConstructorArgs([$this->config, null, $this->guzzle])
-                             ->getMock();
-
-        $this->client->expects($this->once())->method('flush');
+        $this->guzzle->expects($this->once())->method(self::getGuzzleMethod());
 
         $this->client->setBatchSending(false);
 
-        $this->client->notify($report = Report::fromNamedError($this->config, 'Name'));
+        $this->client->notify(Report::fromNamedError($this->config, 'Name'));
     }
 
     public function testCanManuallyFlush()
     {
-        $this->client = new Client($this->config = new Configuration('example-api-key'), null, $this->guzzle);
-
         $this->client->setBatchSending(false);
 
         $this->guzzle->expects($this->once())->method(self::getGuzzleMethod());
 
-        $this->client->notify($report = Report::fromNamedError($this->config, 'Name'));
+        $this->client->notify(Report::fromNamedError($this->config, 'Name'));
 
         $this->client->flush();
         $this->client->flush();
@@ -642,7 +649,7 @@ class ClientTest extends TestCase
 
     public function testDeployWorksOutOfTheBox()
     {
-        $this->guzzlePostWith(
+        $this->expectGuzzlePostWith(
             'https://build.bugsnag.com',
             ['json' => ['releaseStage' => 'production', 'apiKey' => 'example-api-key', 'buildTool' => 'bugsnag-php', 'builderName' => exec('whoami'), 'appVersion' => '1.3.1']]
         );
@@ -655,7 +662,7 @@ class ClientTest extends TestCase
 
     public function testDeployWorksWithReleaseStage()
     {
-        $this->guzzlePostWith(
+        $this->expectGuzzlePostWith(
             'https://build.bugsnag.com',
             ['json' => ['releaseStage' => 'staging', 'apiKey' => 'example-api-key', 'buildTool' => 'bugsnag-php', 'builderName' => exec('whoami'), 'appVersion' => '1.3.1']]
         );
@@ -669,7 +676,7 @@ class ClientTest extends TestCase
 
     public function testDeployWorksWithAppVersion()
     {
-        $this->guzzlePostWith(
+        $this->expectGuzzlePostWith(
             'https://build.bugsnag.com',
             ['json' => ['releaseStage' => 'production', 'appVersion' => '1.1.0', 'apiKey' => 'example-api-key', 'buildTool' => 'bugsnag-php', 'builderName' => exec('whoami'), 'appVersion' => '1.3.1']]
         );
@@ -682,7 +689,7 @@ class ClientTest extends TestCase
 
     public function testDeployWorksWithRepository()
     {
-        $this->guzzlePostWith(
+        $this->expectGuzzlePostWith(
             'https://build.bugsnag.com',
             ['json' => ['sourceControl' => ['repository' => 'foo'], 'releaseStage' => 'production', 'apiKey' => 'example-api-key', 'buildTool' => 'bugsnag-php', 'builderName' => exec('whoami'), 'appVersion' => '1.3.1']]
         );
@@ -695,7 +702,7 @@ class ClientTest extends TestCase
 
     public function testDeployWorksWithBranch()
     {
-        $this->guzzlePostWith(
+        $this->expectGuzzlePostWith(
             'https://build.bugsnag.com',
             ['json' => ['releaseStage' => 'production', 'apiKey' => 'example-api-key', 'buildTool' => 'bugsnag-php', 'builderName' => exec('whoami'), 'appVersion' => '1.3.1']]
         );
@@ -708,7 +715,7 @@ class ClientTest extends TestCase
 
     public function testDeployWorksWithRevision()
     {
-        $this->guzzlePostWith(
+        $this->expectGuzzlePostWith(
             'https://build.bugsnag.com',
             ['json' => ['sourceControl' => ['revision' => 'bar'], 'releaseStage' => 'production', 'apiKey' => 'example-api-key', 'buildTool' => 'bugsnag-php', 'builderName' => exec('whoami'), 'appVersion' => '1.3.1']]
         );
@@ -721,7 +728,7 @@ class ClientTest extends TestCase
 
     public function testDeployWorksWithEverything()
     {
-        $this->guzzlePostWith(
+        $this->expectGuzzlePostWith(
             'https://build.bugsnag.com',
             ['json' => ['sourceControl' => ['repository' => 'baz', 'revision' => 'foo'], 'releaseStage' => 'development', 'appVersion' => '1.3.1', 'apiKey' => 'example-api-key', 'buildTool' => 'bugsnag-php', 'builderName' => exec('whoami'), 'appVersion' => '1.3.1']]
         );
@@ -735,7 +742,7 @@ class ClientTest extends TestCase
 
     public function testBuildWorksOutOfTheBox()
     {
-        $this->guzzlePostWith(
+        $this->expectGuzzlePostWith(
             'https://build.bugsnag.com',
             ['json' => ['releaseStage' => 'production', 'apiKey' => 'example-api-key', 'buildTool' => 'bugsnag-php', 'builderName' => exec('whoami'), 'appVersion' => '1.3.1']]
         );
@@ -748,7 +755,7 @@ class ClientTest extends TestCase
 
     public function testBuildWorksWithReleaseStage()
     {
-        $this->guzzlePostWith(
+        $this->expectGuzzlePostWith(
             'https://build.bugsnag.com',
             ['json' => ['releaseStage' => 'staging', 'apiKey' => 'example-api-key', 'buildTool' => 'bugsnag-php', 'builderName' => exec('whoami'), 'appVersion' => '1.3.1']]
         );
@@ -762,7 +769,7 @@ class ClientTest extends TestCase
 
     public function testBuildWorksWithRepository()
     {
-        $this->guzzlePostWith(
+        $this->expectGuzzlePostWith(
             'https://build.bugsnag.com',
             ['json' => ['sourceControl' => ['repository' => 'foo'], 'releaseStage' => 'production', 'apiKey' => 'example-api-key', 'buildTool' => 'bugsnag-php', 'builderName' => exec('whoami'), 'appVersion' => '1.3.1']]
         );
@@ -775,7 +782,7 @@ class ClientTest extends TestCase
 
     public function testBuildWorksWithProvider()
     {
-        $this->guzzlePostWith(
+        $this->expectGuzzlePostWith(
             'https://build.bugsnag.com',
             ['json' => ['sourceControl' => ['provider' => 'github'], 'releaseStage' => 'production', 'apiKey' => 'example-api-key', 'buildTool' => 'bugsnag-php', 'builderName' => exec('whoami'), 'appVersion' => '1.3.1']]
         );
@@ -788,7 +795,7 @@ class ClientTest extends TestCase
 
     public function testBuildWorksWithRevision()
     {
-        $this->guzzlePostWith(
+        $this->expectGuzzlePostWith(
             'https://build.bugsnag.com',
             ['json' => ['sourceControl' => ['revision' => 'bar'], 'releaseStage' => 'production', 'apiKey' => 'example-api-key', 'buildTool' => 'bugsnag-php', 'builderName' => exec('whoami'), 'appVersion' => '1.3.1']]
         );
@@ -801,7 +808,7 @@ class ClientTest extends TestCase
 
     public function testBuildWorksWithBuilderName()
     {
-        $this->guzzlePostWith(
+        $this->expectGuzzlePostWith(
             'https://build.bugsnag.com',
             ['json' => ['builderName' => 'me', 'releaseStage' => 'production', 'apiKey' => 'example-api-key', 'buildTool' => 'bugsnag-php', 'appVersion' => '1.3.1']]
         );
@@ -814,7 +821,7 @@ class ClientTest extends TestCase
 
     public function testBuildWorksWithBuildTool()
     {
-        $this->guzzlePostWith(
+        $this->expectGuzzlePostWith(
             'https://build.bugsnag.com',
             ['json' => ['releaseStage' => 'production', 'apiKey' => 'example-api-key', 'buildTool' => 'bugsnag-php', 'builderName' => exec('whoami'), 'appVersion' => '1.3.1']]
         );
@@ -827,7 +834,7 @@ class ClientTest extends TestCase
 
     public function testBuildWorksWithEverything()
     {
-        $this->guzzlePostWith(
+        $this->expectGuzzlePostWith(
             'https://build.bugsnag.com',
             ['json' => ['builderName' => 'me', 'sourceControl' => ['repository' => 'baz', 'revision' => 'foo', 'provider' => 'github'], 'releaseStage' => 'development', 'appVersion' => '1.3.1', 'apiKey' => 'example-api-key', 'buildTool' => 'bugsnag-php']]
         );
@@ -1079,15 +1086,27 @@ class ClientTest extends TestCase
         new Client($this->config, null, null, $mockShutdown);
     }
 
-    private function guzzlePostWith($uri, array $options = [])
+    private function expectGuzzlePostWith($uri, array $options = [])
     {
         $method = self::getGuzzleMethod();
         $mock = $this->guzzle->expects($this->once())->method($method);
 
         if ($method === 'request') {
-            return $mock->with($this->equalTo('POST'), $this->equalTo($uri), $this->equalTo($options));
+            return $mock->with('POST', $uri, $options);
         }
 
-        return $mock->with($this->equalTo($uri), $this->equalTo($options));
+        return $mock->with($uri, $options);
+    }
+
+    private function expectGuzzlePostWithCallback($uri, $callback)
+    {
+        $method = self::getGuzzleMethod();
+        $mock = $this->guzzle->expects($this->once())->method($method);
+
+        if ($method === 'request') {
+            return $mock->with('POST', $uri, $this->callback($callback));
+        }
+
+        return $mock->with($uri, $this->callback($callback));
     }
 }

--- a/tests/Fakes/FakeShutdownStrategy.php
+++ b/tests/Fakes/FakeShutdownStrategy.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Bugsnag\Tests\Fakes;
+
+use Bugsnag\Client;
+use Bugsnag\Shutdown\ShutdownStrategyInterface;
+
+final class FakeShutdownStrategy implements ShutdownStrategyInterface
+{
+    private $wasRegistered = false;
+
+    public function registerShutdownStrategy(Client $client)
+    {
+        $this->wasRegistered = true;
+    }
+
+    public function wasRegistered()
+    {
+        return $this->wasRegistered;
+    }
+}

--- a/tests/HttpClientTest.php
+++ b/tests/HttpClientTest.php
@@ -34,9 +34,7 @@ class HttpClientTest extends TestCase
         $this->config = new Configuration('6015a72ff14038114c3d12623dfb018f');
 
         /** @var MockObject&Client */
-        $this->guzzle = $this->getMockBuilder(Client::class)
-            ->setMethods([self::getGuzzleMethod()])
-            ->getMock();
+        $this->guzzle = $this->getMockBuilder(Client::class)->getMock();
 
         $this->http = new HttpClient($this->config, $this->guzzle);
     }

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -2,7 +2,6 @@
 
 namespace Bugsnag\Tests;
 
-use GrahamCampbell\TestBenchCore\MockeryTrait;
 use GuzzleHttp\ClientInterface;
 use phpmock\phpunit\PHPMock;
 use PHPUnit\Framework\TestCase as BaseTestCase;
@@ -11,7 +10,6 @@ use PHPUnit\Runner\Version as PhpUnitVersion;
 abstract class TestCase extends BaseTestCase
 {
     use PHPMock;
-    use MockeryTrait;
 
     public function expectedException($class, $message = null)
     {


### PR DESCRIPTION
## Goal

Following on from https://github.com/bugsnag/bugsnag-php/pull/601, this PR resolves some deprecations in PHPUnit 9 to help get us ready for PHPUnit 10 (will release early next year)

Most notably, `MockBuilder::setMethods` has been deprecated, which we used fairly often. I've fixed _most_ places that were using this to use some other method, but there are still two places that use it:

- `ClientTest` — I've consolidated the usage into one mock, so it should be fairly easy to swap out when PHPUnit 10 releases
- `HandlerTest` — this was completely rewritten in https://github.com/bugsnag/bugsnag-php/pull/600, so I've left this alone for now

While doing this, I also removed Mockery as a dependency because we weren't really using it. Sticking with one way to mock things should make maintaining the test suite easier