### PR TITLE
Avoid calling method_exists on non-objects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 Changelog
 =========
 
+## TBD
+
+### Fixes
+
+* Avoid calling `method_exists` on non-objects
+  [#603](https://github.com/bugsnag/bugsnag-php/pull/603)
+
 ## 3.23.0 (2020-09-14)
 
 ### Enhancements

--- a/src/Client.php
+++ b/src/Client.php
@@ -201,7 +201,7 @@ class Client
 
         $base = $this->getGuzzleBaseUri($guzzle);
 
-        if (is_string($base) || method_exists($base, '__toString')) {
+        if (is_string($base) || (is_object($base) && method_exists($base, '__toString'))) {
             $configuration->setNotifyEndpoint((string) $base);
         }
     }

--- a/src/Report.php
+++ b/src/Report.php
@@ -386,7 +386,7 @@ class Report
      */
     public function setName($name)
     {
-        if (is_scalar($name) || method_exists($name, '__toString')) {
+        if (is_scalar($name) || (is_object($name) && method_exists($name, '__toString'))) {
             $this->name = (string) $name;
         } else {
             throw new InvalidArgumentException('The name must be a string.');
@@ -422,7 +422,10 @@ class Report
     {
         if ($message === null) {
             $this->message = null;
-        } elseif (is_scalar($message) || method_exists($message, '__toString')) {
+        } elseif (
+            is_scalar($message)
+            || (is_object($message) && method_exists($message, '__toString'))
+        ) {
             $this->message = (string) $message;
         } else {
             throw new InvalidArgumentException('The message must be a string.');

--- a/tests/Fakes/StringableObject.php
+++ b/tests/Fakes/StringableObject.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Bugsnag\Tests\Fakes;
+
+final class StringableObject
+{
+    public function __toString()
+    {
+        return '2object2string';
+    }
+}

--- a/tests/ReportTest.php
+++ b/tests/ReportTest.php
@@ -5,6 +5,7 @@ namespace Bugsnag\Tests;
 use Bugsnag\Configuration;
 use Bugsnag\Report;
 use Bugsnag\Stacktrace;
+use Bugsnag\Tests\Fakes\StringableObject;
 use Exception;
 use InvalidArgumentException;
 use ParseError;
@@ -405,44 +406,77 @@ class ReportTest extends TestCase
         $this->assertSame($this->report, $this->report->setPHPThrowable('foo'));
     }
 
-    public function testBadSetName()
+    public function testSetNameThrowsWhenPassedAnArray()
     {
         $this->expectedException(InvalidArgumentException::class);
         $this->report->setName([]);
     }
 
-    public function testBadSetMessage()
+    public function testSetNameThrowsWhenPassedANonStringableObject()
+    {
+        $this->expectedException(InvalidArgumentException::class);
+        $this->report->setName(new stdClass());
+    }
+
+    public function testSetMessageThrowsWhenPassedAnArray()
+    {
+        $this->expectedException(InvalidArgumentException::class);
+        $this->report->setMessage([]);
+    }
+
+    public function testSetMessageThrowsWhenPassedANonStringableObject()
     {
         $this->expectedException(InvalidArgumentException::class);
         $this->report->setMessage(new stdClass());
     }
 
-    public function testGoodSetName()
+    public function testSetNameAcceptsIntegers()
     {
         $this->report->setName(123);
 
         $this->assertSame('123', $this->report->getName());
     }
 
-    public function testGoodSetMessage()
+    public function testSetNameAcceptsStrings()
+    {
+        $this->report->setName('hey');
+
+        $this->assertSame('hey', $this->report->getName());
+    }
+
+    public function testSetNameAcceptsStringableObjects()
+    {
+        $this->report->setName(new StringableObject());
+
+        $this->assertSame('2object2string', $this->report->getName());
+    }
+
+    public function testSetMessageAcceptsStrings()
     {
         $this->report->setMessage('foo bar baz');
 
         $this->assertSame('foo bar baz', $this->report->getMessage());
     }
 
-    public function testEmptySetMessage()
+    public function testSetMessageAcceptsEmptyStrings()
     {
         $this->report->setMessage('');
 
         $this->assertSame('', $this->report->getMessage());
     }
 
-    public function testNullSetMessage()
+    public function testSetMessageAcceptsNull()
     {
         $this->report->setMessage(null);
 
         $this->assertNull($this->report->getMessage());
+    }
+
+    public function testSetMessageAcceptsStringableObjects()
+    {
+        $this->report->setMessage(new StringableObject());
+
+        $this->assertSame('2object2string', $this->report->getMessage());
     }
 
     public function testGetSummaryFull()


### PR DESCRIPTION
## Goal

In PHP 8 `method_exists` throws a `TypeError` when passed something that isn't an object, so we need to avoid doing that

## Design

There is a new `Stringable` interface for this in PHP 8, but we would still need to check with `method_exists` for BC on PHP 5/7, so it's not useful for us (yet!)

## Changeset

- `method_exists` calls that could receive any input are now preceded by `is_object` checks
- `ReportTest` has a few more test cases as the `method_exists` in `setMessage` wasn't covered