### PR TITLE
Fallback to php exception handler if there is no previous exception handler

### DIFF
--- a/.github/workflows/test-package.yml
+++ b/.github/workflows/test-package.yml
@@ -6,6 +6,7 @@ jobs:
   test:
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         php-version: [ 5.5, 5.6, 7.0, 7.1, 7.2, 7.3, 7.4 ]
         guzzle-version: [ '^5.3', '^6.0' ]

--- a/tests/phpt/fixtures/compile_error.php
+++ b/tests/phpt/fixtures/compile_error.php
@@ -1,0 +1,10 @@
+<?php
+
+class Abc
+{
+    /**
+     * Class constants called 'class' are not allowed by PHP because it would break
+     * the class name lookup feature; e.g. Abc::class should always equal "Abc"
+     */
+    const class = ':-)';
+}

--- a/tests/phpt/handler_should_report_compile_errors.phpt
+++ b/tests/phpt/handler_should_report_compile_errors.phpt
@@ -1,0 +1,27 @@
+--TEST--
+Bugsnag\Handler should report compile errors
+
+https://github.com/php/php-src/blob/2772751b58ee579a8f1288a0949e5e1fcb554877/Zend/zend_API.c#L3965-L3968
+--FILE--
+<?php
+$client = require __DIR__ . '/_prelude.php';
+
+Bugsnag\Handler::register($client);
+
+include __DIR__ . '/fixtures/compile_error.php';
+
+var_dump('I should not be reached');
+?>
+--SKIPIF--
+<?php
+if (PHP_MAJOR_VERSION < 7) {
+    echo 'SKIP — this is a different error in PHP 5';
+}
+?>
+--EXPECTF--
+Fatal error: A class constant must not be called 'class'; it is reserved for class name fetching in %s/compile_error.php on line 9
+Guzzle request made (1 event)!
+* Method: 'POST'
+* URI: 'http://localhost/notify'
+* Events:
+    - A class constant must not be called 'class'; it is reserved for class name fetching

--- a/tests/phpt/handler_should_report_uncaught_exceptions.phpt
+++ b/tests/phpt/handler_should_report_uncaught_exceptions.phpt
@@ -11,7 +11,7 @@ throw new Exception('abcxyz');
 var_dump("I should never be reached!");
 ?>
 --EXPECTF--
-Fatal error: Uncaught Exception: abcxyz in %s:6
+Fatal error: Uncaught %SException%S %Sabcxyz%S in %s:6
 Stack trace:
 #0 {main}
   thrown in %s on line 6

--- a/tests/phpt/handler_should_report_uncaught_exceptions.phpt
+++ b/tests/phpt/handler_should_report_uncaught_exceptions.phpt
@@ -1,11 +1,5 @@
 --TEST--
 Bugsnag\Handler should report uncaught exceptions
-
-TODO this should also result in:
-> Fatal error: Uncaught Exception: abcxyz in %s:6
-> Stack trace:
-> #0 {main}
->   thrown in %s on line 6
 --FILE--
 <?php
 $client = require __DIR__ . '/_prelude.php';
@@ -17,6 +11,10 @@ throw new Exception('abcxyz');
 var_dump("I should never be reached!");
 ?>
 --EXPECTF--
+Fatal error: Uncaught Exception: abcxyz in %s:6
+Stack trace:
+#0 {main}
+  thrown in %s on line 6
 Guzzle request made (1 event)!
 * Method: 'POST'
 * URI: 'http://localhost/notify'

--- a/tests/phpt/php5/handler_should_report_parse_errors.phpt
+++ b/tests/phpt/php5/handler_should_report_parse_errors.phpt
@@ -1,0 +1,25 @@
+--TEST--
+Bugsnag\Handler should report parse errors
+--FILE--
+<?php
+$client = require __DIR__ . '/../_prelude.php';
+
+Bugsnag\Handler::register($client);
+
+include __DIR__ . '/../fixtures/parse_error.php';
+
+var_dump('I should not be reached');
+?>
+--SKIPIF--
+<?php
+if (PHP_MAJOR_VERSION !== 5) {
+    echo 'SKIP — this test has different output on PHP 7 & 8';
+}
+?>
+--EXPECTF--
+Parse error: syntax error, unexpected '{' in %s/parse_error.php on line 3
+Guzzle request made (1 event)!
+* Method: 'POST'
+* URI: 'http://localhost/notify'
+* Events:
+    - syntax error, unexpected '{'

--- a/tests/phpt/php7/handler_should_report_parse_errors.phpt
+++ b/tests/phpt/php7/handler_should_report_parse_errors.phpt
@@ -1,0 +1,27 @@
+--TEST--
+Bugsnag\Handler should report parse errors
+--FILE--
+<?php
+$client = require __DIR__ . '/../_prelude.php';
+
+Bugsnag\Handler::register($client);
+
+include __DIR__ . '/../fixtures/parse_error.php';
+
+var_dump('I should not be reached');
+?>
+--SKIPIF--
+<?php
+if (PHP_MAJOR_VERSION !== 7) {
+    echo 'SKIP — this test has different output on PHP 5 & 8';
+}
+?>
+--EXPECTF--
+Parse error: syntax error, unexpected '{' in %s/parse_error.php on line 3
+
+Fatal error: Exception thrown without a stack frame in Unknown on line 0
+Guzzle request made (1 event)!
+* Method: 'POST'
+* URI: 'http://localhost/notify'
+* Events:
+    - syntax error, unexpected '{'

--- a/tests/phpt/php7/handler_should_report_parse_errors_with_previous_handler.phpt
+++ b/tests/phpt/php7/handler_should_report_parse_errors_with_previous_handler.phpt
@@ -1,0 +1,50 @@
+--TEST--
+Bugsnag\Handler should report parse errors with a previous handler
+--FILE--
+<?php
+$client = require __DIR__ . '/../_prelude.php';
+
+set_exception_handler(function ($throwable) {
+    var_dump($throwable);
+    throw $throwable;
+});
+
+Bugsnag\Handler::register($client);
+
+include __DIR__ . '/../fixtures/parse_error.php';
+
+var_dump('I should not be reached');
+?>
+--SKIPIF--
+<?php
+if (PHP_MAJOR_VERSION !== 7) {
+    echo 'SKIP — this test has different output on PHP 5 & 8';
+}
+?>
+--EXPECTF--
+object(ParseError)#15 (7) {
+  ["message":protected]=>
+  string(28) "syntax error, unexpected '{'"
+  ["string":"Error":private]=>
+  string(0) ""
+  ["code":protected]=>
+  int(0)
+  ["file":protected]=>
+  string(%d) "%s/parse_error.php"
+  ["line":protected]=>
+  int(3)
+  ["trace":"Error":private]=>
+  array(0) {
+  }
+  ["previous":"Error":private]=>
+  NULL
+}
+
+Parse error: syntax error, unexpected '{' in %s/parse_error.php on line 3
+
+Fatal error: Exception thrown without a stack frame in Unknown on line 0
+Guzzle request made (1 event)!
+* Method: 'POST'
+* URI: 'http://localhost/notify'
+* Events:
+    - syntax error, unexpected '{'

--- a/tests/phpt/php8/handler_should_report_parse_errors.phpt
+++ b/tests/phpt/php8/handler_should_report_parse_errors.phpt
@@ -1,25 +1,23 @@
 --TEST--
 Bugsnag\Handler should report parse errors
-
-TODO this should also run in PHP 7!
 --FILE--
 <?php
-$client = require __DIR__ . '/_prelude.php';
+$client = require __DIR__ . '/../_prelude.php';
 
 Bugsnag\Handler::register($client);
 
-include __DIR__ . '/fixtures/parse_error.php';
+include __DIR__ . '/../fixtures/parse_error.php';
 
 var_dump('I should not be reached');
 ?>
 --SKIPIF--
 <?php
-if (PHP_MAJOR_VERSION > 5) {
-    echo 'SKIP - PHP 7 does not output the parse error';
+if (PHP_MAJOR_VERSION !== 8) {
+    echo 'SKIP — this test has different output on PHP 5 & 7';
 }
 ?>
 --EXPECTF--
-Parse error: syntax error, unexpected '{' in %s/parse_error.php on line 3
+Parse error: syntax error, unexpected token "}" in %s/parse_error.php on line 3
 Guzzle request made (1 event)!
 * Method: 'POST'
 * URI: 'http://localhost/notify'

--- a/tests/phpt/php8/handler_should_report_parse_errors_with_previous_handler.phpt
+++ b/tests/phpt/php8/handler_should_report_parse_errors_with_previous_handler.phpt
@@ -1,0 +1,48 @@
+--TEST--
+Bugsnag\Handler should report parse errors with a previous handler
+--FILE--
+<?php
+$client = require __DIR__ . '/../_prelude.php';
+
+set_exception_handler(function ($throwable) {
+    var_dump($throwable);
+    throw $throwable;
+});
+
+Bugsnag\Handler::register($client);
+
+include __DIR__ . '/../fixtures/parse_error.php';
+
+var_dump('I should not be reached');
+?>
+--SKIPIF--
+<?php
+if (PHP_MAJOR_VERSION !== 8) {
+    echo 'SKIP — this test has different output on PHP 5 & 7';
+}
+?>
+--EXPECTF--
+object(ParseError)#15 (7) {
+  ["message":protected]=>
+  string(28) "syntax error, unexpected '{'"
+  ["string":"Error":private]=>
+  string(0) ""
+  ["code":protected]=>
+  int(0)
+  ["file":protected]=>
+  string(%d) "%s/parse_error.php"
+  ["line":protected]=>
+  int(3)
+  ["trace":"Error":private]=>
+  array(0) {
+  }
+  ["previous":"Error":private]=>
+  NULL
+}
+
+Parse error: syntax error, unexpected token "}" in %s/parse_error.php on line 3
+Guzzle request made (1 event)!
+* Method: 'POST'
+* URI: 'http://localhost/notify'
+* Events:
+    - syntax error, unexpected '{'


### PR DESCRIPTION
## Goal

This PR tries to ensure that there is no difference between running a script with Bugsnag and running the same script without Bugsnag

Currently if there is no previous exception handler set we can end up reporting exceptions to Bugsnag but suppressing the output. This can make things hard to debug when reports don't get sent to Bugsnag because of release stage rules, e.g. see https://github.com/bugsnag/bugsnag-php/issues/523 & https://github.com/bugsnag/bugsnag-php/issues/475

## Design

Re-throwing the original exception seems to be equivalent to not running an exception handler at all, with one exception: when a parse error occurrs in PHP 7, the parse error _and_ another fatal error are both output (see https://3v4l.org/gG93I). This seems unavoidable unless we suppress the parse error too. This is fixed in PHP 8 and, as the original error is also reported, seems better than suppressing output entirely

## Changeset

- add a fallback previous handler if no previous handler exists
- more PHPT tests to catch edge cases in the error handler
- Disabled fail fast as it makes debugging CI harder — the whole suite finishes in 2 minutes anyway 😀 