### PR TITLE
Fix PHPT test output on PHP 8

### DIFF
--- a/tests/phpt/handler_should_call_the_previous_error_handler.phpt
+++ b/tests/phpt/handler_should_call_the_previous_error_handler.phpt
@@ -11,7 +11,7 @@ set_error_handler(function () {
 
 Bugsnag\Handler::registerWithPrevious($client);
 
-$a = $b;
+new stdClass == 1;
 
 var_dump('Hello!');
 
@@ -22,27 +22,27 @@ array(4) {
   [0]=>
   int(8)
   [1]=>
-  string(21) "Undefined variable: b"
+  string(54) "Object of class stdClass could not be converted to int"
   [2]=>
   string(%d) "%s"
   [3]=>
   int(11)
 }
 
-Notice: Undefined variable: b in %s on line 11
+Notice: Object of class stdClass could not be converted to int in %s on line 11
 string(6) "Hello!"
 array(4) {
   [0]=>
   int(2)
   [1]=>
-  string(%d) "include(%s/abc/xyz.php): failed to open stream: No such file or directory"
+  string(%d) "include(%s/abc/xyz.php): %cailed to open stream: No such file or directory"
   [2]=>
   string(%d) "%s"
   [3]=>
   int(15)
 }
 
-Warning: include(%s/abc/xyz.php): failed to open stream: No such file or directory in %s on line 15
+Warning: include(%s/abc/xyz.php): %cailed to open stream: No such file or directory in %s on line 15
 array(4) {
   [0]=>
   int(2)
@@ -59,6 +59,6 @@ Guzzle request made (3 events)!
 * Method: 'POST'
 * URI: 'http://localhost/notify'
 * Events:
-    - Undefined variable: b
-    - include(%s/abc/xyz.php): failed to open stream: No such file or directory
+    - Object of class stdClass could not be converted to int
+    - include(%s/abc/xyz.php): %cailed to open stream: No such file or directory
     - include(): Failed opening '%s/abc/xyz.php' for inclusion (include_path='%s')

--- a/tests/phpt/handler_should_report_notices.phpt
+++ b/tests/phpt/handler_should_report_notices.phpt
@@ -6,15 +6,15 @@ $client = require __DIR__ . '/_prelude.php';
 
 Bugsnag\Handler::register($client);
 
-$a = $b;
+new stdClass == 1;
 
 var_dump('Hello!');
 ?>
 --EXPECTF--
-Notice: Undefined variable: b in %s on line 6
+Notice: Object of class stdClass could not be converted to int in %s on line 6
 string(6) "Hello!"
 Guzzle request made (1 event)!
 * Method: 'POST'
 * URI: 'http://localhost/notify'
 * Events:
-    - Undefined variable: b
+    - Object of class stdClass could not be converted to int

--- a/tests/phpt/handler_should_report_warnings.phpt
+++ b/tests/phpt/handler_should_report_warnings.phpt
@@ -11,7 +11,7 @@ include __DIR__ . '/abc/xyz.php';
 var_dump('Hello!');
 ?>
 --EXPECTF--
-Warning: include(%s/abc/xyz.php): failed to open stream: No such file or directory in %s on line 6
+Warning: include(%s/abc/xyz.php): %cailed to open stream: No such file or directory in %s on line 6
 
 Warning: include(): Failed opening '%s/abc/xyz.php' for inclusion (include_path='%s') in %s on line 6
 string(6) "Hello!"
@@ -19,5 +19,5 @@ Guzzle request made (2 events)!
 * Method: 'POST'
 * URI: 'http://localhost/notify'
 * Events:
-    - include(%s/abc/xyz.php): failed to open stream: No such file or directory
+    - include(%s/abc/xyz.php): %cailed to open stream: No such file or directory
     - include(): Failed opening '%s/abc/xyz.php' for inclusion (include_path='%s')

--- a/tests/phpt/handler_should_respect_error_suppression_operator.phpt
+++ b/tests/phpt/handler_should_respect_error_suppression_operator.phpt
@@ -6,14 +6,14 @@ $client = require __DIR__ . '/_prelude.php';
 
 Bugsnag\Handler::register($client);
 
-@$a = $b; // should not be reported
-$c = $d;
+@(new stdClass == 1); // should not be reported
+new stdClass == 1;
 
 ?>
 --EXPECTF--
-Notice: Undefined variable: d in %s on line 7
+Notice: Object of class stdClass could not be converted to int in %s on line 7
 Guzzle request made (1 event)!
 * Method: 'POST'
 * URI: 'http://localhost/notify'
 * Events:
-    - Undefined variable: d
+    - Object of class stdClass could not be converted to int

--- a/tests/phpt/handler_should_respect_error_suppression_operator_with_custom_reporting_level.phpt
+++ b/tests/phpt/handler_should_respect_error_suppression_operator_with_custom_reporting_level.phpt
@@ -20,6 +20,12 @@ trigger_error('abc warning', E_USER_WARNING);
 echo "Triggering a suppressed user warning that should be ignored by PHP and ignored by Bugsnag\n";
 @trigger_error('xyz warning', E_USER_WARNING);
 ?>
+--SKIPIF--
+<?php
+if (PHP_MAJOR_VERSION === 8) {
+    echo 'SKIP — PHP 8 changes the error suppression operator (PLAT-4822)';
+}
+?>
 --EXPECTF--
 Triggering a user notice that should be reported by PHP and ignored by Bugsnag
 

--- a/tests/phpt/handler_should_use_the_previous_error_handler_return_value.phpt
+++ b/tests/phpt/handler_should_use_the_previous_error_handler_return_value.phpt
@@ -13,11 +13,11 @@ set_error_handler(function ()use (&$hideError) {
 Bugsnag\Handler::registerWithPrevious($client);
 
 var_dump('Triggering notice with hide error:', $hideError);
-$a = $b;
+new stdClass == 1;
 
 $hideError = false;
 var_dump('Triggering notice with hide error:', $hideError);
-$a = $b;
+new stdClass == 1;
 ?>
 --EXPECTF--
 string(34) "Triggering notice with hide error:"
@@ -25,10 +25,10 @@ bool(true)
 string(34) "Triggering notice with hide error:"
 bool(false)
 
-Notice: Undefined variable: b in %s on line 17
+Notice: Object of class stdClass could not be converted to int in %s on line 17
 Guzzle request made (2 events)!
 * Method: 'POST'
 * URI: 'http://localhost/notify'
 * Events:
-    - Undefined variable: b
-    - Undefined variable: b
+    - Object of class stdClass could not be converted to int
+    - Object of class stdClass could not be converted to int


### PR DESCRIPTION
## Goal

A lot of error messages have changed in PHP 8 so our PHPT tests fail as the expected output has changed

The main change is that undefined variables are now warnings rather than notices, so we now trigger a "Object of class stdClass could not be converted to int" notice instead. The only other change is the output of failed includes has been capitalised ('Failed' not 'failed') — we have to use a `%c` placeholder here, which stands for any single character

Finally, one test has been skipped due to changes to the error suppression operator in PHP 8 — this will be handled separately

With this PR, all tests now pass on PHP 8