### PR TITLE
Add PHP 8 to CI

### DIFF
--- a/.github/workflows/test-package.yml
+++ b/.github/workflows/test-package.yml
@@ -16,6 +16,9 @@ jobs:
           guzzle-version: '^7.0'
         - php-version: 7.4
           guzzle-version: '^7.0'
+        - php-version: 8.0
+          guzzle-version: '^7.0'
+          composer-flags: '--ignore-platform-reqs'
 
     steps:
     - uses: actions/checkout@v2
@@ -28,9 +31,9 @@ jobs:
     - run: composer validate
 
     - name: require guzzle
-      run: composer require "guzzlehttp/guzzle:${{ matrix.guzzle-version }}" --no-update
+      run: composer require "guzzlehttp/guzzle:${{ matrix.guzzle-version }}" --no-update ${{ matrix.composer-flags }}
 
     - name: install dependencies
-      run: composer update --prefer-dist --no-progress --no-suggest --no-interaction
+      run: composer update --prefer-dist --no-progress --no-suggest --no-interaction ${{ matrix.composer-flags }}
 
     - run: composer run-script test


### PR DESCRIPTION
## Goal

Add PHP 8 to CI so that any new changes are automatically tested against it

This requires ignoring platform requirements (i.e. PHP version requirements) when installing dependencies as some still require PHP 7 — we don't actually use these in our unit tests so this is safe to do (as evidenced by the test suite passing!)

## Changeset

PHP 8 added to the test matrix
Note: this builds against the master branch, rather than an RC as that's currently the only option with the setup-php action. I think this should be stable enough so haven't added a soft fail flag, but we can do that later if it causes random build breakages