### PR TITLE
Fixed branch alias

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -36,7 +36,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-master": "3.20-dev"
+            "dev-master": "3.23-dev"
         }
     },
     "minimum-stability": "dev",


### PR DESCRIPTION
The purpose of branch aliases is to indicate to Packagist what version the branch is. That is, what release series to expect the next tag on the master branch to be. This allows people to test with `@dev` stability, and get the correct version of Bugsnag.