### PR TITLE
Require errorReportingLevel to be a subset of error_reporting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,17 @@
 Changelog
 =========
 
+## TBD
+
+This release changes how Bugsnag detects the error suppression operator in combination with the `errorReportingLevel` configuration option, for PHP 8 compatibility. Bugsnag's `errorReportingLevel` must now be a subset of `error_reporting` — i.e. every error level in `errorReportingLevel` must also be in `error_reporting`
+
+If you use the `errorReportingLevel` option, you may need to change your Bugsnag or PHP configuration in order to report all expected errors. See [PR #611](https://github.com/bugsnag/bugsnag-php/pull/611) for more details
+
+### Fixes
+
+* Make `Configuration::shouldIgnoreErrorCode` compatible with PHP 8 by requiring the `errorReportingLevel` option to be a subset of `error_reporting`
+  [#611](https://github.com/bugsnag/bugsnag-php/pull/611)
+
 ## 3.23.1 (2020-10-19)
 
 This release fixes several issues with Bugsnag's error handlers that caused it to affect the behaviour of shutdown functions ([#475](https://github.com/bugsnag/bugsnag-php/issues/475)) and CLI script exit codes ([#523](https://github.com/bugsnag/bugsnag-php/issues/523)). This does not apply if you are using the Laravel or Symfony integrations, as they use separate methods of error handling.

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -29,4 +29,9 @@
             <directory suffix=".phpt">./tests/phpt</directory>
         </testsuite>
     </testsuites>
+
+    <php>
+        <!-- Use a very big number as we can't use the 'E_ALL' constant here -->
+        <ini name="error_reporting" value="2147483647" />
+    </php>
 </phpunit>

--- a/src/Configuration.php
+++ b/src/Configuration.php
@@ -569,9 +569,66 @@ class Configuration
      */
     public function setErrorReportingLevel($errorReportingLevel)
     {
+        if (!$this->isSubsetOfErrorReporting($errorReportingLevel)) {
+            $missingLevels = implode(', ', $this->getMissingErrorLevelNames($errorReportingLevel));
+            $message =
+                'Bugsnag Warning: errorReportingLevel cannot contain values that are not in error_reporting. '.
+                "Any errors of these levels will be ignored: {$missingLevels}.";
+
+            error_log($message);
+        }
+
         $this->errorReportingLevel = $errorReportingLevel;
 
         return $this;
+    }
+
+    /**
+     * Check if the given error reporting level is a subset of error_reporting.
+     *
+     * For example, if $level contains E_WARNING then error_reporting must too.
+     *
+     * @param int|null $level
+     *
+     * @return bool
+     */
+    private function isSubsetOfErrorReporting($level)
+    {
+        if (!is_int($level)) {
+            return true;
+        }
+
+        $errorReporting = error_reporting();
+
+        // If all of the bits in $level are also in $errorReporting, ORing them
+        // together will result in the same value as $errorReporting because
+        // there are no new bits to add
+        return ($errorReporting | $level) === $errorReporting;
+    }
+
+    /**
+     * Get a list of error level names that are in $level but not error_reporting.
+     *
+     * For example, if error_reporting is E_NOTICE and $level is E_ERROR then
+     * this will return ['E_ERROR']
+     *
+     * @param int $level
+     *
+     * @return string[]
+     */
+    private function getMissingErrorLevelNames($level)
+    {
+        $missingLevels = [];
+        $errorReporting = error_reporting();
+
+        foreach (ErrorTypes::getAllCodes() as $code) {
+            // $code is "missing" if it's in $level but not in $errorReporting
+            if (($code & $level) && !($code & $errorReporting)) {
+                $missingLevels[] = ErrorTypes::codeToString($code);
+            }
+        }
+
+        return $missingLevels;
     }
 
     /**
@@ -583,19 +640,19 @@ class Configuration
      */
     public function shouldIgnoreErrorCode($code)
     {
-        $defaultReportingLevel = error_reporting();
-
-        if ($defaultReportingLevel === 0) {
-            // The error has been suppressed using the error control operator ('@')
-            // Ignore the error in all cases.
+        // If the code is not in error_reporting then it is either totally
+        // disabled or is being suppressed with '@'
+        if (!(error_reporting() & $code)) {
             return true;
         }
 
+        // Filter the error code further against our error reporting level, which
+        // can be lower than error_reporting
         if (isset($this->errorReportingLevel)) {
             return !($this->errorReportingLevel & $code);
         }
 
-        return !($defaultReportingLevel & $code);
+        return false;
     }
 
     /**

--- a/src/ErrorTypes.php
+++ b/src/ErrorTypes.php
@@ -159,4 +159,66 @@ class ErrorTypes
     {
         return array_keys(self::$ERROR_TYPES);
     }
+
+    /**
+     * Convert the given error code to a string representation.
+     *
+     * For example, E_ERROR => 'E_ERROR'.
+     *
+     * @param int $code
+     *
+     * @return string
+     */
+    public static function codeToString($code)
+    {
+        switch ($code) {
+            case E_ERROR:
+                return 'E_ERROR';
+
+            case E_WARNING:
+                return 'E_WARNING';
+
+            case E_PARSE:
+                return 'E_PARSE';
+
+            case E_NOTICE:
+                return 'E_NOTICE';
+
+            case E_CORE_ERROR:
+                return 'E_CORE_ERROR';
+
+            case E_CORE_WARNING:
+                return 'E_CORE_WARNING';
+
+            case E_COMPILE_ERROR:
+                return 'E_COMPILE_ERROR';
+
+            case E_COMPILE_WARNING:
+                return 'E_COMPILE_WARNING';
+
+            case E_USER_ERROR:
+                return 'E_USER_ERROR';
+
+            case E_USER_WARNING:
+                return 'E_USER_WARNING';
+
+            case E_USER_NOTICE:
+                return 'E_USER_NOTICE';
+
+            case E_STRICT:
+                return 'E_STRICT';
+
+            case E_RECOVERABLE_ERROR:
+                return 'E_RECOVERABLE_ERROR';
+
+            case E_DEPRECATED:
+                return 'E_DEPRECATED';
+
+            case E_USER_DEPRECATED:
+                return 'E_USER_DEPRECATED';
+
+            default:
+                return 'Unknown';
+        }
+    }
 }

--- a/src/ErrorTypes.php
+++ b/src/ErrorTypes.php
@@ -149,4 +149,14 @@ class ErrorTypes
 
         return $levels;
     }
+
+    /**
+     * Get a list of all PHP error codes.
+     *
+     * @return int[]
+     */
+    public static function getAllCodes()
+    {
+        return array_keys(self::$ERROR_TYPES);
+    }
 }

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -1036,10 +1036,21 @@ class ClientTest extends TestCase
     public function testErrorReportingLevel()
     {
         $client = Client::make('foo');
+
         $this->assertSame($client, $client->setErrorReportingLevel(E_ALL));
         $this->assertFalse($client->shouldIgnoreErrorCode(E_NOTICE));
-        $this->assertSame($client, $client->setErrorReportingLevel(E_ALL && ~E_NOTICE));
+
+        $this->assertSame($client, $client->setErrorReportingLevel(E_ALL & ~E_NOTICE));
         $this->assertTrue($client->shouldIgnoreErrorCode(E_NOTICE));
+
+        $this->assertSame($client, $client->setErrorReportingLevel(E_NOTICE));
+        $this->assertFalse($client->shouldIgnoreErrorCode(E_NOTICE));
+
+        $this->assertSame($client, $client->setErrorReportingLevel(0));
+        $this->assertTrue($client->shouldIgnoreErrorCode(E_NOTICE));
+
+        $this->assertSame($client, $client->setErrorReportingLevel(null));
+        $this->assertFalse($client->shouldIgnoreErrorCode(E_NOTICE));
     }
 
     public function testMetaData()

--- a/tests/ErrorTypesTest.php
+++ b/tests/ErrorTypesTest.php
@@ -58,6 +58,18 @@ class ErrorTypesTest extends TestCase
         $this->assertSame($expected, ErrorTypes::getSeverity($code));
     }
 
+    public function testGetAllCodes()
+    {
+        $codes = ErrorTypes::getAllCodes();
+
+        // If we actually got all of the codes, they should combine to equal E_ALL
+        $combined = array_reduce($codes, function ($acc, $code) {
+            return $acc | $code;
+        }, 0);
+
+        $this->assertSame(E_ALL, $combined);
+    }
+
     public function levelsForSeverityProvider()
     {
         return [

--- a/tests/ErrorTypesTest.php
+++ b/tests/ErrorTypesTest.php
@@ -70,6 +70,19 @@ class ErrorTypesTest extends TestCase
         $this->assertSame(E_ALL, $combined);
     }
 
+    /**
+     * @dataProvider codeToStringProvider
+     *
+     * @param int $code
+     * @param string $expected
+     *
+     * @return void
+     */
+    public function testCodeToString($code, $expected)
+    {
+        $this->assertSame($expected, ErrorTypes::codeToString($code));
+    }
+
     public function levelsForSeverityProvider()
     {
         return [
@@ -155,6 +168,28 @@ class ErrorTypesTest extends TestCase
             'E_DEPRECATED' => [E_DEPRECATED, 'info'],
             'E_USER_DEPRECATED' => [E_USER_DEPRECATED, 'info'],
             'invalid code' => ['hello', 'error'],
+        ];
+    }
+
+    public function codeToStringProvider()
+    {
+        return [
+            'E_ERROR' => [E_ERROR, 'E_ERROR'],
+            'E_PARSE' => [E_PARSE, 'E_PARSE'],
+            'E_CORE_ERROR' => [E_CORE_ERROR, 'E_CORE_ERROR'],
+            'E_COMPILE_ERROR' => [E_COMPILE_ERROR, 'E_COMPILE_ERROR'],
+            'E_USER_ERROR' => [E_USER_ERROR, 'E_USER_ERROR'],
+            'E_RECOVERABLE_ERROR' => [E_RECOVERABLE_ERROR, 'E_RECOVERABLE_ERROR'],
+            'E_WARNING' => [E_WARNING, 'E_WARNING'],
+            'E_CORE_WARNING' => [E_CORE_WARNING, 'E_CORE_WARNING'],
+            'E_COMPILE_WARNING' => [E_COMPILE_WARNING, 'E_COMPILE_WARNING'],
+            'E_USER_WARNING' => [E_USER_WARNING, 'E_USER_WARNING'],
+            'E_NOTICE' => [E_NOTICE, 'E_NOTICE'],
+            'E_USER_NOTICE' => [E_USER_NOTICE, 'E_USER_NOTICE'],
+            'E_STRICT' => [E_STRICT, 'E_STRICT'],
+            'E_DEPRECATED' => [E_DEPRECATED, 'E_DEPRECATED'],
+            'E_USER_DEPRECATED' => [E_USER_DEPRECATED, 'E_USER_DEPRECATED'],
+            'invalid code' => ['hello', 'Unknown'],
         ];
     }
 }

--- a/tests/ErrorTypesTest.php
+++ b/tests/ErrorTypesTest.php
@@ -6,28 +6,143 @@ use Bugsnag\ErrorTypes;
 
 class ErrorTypesTest extends TestCase
 {
-    public function testGetLevelsForSeverity()
+    /**
+     * @dataProvider levelsForSeverityProvider
+     *
+     * @param string $severity
+     * @param int $expected
+     *
+     * @return void
+     */
+    public function testGetLevelsForSeverity($severity, $expected)
     {
-        $this->assertSame(4437, ErrorTypes::getLevelsForSeverity('error'));
-        $this->assertSame(674, ErrorTypes::getLevelsForSeverity('warning'));
-        $this->assertSame(27656, ErrorTypes::getLevelsForSeverity('info'));
+        $this->assertSame($expected, ErrorTypes::getLevelsForSeverity($severity));
     }
 
-    public function testIsFatal()
+    /**
+     * @dataProvider isFatalProvider
+     *
+     * @param int $code
+     * @param bool $expected
+     *
+     * @return void
+     */
+    public function testIsFatal($code, $expected)
     {
-        $this->assertFalse(ErrorTypes::isFatal(E_CORE_WARNING));
-        $this->assertTrue(ErrorTypes::isFatal(E_COMPILE_ERROR));
+        $this->assertSame($expected, ErrorTypes::isFatal($code));
     }
 
-    public function testGetName()
+    /**
+     * @dataProvider nameProvider
+     *
+     * @param int $code
+     * @param string $expected
+     *
+     * @return void
+     */
+    public function testGetName($code, $expected)
     {
-        $this->assertSame('PHP Notice', ErrorTypes::getName(E_NOTICE));
-        $this->assertSame('Unknown', ErrorTypes::getName(42));
+        $this->assertSame($expected, ErrorTypes::getName($code));
     }
 
-    public function testGetSeverity()
+    /**
+     * @dataProvider severityProvider
+     *
+     * @param int $code
+     * @param string $expected
+     *
+     * @return void
+     */
+    public function testGetSeverity($code, $expected)
     {
-        $this->assertSame('info', ErrorTypes::getSeverity(E_NOTICE));
-        $this->assertSame('error', ErrorTypes::getSeverity(42));
+        $this->assertSame($expected, ErrorTypes::getSeverity($code));
+    }
+
+    public function levelsForSeverityProvider()
+    {
+        return [
+            'error' => [
+                'error',
+                E_ERROR | E_PARSE | E_CORE_ERROR | E_COMPILE_ERROR | E_USER_ERROR | E_RECOVERABLE_ERROR,
+            ],
+            'warning' => [
+                'warning',
+                E_WARNING | E_CORE_WARNING | E_COMPILE_WARNING | E_USER_WARNING,
+            ],
+            'info' => [
+                'info',
+                E_NOTICE | E_USER_NOTICE | E_STRICT | E_DEPRECATED | E_USER_DEPRECATED,
+            ],
+            'non existent severity' => [
+                'non existent severity',
+                0,
+            ],
+        ];
+    }
+
+    public function isFatalProvider()
+    {
+        return [
+            'E_ERROR' => [E_ERROR, true],
+            'E_PARSE' => [E_PARSE, true],
+            'E_CORE_ERROR' => [E_CORE_ERROR, true],
+            'E_COMPILE_ERROR' => [E_COMPILE_ERROR, true],
+            'E_USER_ERROR' => [E_USER_ERROR, true],
+            'E_RECOVERABLE_ERROR' => [E_RECOVERABLE_ERROR, true],
+            'E_WARNING' => [E_WARNING, false],
+            'E_CORE_WARNING' => [E_CORE_WARNING, false],
+            'E_COMPILE_WARNING' => [E_COMPILE_WARNING, false],
+            'E_USER_WARNING' => [E_USER_WARNING, false],
+            'E_NOTICE' => [E_NOTICE, false],
+            'E_USER_NOTICE' => [E_USER_NOTICE, false],
+            'E_STRICT' => [E_STRICT, false],
+            'E_DEPRECATED' => [E_DEPRECATED, false],
+            'E_USER_DEPRECATED' => [E_USER_DEPRECATED, false],
+            'invalid code' => ['hello', true],
+        ];
+    }
+
+    public function nameProvider()
+    {
+        return [
+            'E_ERROR' => [E_ERROR, 'PHP Fatal Error'],
+            'E_WARNING' => [E_WARNING, 'PHP Warning'],
+            'E_PARSE' => [E_PARSE, 'PHP Parse Error'],
+            'E_NOTICE' => [E_NOTICE, 'PHP Notice'],
+            'E_CORE_ERROR' => [E_CORE_ERROR, 'PHP Core Error'],
+            'E_CORE_WARNING' => [E_CORE_WARNING, 'PHP Core Warning'],
+            'E_COMPILE_ERROR' => [E_COMPILE_ERROR, 'PHP Compile Error'],
+            'E_COMPILE_WARNING' => [E_COMPILE_WARNING, 'PHP Compile Warning'],
+            'E_USER_ERROR' => [E_USER_ERROR, 'User Error'],
+            'E_USER_WARNING' => [E_USER_WARNING, 'User Warning'],
+            'E_USER_NOTICE' => [E_USER_NOTICE, 'User Notice'],
+            'E_STRICT' => [E_STRICT, 'PHP Strict'],
+            'E_RECOVERABLE_ERROR' => [E_RECOVERABLE_ERROR, 'PHP Recoverable Error'],
+            'E_DEPRECATED' => [E_DEPRECATED, 'PHP Deprecated'],
+            'E_USER_DEPRECATED' => [E_USER_DEPRECATED, 'User Deprecated'],
+            'invalid code' => ['hello', 'Unknown'],
+        ];
+    }
+
+    public function severityProvider()
+    {
+        return [
+            'E_ERROR' => [E_ERROR, 'error'],
+            'E_PARSE' => [E_PARSE, 'error'],
+            'E_CORE_ERROR' => [E_CORE_ERROR, 'error'],
+            'E_COMPILE_ERROR' => [E_COMPILE_ERROR, 'error'],
+            'E_USER_ERROR' => [E_USER_ERROR, 'error'],
+            'E_RECOVERABLE_ERROR' => [E_RECOVERABLE_ERROR, 'error'],
+            'E_WARNING' => [E_WARNING, 'warning'],
+            'E_CORE_WARNING' => [E_CORE_WARNING, 'warning'],
+            'E_COMPILE_WARNING' => [E_COMPILE_WARNING, 'warning'],
+            'E_USER_WARNING' => [E_USER_WARNING, 'warning'],
+            'E_NOTICE' => [E_NOTICE, 'info'],
+            'E_USER_NOTICE' => [E_USER_NOTICE, 'info'],
+            'E_STRICT' => [E_STRICT, 'info'],
+            'E_DEPRECATED' => [E_DEPRECATED, 'info'],
+            'E_USER_DEPRECATED' => [E_USER_DEPRECATED, 'info'],
+            'invalid code' => ['hello', 'error'],
+        ];
     }
 }

--- a/tests/HandlerTest.php
+++ b/tests/HandlerTest.php
@@ -121,25 +121,21 @@ class HandlerTest extends TestCase
     public function testErrorReportingSuppressed()
     {
         $this->runErrorHandlerTest(function () {
-            error_reporting(0);
-
             $this->client->setErrorReportingLevel(E_NOTICE);
             $this->client->expects($this->never())->method('notify');
 
             $handler = Handler::register($this->client);
-            $handler->errorHandler(E_NOTICE, 'Something broke', 'somefile.php', 123);
+            @$handler->errorHandler(E_NOTICE, 'Something broke', 'somefile.php', 123);
         });
     }
 
     public function testErrorReportingDefaultSuppressed()
     {
         $this->runErrorHandlerTest(function () {
-            error_reporting(0);
-
             $this->client->expects($this->never())->method('notify');
 
             $handler = Handler::register($this->client);
-            $handler->errorHandler(E_NOTICE, 'Something broke', 'somefile.php', 123);
+            @$handler->errorHandler(E_NOTICE, 'Something broke', 'somefile.php', 123);
         });
     }
 

--- a/tests/phpt/configuration_should_warn_if_error_reporting_level_is_set_incorrectly.phpt
+++ b/tests/phpt/configuration_should_warn_if_error_reporting_level_is_set_incorrectly.phpt
@@ -1,0 +1,45 @@
+--TEST--
+Bugsnag\Configuration should warn if error reporting level is set incorrectly
+--FILE--
+<?php
+// PHPUnit 4 or PHP < 7.1 (or both) fail to write error_log calls to stdout, even
+// with php's 'php://stdout' stream. Forcing error logs to write to /dev/stdout
+// works around this
+ini_set('error_log', '/dev/stdout');
+
+$client = require __DIR__ . '/_prelude.php';
+
+echo "Including values in Bugsnag's errorReportingLevel that are not in error_reporting should log a warning\n";
+error_reporting(E_ALL & ~E_WARNING & ~E_USER_DEPRECATED);
+$client->setErrorReportingLevel(E_ERROR | E_WARNING | E_NOTICE | E_USER_DEPRECATED);
+
+echo "\nSetting Bugsnag's errorReportingLevel to null should be fine\n";
+$client->setErrorReportingLevel(null);
+
+echo "\nSetting Bugsnag's errorReportingLevel to a subset of error_reporting should be fine\n";
+$client->setErrorReportingLevel(E_ERROR);
+
+echo "\nSetting Bugsnag's errorReportingLevel to 0 should be fine\n";
+$client->setErrorReportingLevel(0);
+
+echo "\nSetting Bugsnag's errorReportingLevel to exclusively E_WARNING (which is missing from error_reporting) should log a warning\n";
+$client->setErrorReportingLevel(E_WARNING);
+
+echo "\nSetting both error_reporing and Bugsnag's errorReportingLevel to exclusively E_WARNING should be fine\n";
+error_reporting(E_WARNING);
+$client->setErrorReportingLevel(E_WARNING);
+?>
+--EXPECTF--
+Including values in Bugsnag's errorReportingLevel that are not in error_reporting should log a warning
+[%s] Bugsnag Warning: errorReportingLevel cannot contain values that are not in error_reporting. Any errors of these levels will be ignored: E_WARNING, E_USER_DEPRECATED.
+
+Setting Bugsnag's errorReportingLevel to null should be fine
+
+Setting Bugsnag's errorReportingLevel to a subset of error_reporting should be fine
+
+Setting Bugsnag's errorReportingLevel to 0 should be fine
+
+Setting Bugsnag's errorReportingLevel to exclusively E_WARNING (which is missing from error_reporting) should log a warning
+[%s] Bugsnag Warning: errorReportingLevel cannot contain values that are not in error_reporting. Any errors of these levels will be ignored: E_WARNING.
+
+Setting both error_reporing and Bugsnag's errorReportingLevel to exclusively E_WARNING should be fine

--- a/tests/phpt/handler_should_respect_error_suppression_operator_with_custom_reporting_level.phpt
+++ b/tests/phpt/handler_should_respect_error_suppression_operator_with_custom_reporting_level.phpt
@@ -3,8 +3,9 @@ Bugsnag\Handler should respect the error suppression operator with a custom repo
 --FILE--
 <?php
 $client = require __DIR__ . '/_prelude.php';
+
+error_reporting(E_ALL);
 $client->getConfig()->setErrorReportingLevel(E_ALL & ~E_USER_NOTICE);
-error_reporting(E_ALL & ~E_USER_WARNING);
 
 Bugsnag\Handler::register($client);
 
@@ -14,24 +15,20 @@ trigger_error('abc notice', E_USER_NOTICE);
 echo "Triggering a suppressed user notice that should be ignored by PHP and ignored by Bugsnag\n";
 @trigger_error('xyz notice', E_USER_NOTICE);
 
-echo "Triggering a user warning that should be ignored by PHP and reported by Bugsnag\n";
+echo "Triggering a user warning that should be reported by PHP and reported by Bugsnag\n";
 trigger_error('abc warning', E_USER_WARNING);
 
 echo "Triggering a suppressed user warning that should be ignored by PHP and ignored by Bugsnag\n";
 @trigger_error('xyz warning', E_USER_WARNING);
 ?>
---SKIPIF--
-<?php
-if (PHP_MAJOR_VERSION === 8) {
-    echo 'SKIP — PHP 8 changes the error suppression operator (PLAT-4822)';
-}
-?>
 --EXPECTF--
 Triggering a user notice that should be reported by PHP and ignored by Bugsnag
 
-Notice: abc notice in %s on line 9
+Notice: abc notice in %s on line 10
 Triggering a suppressed user notice that should be ignored by PHP and ignored by Bugsnag
-Triggering a user warning that should be ignored by PHP and reported by Bugsnag
+Triggering a user warning that should be reported by PHP and reported by Bugsnag
+
+Warning: abc warning in %s on line 16
 Triggering a suppressed user warning that should be ignored by PHP and ignored by Bugsnag
 Guzzle request made (1 event)!
 * Method: 'POST'


### PR DESCRIPTION
## Goal

PHP 8 has changed how the `@` operator works:

> The @ operator will no longer silence fatal errors (E_ERROR, E_CORE_ERROR, E_COMPILE_ERROR, E_USER_ERROR, E_RECOVERABLE_ERROR, E_PARSE).
>
> https://github.com/php/php-src/blob/7be61bec8037e601c989e5002198f77bf39e8d59/UPGRADING#L59-L82

Previously, `error_reporting` would return '0' if `@` is used but in PHP 8 it can now return any combination of fatal error types, depending on which were enabled (see https://3v4l.org/Z2lfD)

This means that our current check for the `@` operator will no longer work so we need an alternative in order to fully support PHP 8. This is made more complicated because we have a second, Bugsnag only error level (`errorReportingLevel`), otherwise this would be a simple change

## Design

Quite a few options were explored, but eventually we decided that the best way to solve this is to require that Bugsnag's `errorReportingLevel` is a subset of `error_reporting` — i.e. every error level in `errorReportingLevel` must also be in `error_reporting`

This allows us to check if something has been silenced by checking against `error_reporting` first — if the error code is not in `error_reporting` then it has either been silenced or was never being reported to begin with

If `errorReportingLevel` is not a subset of `error_reporting`, a warning will be logged and all errors of the incorrect level(s) will be ignored

For example, this would be valid usage of `errorReportingLevel` because everything in `errorReportingLevel` is also in `error_reporting`:

```php
error_reporting(E_ALL & ~E_WARNING & ~E_USER_DEPRECATED);
$client->setErrorReportingLevel(E_ALL & ~E_WARNING & ~E_USER_DEPRECATED & ~E_NOTICE & ~E_USER_NOTICE);
```

However, this would be invalid usage of `errorReportingLevel` because `E_WARNING` is not in `error_reporting` but is in `errorReportingLevel`:

```php
error_reporting(E_ALL & ~E_WARNING);
$client->setErrorReportingLevel(E_ALL);
```

As before, setting `errorReportingLevel` to `0` will ignore all errors and setting it to `null` (or not setting it at all) will use `error_reporting` instead

We decided to implement this universally across PHP versions, so that there's not an unexpected change in Bugsnag's behaviour when going from PHP 7 &rarr; 8

## Changeset

- `Configuration::setErrorReportingLevel` now validates the given level is a subset of `error_reporting`
- `Configuration::shouldIgnoreErrorCode` uses a PHP 8 compatible way to check for `@`, enabled by the above change
- Additional helper methods added to `ErrorTypes`
- Set error_reporting to include all error types in PHPUnit config (this previously varied based on PHP/PHPUnit versions)
- Tests for all the above