### PR TITLE
Increase timestamp resolution to include milliseconds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ This release changes how Bugsnag detects the error suppression operator in combi
 
 If you use the `errorReportingLevel` option, you may need to change your Bugsnag or PHP configuration in order to report all expected errors. See [PR #611](https://github.com/bugsnag/bugsnag-php/pull/611) for more details
 
+### Enhancements
+
+* Improve the display of breadrumbs in the Bugsnag app by including milliseconds in timestamps
+  [#612](https://github.com/bugsnag/bugsnag-php/pull/612)
+
 ### Fixes
 
 * Make `Configuration::shouldIgnoreErrorCode` compatible with PHP 8 by requiring the `errorReportingLevel` option to be a subset of `error_reporting`

--- a/src/Breadcrumbs/Breadcrumb.php
+++ b/src/Breadcrumbs/Breadcrumb.php
@@ -2,6 +2,7 @@
 
 namespace Bugsnag\Breadcrumbs;
 
+use Bugsnag\DateTime\Date;
 use InvalidArgumentException;
 
 class Breadcrumb
@@ -129,7 +130,7 @@ class Breadcrumb
             throw new InvalidArgumentException(sprintf('The breadcrumb type must be one of the set of %d standard types.', count($types)));
         }
 
-        $this->timestamp = gmdate('Y-m-d\TH:i:s\Z');
+        $this->timestamp = Date::now();
         $this->name = $name;
         $this->type = $type;
         $this->metaData = $metaData;

--- a/src/DateTime/Clock.php
+++ b/src/DateTime/Clock.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Bugsnag\DateTime;
+
+use DateTimeImmutable;
+
+final class Clock implements ClockInterface
+{
+    /**
+     * @return DateTimeImmutable
+     */
+    public function now()
+    {
+        return new DateTimeImmutable();
+    }
+}

--- a/src/DateTime/ClockInterface.php
+++ b/src/DateTime/ClockInterface.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Bugsnag\DateTime;
+
+use DateTimeImmutable;
+
+interface ClockInterface
+{
+    /**
+     * @return DateTimeImmutable
+     */
+    public function now();
+}

--- a/src/DateTime/Date.php
+++ b/src/DateTime/Date.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Bugsnag\DateTime;
+
+use DateTimeImmutable;
+
+final class Date
+{
+    /**
+     * @return string
+     */
+    public static function now(ClockInterface $clock = null)
+    {
+        if ($clock === null) {
+            $clock = new Clock();
+        }
+
+        $date = $clock->now();
+
+        return self::format($date);
+    }
+
+    /**
+     * @param DateTimeImmutable $date
+     *
+     * @return string
+     */
+    private static function format(DateTimeImmutable $date)
+    {
+        $dateTime = $date->format('Y-m-d\TH:i:s');
+
+        // The milliseconds format character ("v") was introduced in PHP 7.0, so
+        // we need to take microseconds (PHP 5.2+) and convert to milliseconds
+        $microseconds = $date->format('u');
+        $milliseconds = substr($microseconds, 0, 3);
+
+        $offset = $date->format('P');
+
+        return "{$dateTime}.{$milliseconds}{$offset}";
+    }
+}

--- a/src/HttpClient.php
+++ b/src/HttpClient.php
@@ -251,7 +251,7 @@ class HttpClient
     {
         return [
             'Bugsnag-Api-Key' => $this->config->getApiKey(),
-            'Bugsnag-Sent-At' => strftime('%Y-%m-%dT%H:%M:%S'),
+            'Bugsnag-Sent-At' => gmdate('Y-m-d\TH:i:s\Z'),
             'Bugsnag-Payload-Version' => $version,
         ];
     }

--- a/src/HttpClient.php
+++ b/src/HttpClient.php
@@ -2,6 +2,7 @@
 
 namespace Bugsnag;
 
+use Bugsnag\DateTime\Date;
 use Exception;
 use GuzzleHttp\ClientInterface;
 use RuntimeException;
@@ -251,7 +252,7 @@ class HttpClient
     {
         return [
             'Bugsnag-Api-Key' => $this->config->getApiKey(),
-            'Bugsnag-Sent-At' => gmdate('Y-m-d\TH:i:s\Z'),
+            'Bugsnag-Sent-At' => Date::now(),
             'Bugsnag-Payload-Version' => $version,
         ];
     }

--- a/src/Report.php
+++ b/src/Report.php
@@ -3,6 +3,7 @@
 namespace Bugsnag;
 
 use Bugsnag\Breadcrumbs\Breadcrumb;
+use Bugsnag\DateTime\Date;
 use Exception;
 use InvalidArgumentException;
 use Throwable;
@@ -204,7 +205,7 @@ class Report
     protected function __construct(Configuration $config)
     {
         $this->config = $config;
-        $this->time = gmdate('Y-m-d\TH:i:s\Z');
+        $this->time = Date::now();
     }
 
     /**

--- a/tests/Assert.php
+++ b/tests/Assert.php
@@ -2,6 +2,7 @@
 
 namespace Bugsnag\Tests;
 
+use DateTimeImmutable;
 use InvalidArgumentException;
 use PHPUnit\Framework\Assert as PhpUnitAssert;
 
@@ -71,5 +72,22 @@ final class Assert
         }
 
         $typeToAssertion[$type]($value);
+    }
+
+    /**
+     * @param string $format
+     * @param string $dateString
+     *
+     * @return void
+     */
+    public static function matchesDateFormat($format, $dateString)
+    {
+        $date = new DateTimeImmutable($dateString);
+
+        PhpUnitAssert::assertSame(
+            $dateString,
+            $date->format($format),
+            "Date '{$dateString}' did not match format '{$format}'"
+        );
     }
 }

--- a/tests/Assert.php
+++ b/tests/Assert.php
@@ -90,4 +90,30 @@ final class Assert
             "Date '{$dateString}' did not match format '{$format}'"
         );
     }
+
+    /**
+     * @param string $date
+     *
+     * @return void
+     */
+    public static function matchesBugsnagDateFormat($date)
+    {
+        // The millisecond format specifier ("v") was added in PHP 7.0
+        if (PHP_MAJOR_VERSION >= 7) {
+            Assert::matchesDateFormat('Y-m-d\TH:i:s.vP', $date);
+
+            return;
+        }
+
+        $regex = '/^(\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2})\.\d{3}([+-]\d{2}:\d{2})$/';
+
+        Assert::matchesRegularExpression($regex, $date);
+
+        preg_match($regex, $date, $matches);
+
+        $dateTime = $matches[1];
+        $offset = $matches[2];
+
+        Assert::matchesDateFormat('Y-m-d\TH:i:sP', $dateTime.$offset);
+    }
 }

--- a/tests/Breadcrumbs/BreadcrumbTest.php
+++ b/tests/Breadcrumbs/BreadcrumbTest.php
@@ -66,7 +66,7 @@ class BreadcrumbTest extends TestCase
 
         Assert::isType('array', $breadcrumb->toArray());
         $this->assertCount(3, $breadcrumb->toArray());
-        Assert::isType('string', $breadcrumb->toArray()['timestamp']);
+        Assert::matchesDateFormat('Y-m-d\TH:i:s\Z', $breadcrumb->toArray()['timestamp']);
         $this->assertSame('Foo', $breadcrumb->toArray()['name']);
         $this->assertSame('request', $breadcrumb->toArray()['type']);
     }

--- a/tests/Breadcrumbs/BreadcrumbTest.php
+++ b/tests/Breadcrumbs/BreadcrumbTest.php
@@ -66,7 +66,7 @@ class BreadcrumbTest extends TestCase
 
         Assert::isType('array', $breadcrumb->toArray());
         $this->assertCount(3, $breadcrumb->toArray());
-        Assert::matchesDateFormat('Y-m-d\TH:i:s\Z', $breadcrumb->toArray()['timestamp']);
+        Assert::matchesBugsnagDateFormat($breadcrumb->toArray()['timestamp']);
         $this->assertSame('Foo', $breadcrumb->toArray()['name']);
         $this->assertSame('request', $breadcrumb->toArray()['type']);
     }

--- a/tests/DateTime/ClockTest.php
+++ b/tests/DateTime/ClockTest.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace Bugsnag\Tests\DateTime;
+
+use Bugsnag\DateTime\Clock;
+use Bugsnag\DateTime\ClockInterface;
+use Bugsnag\Tests\TestCase;
+use DateTimeImmutable;
+
+class ClockTest extends TestCase
+{
+    public function testItImplementsClockInterface()
+    {
+        $clock = new Clock();
+
+        $this->assertInstanceOf(ClockInterface::class, $clock);
+    }
+
+    public function testItReturnsADateTimeImmutable()
+    {
+        $clock = new Clock();
+
+        $this->assertInstanceOf(DateTimeImmutable::class, $clock->now());
+    }
+
+    public function testItReturnsTheCurrentDateTime()
+    {
+        // We need to sleep between creating date objects, otherwise we hit
+        // issues due to $now possibly being equal to $before
+
+        // Sleeping for 5ms is enough on PHP 7.1+
+        $timeToSleep = 5000;
+
+        // Before PHP 7.1, microseconds were not included when constructing date
+        // objects, so we need to sleep for an entire second
+        if (version_compare(PHP_VERSION, '7.1.0', '<')) {
+            $timeToSleep = 1000 * 1000;
+        }
+
+        $clock = new Clock();
+
+        $before = new DateTimeImmutable();
+
+        usleep($timeToSleep);
+
+        $now = $clock->now();
+
+        usleep($timeToSleep);
+
+        $after = new DateTimeImmutable();
+
+        $this->assertGreaterThan($before, $now);
+        $this->assertLessThan($after, $now);
+    }
+}

--- a/tests/DateTime/DateTest.php
+++ b/tests/DateTime/DateTest.php
@@ -3,6 +3,7 @@
 namespace Bugsnag\Tests\DateTime;
 
 use Bugsnag\DateTime\Date;
+use Bugsnag\Tests\Assert;
 use Bugsnag\Tests\Fakes\FakeClock;
 use Bugsnag\Tests\TestCase;
 use DateTimeImmutable;
@@ -24,7 +25,10 @@ class DateTest extends TestCase
         $date = new DateTimeImmutable($dateString, new DateTimeZone($offset));
         $clock = new FakeClock($date);
 
-        $this->assertSame($expected, Date::now($clock));
+        $actual = Date::now($clock);
+
+        $this->assertSame($expected, $actual);
+        Assert::matchesBugsnagDateFormat($actual);
     }
 
     public function testItReturnsTheCurrentDateTimeWithARealClock()

--- a/tests/DateTime/DateTest.php
+++ b/tests/DateTime/DateTest.php
@@ -1,0 +1,68 @@
+<?php
+
+namespace Bugsnag\Tests\DateTime;
+
+use Bugsnag\DateTime\Date;
+use Bugsnag\Tests\Fakes\FakeClock;
+use Bugsnag\Tests\TestCase;
+use DateTimeImmutable;
+use DateTimeZone;
+
+class DateTest extends TestCase
+{
+    /**
+     * @dataProvider dateProvider
+     *
+     * @param string $dateString
+     * @param string $offset
+     * @param string $expected
+     *
+     * @return void
+     */
+    public function testItFormatsTheDateCorrectly($dateString, $offset, $expected)
+    {
+        $date = new DateTimeImmutable($dateString, new DateTimeZone($offset));
+        $clock = new FakeClock($date);
+
+        $this->assertSame($expected, Date::now($clock));
+    }
+
+    public function testItReturnsTheCurrentDateTimeWithARealClock()
+    {
+        // We need to sleep between creating date objects, otherwise we hit
+        // issues due to $now possibly being equal to $before
+
+        // Sleeping for 5ms is enough on PHP 7.1+
+        $timeToSleep = 5000;
+
+        // Before PHP 7.1, microseconds were not included when constructing date
+        // objects, so we need to sleep for an entire second
+        if (version_compare(PHP_VERSION, '7.1.0', '<')) {
+            $timeToSleep = 1000 * 1000;
+        }
+
+        $before = new DateTimeImmutable();
+
+        usleep($timeToSleep);
+
+        $now = new DateTimeImmutable(Date::now());
+
+        usleep($timeToSleep);
+
+        $after = new DateTimeImmutable();
+
+        $this->assertGreaterThan($before, $now);
+        $this->assertLessThan($after, $now);
+    }
+
+    public function dateProvider()
+    {
+        return [
+            ['2020-01-02 03:04:05.678912', '+0000', '2020-01-02T03:04:05.678+00:00'],
+            ['2020-01-02 03:04:05.678912', '+1000', '2020-01-02T03:04:05.678+10:00'],
+            ['2020-01-02 03:04:05.678912', '+1234', '2020-01-02T03:04:05.678+12:34'],
+            ['2020-01-02 03:04:05.678912', '-1234', '2020-01-02T03:04:05.678-12:34'],
+            ['1900-12-31 19:00:12.311900', '+1900', '1900-12-31T19:00:12.311+19:00'],
+        ];
+    }
+}

--- a/tests/Fakes/FakeClock.php
+++ b/tests/Fakes/FakeClock.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Bugsnag\Tests\Fakes;
+
+use Bugsnag\DateTime\ClockInterface;
+use DateTimeImmutable;
+
+final class FakeClock implements ClockInterface
+{
+    private $date;
+
+    public function __construct(DateTimeImmutable $date)
+    {
+        $this->date = $date;
+    }
+
+    public function now()
+    {
+        return $this->date;
+    }
+}

--- a/tests/HttpClientTest.php
+++ b/tests/HttpClientTest.php
@@ -69,7 +69,7 @@ class HttpClientTest extends TestCase
             $headers = $options['headers'];
 
             $this->assertSame('6015a72ff14038114c3d12623dfb018f', $headers['Bugsnag-Api-Key']);
-            Assert::matchesDateFormat('Y-m-d\TH:i:s\Z', $headers['Bugsnag-Sent-At']);
+            Assert::matchesBugsnagDateFormat($headers['Bugsnag-Sent-At']);
             $this->assertSame('4.0', $headers['Bugsnag-Payload-Version']);
 
             return true;
@@ -98,7 +98,7 @@ class HttpClientTest extends TestCase
             $headers = $options['headers'];
 
             $this->assertSame('6015a72ff14038114c3d12623dfb018f', $headers['Bugsnag-Api-Key']);
-            Assert::matchesDateFormat('Y-m-d\TH:i:s\Z', $headers['Bugsnag-Sent-At']);
+            Assert::matchesBugsnagDateFormat($headers['Bugsnag-Sent-At']);
             $this->assertSame('4.0', $headers['Bugsnag-Payload-Version']);
 
             return true;
@@ -128,7 +128,7 @@ class HttpClientTest extends TestCase
             $headers = $options['headers'];
 
             $this->assertSame('6015a72ff14038114c3d12623dfb018f', $headers['Bugsnag-Api-Key']);
-            Assert::matchesDateFormat('Y-m-d\TH:i:s\Z', $headers['Bugsnag-Sent-At']);
+            Assert::matchesBugsnagDateFormat($headers['Bugsnag-Sent-At']);
             $this->assertSame('4.0', $headers['Bugsnag-Payload-Version']);
 
             return true;
@@ -173,7 +173,7 @@ class HttpClientTest extends TestCase
 
             $headers = $options['headers'];
             $this->assertSame('6015a72ff14038114c3d12623dfb018f', $headers['Bugsnag-Api-Key']);
-            Assert::matchesDateFormat('Y-m-d\TH:i:s\Z', $headers['Bugsnag-Sent-At']);
+            Assert::matchesBugsnagDateFormat($headers['Bugsnag-Sent-At']);
             $this->assertSame('4.0', $headers['Bugsnag-Payload-Version']);
 
             return true;

--- a/tests/HttpClientTest.php
+++ b/tests/HttpClientTest.php
@@ -69,7 +69,7 @@ class HttpClientTest extends TestCase
             $headers = $options['headers'];
 
             $this->assertSame('6015a72ff14038114c3d12623dfb018f', $headers['Bugsnag-Api-Key']);
-            $this->assertArrayHasKey('Bugsnag-Sent-At', $headers);
+            Assert::matchesDateFormat('Y-m-d\TH:i:s', $headers['Bugsnag-Sent-At']);
             $this->assertSame('4.0', $headers['Bugsnag-Payload-Version']);
 
             return true;
@@ -98,7 +98,7 @@ class HttpClientTest extends TestCase
             $headers = $options['headers'];
 
             $this->assertSame('6015a72ff14038114c3d12623dfb018f', $headers['Bugsnag-Api-Key']);
-            $this->assertArrayHasKey('Bugsnag-Sent-At', $headers);
+            Assert::matchesDateFormat('Y-m-d\TH:i:s', $headers['Bugsnag-Sent-At']);
             $this->assertSame('4.0', $headers['Bugsnag-Payload-Version']);
 
             return true;
@@ -128,7 +128,7 @@ class HttpClientTest extends TestCase
             $headers = $options['headers'];
 
             $this->assertSame('6015a72ff14038114c3d12623dfb018f', $headers['Bugsnag-Api-Key']);
-            $this->assertArrayHasKey('Bugsnag-Sent-At', $headers);
+            Assert::matchesDateFormat('Y-m-d\TH:i:s', $headers['Bugsnag-Sent-At']);
             $this->assertSame('4.0', $headers['Bugsnag-Payload-Version']);
 
             return true;
@@ -173,7 +173,7 @@ class HttpClientTest extends TestCase
 
             $headers = $options['headers'];
             $this->assertSame('6015a72ff14038114c3d12623dfb018f', $headers['Bugsnag-Api-Key']);
-            $this->assertArrayHasKey('Bugsnag-Sent-At', $headers);
+            Assert::matchesDateFormat('Y-m-d\TH:i:s', $headers['Bugsnag-Sent-At']);
             $this->assertSame('4.0', $headers['Bugsnag-Payload-Version']);
 
             return true;

--- a/tests/HttpClientTest.php
+++ b/tests/HttpClientTest.php
@@ -69,7 +69,7 @@ class HttpClientTest extends TestCase
             $headers = $options['headers'];
 
             $this->assertSame('6015a72ff14038114c3d12623dfb018f', $headers['Bugsnag-Api-Key']);
-            Assert::matchesDateFormat('Y-m-d\TH:i:s', $headers['Bugsnag-Sent-At']);
+            Assert::matchesDateFormat('Y-m-d\TH:i:s\Z', $headers['Bugsnag-Sent-At']);
             $this->assertSame('4.0', $headers['Bugsnag-Payload-Version']);
 
             return true;
@@ -98,7 +98,7 @@ class HttpClientTest extends TestCase
             $headers = $options['headers'];
 
             $this->assertSame('6015a72ff14038114c3d12623dfb018f', $headers['Bugsnag-Api-Key']);
-            Assert::matchesDateFormat('Y-m-d\TH:i:s', $headers['Bugsnag-Sent-At']);
+            Assert::matchesDateFormat('Y-m-d\TH:i:s\Z', $headers['Bugsnag-Sent-At']);
             $this->assertSame('4.0', $headers['Bugsnag-Payload-Version']);
 
             return true;
@@ -128,7 +128,7 @@ class HttpClientTest extends TestCase
             $headers = $options['headers'];
 
             $this->assertSame('6015a72ff14038114c3d12623dfb018f', $headers['Bugsnag-Api-Key']);
-            Assert::matchesDateFormat('Y-m-d\TH:i:s', $headers['Bugsnag-Sent-At']);
+            Assert::matchesDateFormat('Y-m-d\TH:i:s\Z', $headers['Bugsnag-Sent-At']);
             $this->assertSame('4.0', $headers['Bugsnag-Payload-Version']);
 
             return true;
@@ -173,7 +173,7 @@ class HttpClientTest extends TestCase
 
             $headers = $options['headers'];
             $this->assertSame('6015a72ff14038114c3d12623dfb018f', $headers['Bugsnag-Api-Key']);
-            Assert::matchesDateFormat('Y-m-d\TH:i:s', $headers['Bugsnag-Sent-At']);
+            Assert::matchesDateFormat('Y-m-d\TH:i:s\Z', $headers['Bugsnag-Sent-At']);
             $this->assertSame('4.0', $headers['Bugsnag-Payload-Version']);
 
             return true;

--- a/tests/ReportTest.php
+++ b/tests/ReportTest.php
@@ -37,7 +37,7 @@ class ReportTest extends TestCase
         $data = $this->report->toArray();
 
         $this->assertCount(3, $data['device']);
-        Assert::isType('string', $data['device']['time']);
+        Assert::matchesDateFormat('Y-m-d\TH:i:s\Z', $data['device']['time']);
         $this->assertSame(php_uname('n'), $data['device']['hostname']);
         $this->assertSame(phpversion(), $data['device']['runtimeVersions']['php']);
     }

--- a/tests/ReportTest.php
+++ b/tests/ReportTest.php
@@ -37,7 +37,7 @@ class ReportTest extends TestCase
         $data = $this->report->toArray();
 
         $this->assertCount(3, $data['device']);
-        Assert::matchesDateFormat('Y-m-d\TH:i:s\Z', $data['device']['time']);
+        Assert::matchesBugsnagDateFormat($data['device']['time']);
         $this->assertSame(php_uname('n'), $data['device']['hostname']);
         $this->assertSame(phpversion(), $data['device']['runtimeVersions']['php']);
     }


### PR DESCRIPTION
## Goal

In order for the Bugsnag app to report breadcrumb times more accurately, we need to send timestamps with milliseconds. Other timestamps have also been updated for consistency, but shouldn't have any impact. The session tracker has not been updated as it intentionally rounds to the minute

This includes some "fun" workarounds in order to support PHP 5 as the millisecond format character (`v`) was introduced in 7.0. The final format we want has a constant which was also introduced in PHP 7.0 (`RFC3339_EXTENDED`), however I've implemented PHP 5 compatible formatting on every version, to avoid the possibility of bugs related to using PHP 5/7/8

## Testing

Unit tests now check the date format in places that have changed. I've manually tested that the breadcrumb timestamps appear correctly to the millisecond