### PR TITLE
Release v3.24.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,17 @@
 Changelog
 =========
 
+## TBD
+
+This release changes how Bugsnag detects the error suppression operator in combination with the `errorReportingLevel` configuration option, for PHP 8 compatibility. Bugsnag's `errorReportingLevel` must now be a subset of `error_reporting` — i.e. every error level in `errorReportingLevel` must also be in `error_reporting`
+
+If you use the `errorReportingLevel` option, you may need to change your Bugsnag or PHP configuration in order to report all expected errors. See [PR #611](https://github.com/bugsnag/bugsnag-php/pull/611) for more details
+
+### Fixes
+
+* Make `Configuration::shouldIgnoreErrorCode` compatible with PHP 8 by requiring the `errorReportingLevel` option to be a subset of `error_reporting`
+  [#611](https://github.com/bugsnag/bugsnag-php/pull/611)
+
 ## 3.23.1 (2020-10-19)
 
 This release fixes several issues with Bugsnag's error handlers that caused it to affect the behaviour of shutdown functions ([#475](https://github.com/bugsnag/bugsnag-php/issues/475)) and CLI script exit codes ([#523](https://github.com/bugsnag/bugsnag-php/issues/523)). This does not apply if you are using the Laravel or Symfony integrations, as they use separate methods of error handling.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ This release changes how Bugsnag detects the error suppression operator in combi
 
 If you use the `errorReportingLevel` option, you may need to change your Bugsnag or PHP configuration in order to report all expected errors. See [PR #611](https://github.com/bugsnag/bugsnag-php/pull/611) for more details
 
+### Enhancements
+
+* Improve the display of breadrumbs in the Bugsnag app by including milliseconds in timestamps
+  [#612](https://github.com/bugsnag/bugsnag-php/pull/612)
+
 ### Fixes
 
 * Make `Configuration::shouldIgnoreErrorCode` compatible with PHP 8 by requiring the `errorReportingLevel` option to be a subset of `error_reporting`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 Changelog
 =========
 
-## TBD
+## 3.24.0 (2020-10-27)
 
 This release changes how Bugsnag detects the error suppression operator in combination with the `errorReportingLevel` configuration option, for PHP 8 compatibility. Bugsnag's `errorReportingLevel` must now be a subset of `error_reporting` — i.e. every error level in `errorReportingLevel` must also be in `error_reporting`
 

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -29,4 +29,9 @@
             <directory suffix=".phpt">./tests/phpt</directory>
         </testsuite>
     </testsuites>
+
+    <php>
+        <!-- Use a very big number as we can't use the 'E_ALL' constant here -->
+        <ini name="error_reporting" value="2147483647" />
+    </php>
 </phpunit>

--- a/src/Breadcrumbs/Breadcrumb.php
+++ b/src/Breadcrumbs/Breadcrumb.php
@@ -2,6 +2,7 @@
 
 namespace Bugsnag\Breadcrumbs;
 
+use Bugsnag\DateTime\Date;
 use InvalidArgumentException;
 
 class Breadcrumb
@@ -129,7 +130,7 @@ class Breadcrumb
             throw new InvalidArgumentException(sprintf('The breadcrumb type must be one of the set of %d standard types.', count($types)));
         }
 
-        $this->timestamp = gmdate('Y-m-d\TH:i:s\Z');
+        $this->timestamp = Date::now();
         $this->name = $name;
         $this->type = $type;
         $this->metaData = $metaData;

--- a/src/Configuration.php
+++ b/src/Configuration.php
@@ -82,7 +82,7 @@ class Configuration
      */
     protected $notifier = [
         'name' => 'Bugsnag PHP (Official)',
-        'version' => '3.23.1',
+        'version' => '3.24.0',
         'url' => 'https://bugsnag.com',
     ];
 

--- a/src/Configuration.php
+++ b/src/Configuration.php
@@ -569,9 +569,66 @@ class Configuration
      */
     public function setErrorReportingLevel($errorReportingLevel)
     {
+        if (!$this->isSubsetOfErrorReporting($errorReportingLevel)) {
+            $missingLevels = implode(', ', $this->getMissingErrorLevelNames($errorReportingLevel));
+            $message =
+                'Bugsnag Warning: errorReportingLevel cannot contain values that are not in error_reporting. '.
+                "Any errors of these levels will be ignored: {$missingLevels}.";
+
+            error_log($message);
+        }
+
         $this->errorReportingLevel = $errorReportingLevel;
 
         return $this;
+    }
+
+    /**
+     * Check if the given error reporting level is a subset of error_reporting.
+     *
+     * For example, if $level contains E_WARNING then error_reporting must too.
+     *
+     * @param int|null $level
+     *
+     * @return bool
+     */
+    private function isSubsetOfErrorReporting($level)
+    {
+        if (!is_int($level)) {
+            return true;
+        }
+
+        $errorReporting = error_reporting();
+
+        // If all of the bits in $level are also in $errorReporting, ORing them
+        // together will result in the same value as $errorReporting because
+        // there are no new bits to add
+        return ($errorReporting | $level) === $errorReporting;
+    }
+
+    /**
+     * Get a list of error level names that are in $level but not error_reporting.
+     *
+     * For example, if error_reporting is E_NOTICE and $level is E_ERROR then
+     * this will return ['E_ERROR']
+     *
+     * @param int $level
+     *
+     * @return string[]
+     */
+    private function getMissingErrorLevelNames($level)
+    {
+        $missingLevels = [];
+        $errorReporting = error_reporting();
+
+        foreach (ErrorTypes::getAllCodes() as $code) {
+            // $code is "missing" if it's in $level but not in $errorReporting
+            if (($code & $level) && !($code & $errorReporting)) {
+                $missingLevels[] = ErrorTypes::codeToString($code);
+            }
+        }
+
+        return $missingLevels;
     }
 
     /**
@@ -583,19 +640,19 @@ class Configuration
      */
     public function shouldIgnoreErrorCode($code)
     {
-        $defaultReportingLevel = error_reporting();
-
-        if ($defaultReportingLevel === 0) {
-            // The error has been suppressed using the error control operator ('@')
-            // Ignore the error in all cases.
+        // If the code is not in error_reporting then it is either totally
+        // disabled or is being suppressed with '@'
+        if (!(error_reporting() & $code)) {
             return true;
         }
 
+        // Filter the error code further against our error reporting level, which
+        // can be lower than error_reporting
         if (isset($this->errorReportingLevel)) {
             return !($this->errorReportingLevel & $code);
         }
 
-        return !($defaultReportingLevel & $code);
+        return false;
     }
 
     /**

--- a/src/DateTime/Clock.php
+++ b/src/DateTime/Clock.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Bugsnag\DateTime;
+
+use DateTimeImmutable;
+
+final class Clock implements ClockInterface
+{
+    /**
+     * @return DateTimeImmutable
+     */
+    public function now()
+    {
+        return new DateTimeImmutable();
+    }
+}

--- a/src/DateTime/ClockInterface.php
+++ b/src/DateTime/ClockInterface.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Bugsnag\DateTime;
+
+use DateTimeImmutable;
+
+interface ClockInterface
+{
+    /**
+     * @return DateTimeImmutable
+     */
+    public function now();
+}

--- a/src/DateTime/Date.php
+++ b/src/DateTime/Date.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Bugsnag\DateTime;
+
+use DateTimeImmutable;
+
+final class Date
+{
+    /**
+     * @return string
+     */
+    public static function now(ClockInterface $clock = null)
+    {
+        if ($clock === null) {
+            $clock = new Clock();
+        }
+
+        $date = $clock->now();
+
+        return self::format($date);
+    }
+
+    /**
+     * @param DateTimeImmutable $date
+     *
+     * @return string
+     */
+    private static function format(DateTimeImmutable $date)
+    {
+        $dateTime = $date->format('Y-m-d\TH:i:s');
+
+        // The milliseconds format character ("v") was introduced in PHP 7.0, so
+        // we need to take microseconds (PHP 5.2+) and convert to milliseconds
+        $microseconds = $date->format('u');
+        $milliseconds = substr($microseconds, 0, 3);
+
+        $offset = $date->format('P');
+
+        return "{$dateTime}.{$milliseconds}{$offset}";
+    }
+}

--- a/src/ErrorTypes.php
+++ b/src/ErrorTypes.php
@@ -149,4 +149,76 @@ class ErrorTypes
 
         return $levels;
     }
+
+    /**
+     * Get a list of all PHP error codes.
+     *
+     * @return int[]
+     */
+    public static function getAllCodes()
+    {
+        return array_keys(self::$ERROR_TYPES);
+    }
+
+    /**
+     * Convert the given error code to a string representation.
+     *
+     * For example, E_ERROR => 'E_ERROR'.
+     *
+     * @param int $code
+     *
+     * @return string
+     */
+    public static function codeToString($code)
+    {
+        switch ($code) {
+            case E_ERROR:
+                return 'E_ERROR';
+
+            case E_WARNING:
+                return 'E_WARNING';
+
+            case E_PARSE:
+                return 'E_PARSE';
+
+            case E_NOTICE:
+                return 'E_NOTICE';
+
+            case E_CORE_ERROR:
+                return 'E_CORE_ERROR';
+
+            case E_CORE_WARNING:
+                return 'E_CORE_WARNING';
+
+            case E_COMPILE_ERROR:
+                return 'E_COMPILE_ERROR';
+
+            case E_COMPILE_WARNING:
+                return 'E_COMPILE_WARNING';
+
+            case E_USER_ERROR:
+                return 'E_USER_ERROR';
+
+            case E_USER_WARNING:
+                return 'E_USER_WARNING';
+
+            case E_USER_NOTICE:
+                return 'E_USER_NOTICE';
+
+            case E_STRICT:
+                return 'E_STRICT';
+
+            case E_RECOVERABLE_ERROR:
+                return 'E_RECOVERABLE_ERROR';
+
+            case E_DEPRECATED:
+                return 'E_DEPRECATED';
+
+            case E_USER_DEPRECATED:
+                return 'E_USER_DEPRECATED';
+
+            default:
+                return 'Unknown';
+        }
+    }
 }

--- a/src/HttpClient.php
+++ b/src/HttpClient.php
@@ -2,6 +2,7 @@
 
 namespace Bugsnag;
 
+use Bugsnag\DateTime\Date;
 use Exception;
 use GuzzleHttp\ClientInterface;
 use RuntimeException;
@@ -251,7 +252,7 @@ class HttpClient
     {
         return [
             'Bugsnag-Api-Key' => $this->config->getApiKey(),
-            'Bugsnag-Sent-At' => strftime('%Y-%m-%dT%H:%M:%S'),
+            'Bugsnag-Sent-At' => Date::now(),
             'Bugsnag-Payload-Version' => $version,
         ];
     }

--- a/src/Report.php
+++ b/src/Report.php
@@ -3,6 +3,7 @@
 namespace Bugsnag;
 
 use Bugsnag\Breadcrumbs\Breadcrumb;
+use Bugsnag\DateTime\Date;
 use Exception;
 use InvalidArgumentException;
 use Throwable;
@@ -204,7 +205,7 @@ class Report
     protected function __construct(Configuration $config)
     {
         $this->config = $config;
-        $this->time = gmdate('Y-m-d\TH:i:s\Z');
+        $this->time = Date::now();
     }
 
     /**

--- a/tests/Assert.php
+++ b/tests/Assert.php
@@ -2,6 +2,7 @@
 
 namespace Bugsnag\Tests;
 
+use DateTimeImmutable;
 use InvalidArgumentException;
 use PHPUnit\Framework\Assert as PhpUnitAssert;
 
@@ -71,5 +72,48 @@ final class Assert
         }
 
         $typeToAssertion[$type]($value);
+    }
+
+    /**
+     * @param string $format
+     * @param string $dateString
+     *
+     * @return void
+     */
+    public static function matchesDateFormat($format, $dateString)
+    {
+        $date = new DateTimeImmutable($dateString);
+
+        PhpUnitAssert::assertSame(
+            $dateString,
+            $date->format($format),
+            "Date '{$dateString}' did not match format '{$format}'"
+        );
+    }
+
+    /**
+     * @param string $date
+     *
+     * @return void
+     */
+    public static function matchesBugsnagDateFormat($date)
+    {
+        // The millisecond format specifier ("v") was added in PHP 7.0
+        if (PHP_MAJOR_VERSION >= 7) {
+            Assert::matchesDateFormat('Y-m-d\TH:i:s.vP', $date);
+
+            return;
+        }
+
+        $regex = '/^(\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2})\.\d{3}([+-]\d{2}:\d{2})$/';
+
+        Assert::matchesRegularExpression($regex, $date);
+
+        preg_match($regex, $date, $matches);
+
+        $dateTime = $matches[1];
+        $offset = $matches[2];
+
+        Assert::matchesDateFormat('Y-m-d\TH:i:sP', $dateTime.$offset);
     }
 }

--- a/tests/Breadcrumbs/BreadcrumbTest.php
+++ b/tests/Breadcrumbs/BreadcrumbTest.php
@@ -66,7 +66,7 @@ class BreadcrumbTest extends TestCase
 
         Assert::isType('array', $breadcrumb->toArray());
         $this->assertCount(3, $breadcrumb->toArray());
-        Assert::isType('string', $breadcrumb->toArray()['timestamp']);
+        Assert::matchesBugsnagDateFormat($breadcrumb->toArray()['timestamp']);
         $this->assertSame('Foo', $breadcrumb->toArray()['name']);
         $this->assertSame('request', $breadcrumb->toArray()['type']);
     }

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -1036,10 +1036,21 @@ class ClientTest extends TestCase
     public function testErrorReportingLevel()
     {
         $client = Client::make('foo');
+
         $this->assertSame($client, $client->setErrorReportingLevel(E_ALL));
         $this->assertFalse($client->shouldIgnoreErrorCode(E_NOTICE));
-        $this->assertSame($client, $client->setErrorReportingLevel(E_ALL && ~E_NOTICE));
+
+        $this->assertSame($client, $client->setErrorReportingLevel(E_ALL & ~E_NOTICE));
         $this->assertTrue($client->shouldIgnoreErrorCode(E_NOTICE));
+
+        $this->assertSame($client, $client->setErrorReportingLevel(E_NOTICE));
+        $this->assertFalse($client->shouldIgnoreErrorCode(E_NOTICE));
+
+        $this->assertSame($client, $client->setErrorReportingLevel(0));
+        $this->assertTrue($client->shouldIgnoreErrorCode(E_NOTICE));
+
+        $this->assertSame($client, $client->setErrorReportingLevel(null));
+        $this->assertFalse($client->shouldIgnoreErrorCode(E_NOTICE));
     }
 
     public function testMetaData()

--- a/tests/DateTime/ClockTest.php
+++ b/tests/DateTime/ClockTest.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace Bugsnag\Tests\DateTime;
+
+use Bugsnag\DateTime\Clock;
+use Bugsnag\DateTime\ClockInterface;
+use Bugsnag\Tests\TestCase;
+use DateTimeImmutable;
+
+class ClockTest extends TestCase
+{
+    public function testItImplementsClockInterface()
+    {
+        $clock = new Clock();
+
+        $this->assertInstanceOf(ClockInterface::class, $clock);
+    }
+
+    public function testItReturnsADateTimeImmutable()
+    {
+        $clock = new Clock();
+
+        $this->assertInstanceOf(DateTimeImmutable::class, $clock->now());
+    }
+
+    public function testItReturnsTheCurrentDateTime()
+    {
+        // We need to sleep between creating date objects, otherwise we hit
+        // issues due to $now possibly being equal to $before
+
+        // Sleeping for 5ms is enough on PHP 7.1+
+        $timeToSleep = 5000;
+
+        // Before PHP 7.1, microseconds were not included when constructing date
+        // objects, so we need to sleep for an entire second
+        if (version_compare(PHP_VERSION, '7.1.0', '<')) {
+            $timeToSleep = 1000 * 1000;
+        }
+
+        $clock = new Clock();
+
+        $before = new DateTimeImmutable();
+
+        usleep($timeToSleep);
+
+        $now = $clock->now();
+
+        usleep($timeToSleep);
+
+        $after = new DateTimeImmutable();
+
+        $this->assertGreaterThan($before, $now);
+        $this->assertLessThan($after, $now);
+    }
+}

--- a/tests/DateTime/DateTest.php
+++ b/tests/DateTime/DateTest.php
@@ -1,0 +1,72 @@
+<?php
+
+namespace Bugsnag\Tests\DateTime;
+
+use Bugsnag\DateTime\Date;
+use Bugsnag\Tests\Assert;
+use Bugsnag\Tests\Fakes\FakeClock;
+use Bugsnag\Tests\TestCase;
+use DateTimeImmutable;
+use DateTimeZone;
+
+class DateTest extends TestCase
+{
+    /**
+     * @dataProvider dateProvider
+     *
+     * @param string $dateString
+     * @param string $offset
+     * @param string $expected
+     *
+     * @return void
+     */
+    public function testItFormatsTheDateCorrectly($dateString, $offset, $expected)
+    {
+        $date = new DateTimeImmutable($dateString, new DateTimeZone($offset));
+        $clock = new FakeClock($date);
+
+        $actual = Date::now($clock);
+
+        $this->assertSame($expected, $actual);
+        Assert::matchesBugsnagDateFormat($actual);
+    }
+
+    public function testItReturnsTheCurrentDateTimeWithARealClock()
+    {
+        // We need to sleep between creating date objects, otherwise we hit
+        // issues due to $now possibly being equal to $before
+
+        // Sleeping for 5ms is enough on PHP 7.1+
+        $timeToSleep = 5000;
+
+        // Before PHP 7.1, microseconds were not included when constructing date
+        // objects, so we need to sleep for an entire second
+        if (version_compare(PHP_VERSION, '7.1.0', '<')) {
+            $timeToSleep = 1000 * 1000;
+        }
+
+        $before = new DateTimeImmutable();
+
+        usleep($timeToSleep);
+
+        $now = new DateTimeImmutable(Date::now());
+
+        usleep($timeToSleep);
+
+        $after = new DateTimeImmutable();
+
+        $this->assertGreaterThan($before, $now);
+        $this->assertLessThan($after, $now);
+    }
+
+    public function dateProvider()
+    {
+        return [
+            ['2020-01-02 03:04:05.678912', '+0000', '2020-01-02T03:04:05.678+00:00'],
+            ['2020-01-02 03:04:05.678912', '+1000', '2020-01-02T03:04:05.678+10:00'],
+            ['2020-01-02 03:04:05.678912', '+1234', '2020-01-02T03:04:05.678+12:34'],
+            ['2020-01-02 03:04:05.678912', '-1234', '2020-01-02T03:04:05.678-12:34'],
+            ['1900-12-31 19:00:12.311900', '+1900', '1900-12-31T19:00:12.311+19:00'],
+        ];
+    }
+}

--- a/tests/ErrorTypesTest.php
+++ b/tests/ErrorTypesTest.php
@@ -6,28 +6,190 @@ use Bugsnag\ErrorTypes;
 
 class ErrorTypesTest extends TestCase
 {
-    public function testGetLevelsForSeverity()
+    /**
+     * @dataProvider levelsForSeverityProvider
+     *
+     * @param string $severity
+     * @param int $expected
+     *
+     * @return void
+     */
+    public function testGetLevelsForSeverity($severity, $expected)
     {
-        $this->assertSame(4437, ErrorTypes::getLevelsForSeverity('error'));
-        $this->assertSame(674, ErrorTypes::getLevelsForSeverity('warning'));
-        $this->assertSame(27656, ErrorTypes::getLevelsForSeverity('info'));
+        $this->assertSame($expected, ErrorTypes::getLevelsForSeverity($severity));
     }
 
-    public function testIsFatal()
+    /**
+     * @dataProvider isFatalProvider
+     *
+     * @param int $code
+     * @param bool $expected
+     *
+     * @return void
+     */
+    public function testIsFatal($code, $expected)
     {
-        $this->assertFalse(ErrorTypes::isFatal(E_CORE_WARNING));
-        $this->assertTrue(ErrorTypes::isFatal(E_COMPILE_ERROR));
+        $this->assertSame($expected, ErrorTypes::isFatal($code));
     }
 
-    public function testGetName()
+    /**
+     * @dataProvider nameProvider
+     *
+     * @param int $code
+     * @param string $expected
+     *
+     * @return void
+     */
+    public function testGetName($code, $expected)
     {
-        $this->assertSame('PHP Notice', ErrorTypes::getName(E_NOTICE));
-        $this->assertSame('Unknown', ErrorTypes::getName(42));
+        $this->assertSame($expected, ErrorTypes::getName($code));
     }
 
-    public function testGetSeverity()
+    /**
+     * @dataProvider severityProvider
+     *
+     * @param int $code
+     * @param string $expected
+     *
+     * @return void
+     */
+    public function testGetSeverity($code, $expected)
     {
-        $this->assertSame('info', ErrorTypes::getSeverity(E_NOTICE));
-        $this->assertSame('error', ErrorTypes::getSeverity(42));
+        $this->assertSame($expected, ErrorTypes::getSeverity($code));
+    }
+
+    public function testGetAllCodes()
+    {
+        $codes = ErrorTypes::getAllCodes();
+
+        // If we actually got all of the codes, they should combine to equal E_ALL
+        $combined = array_reduce($codes, function ($acc, $code) {
+            return $acc | $code;
+        }, 0);
+
+        $this->assertSame(E_ALL, $combined);
+    }
+
+    /**
+     * @dataProvider codeToStringProvider
+     *
+     * @param int $code
+     * @param string $expected
+     *
+     * @return void
+     */
+    public function testCodeToString($code, $expected)
+    {
+        $this->assertSame($expected, ErrorTypes::codeToString($code));
+    }
+
+    public function levelsForSeverityProvider()
+    {
+        return [
+            'error' => [
+                'error',
+                E_ERROR | E_PARSE | E_CORE_ERROR | E_COMPILE_ERROR | E_USER_ERROR | E_RECOVERABLE_ERROR,
+            ],
+            'warning' => [
+                'warning',
+                E_WARNING | E_CORE_WARNING | E_COMPILE_WARNING | E_USER_WARNING,
+            ],
+            'info' => [
+                'info',
+                E_NOTICE | E_USER_NOTICE | E_STRICT | E_DEPRECATED | E_USER_DEPRECATED,
+            ],
+            'non existent severity' => [
+                'non existent severity',
+                0,
+            ],
+        ];
+    }
+
+    public function isFatalProvider()
+    {
+        return [
+            'E_ERROR' => [E_ERROR, true],
+            'E_PARSE' => [E_PARSE, true],
+            'E_CORE_ERROR' => [E_CORE_ERROR, true],
+            'E_COMPILE_ERROR' => [E_COMPILE_ERROR, true],
+            'E_USER_ERROR' => [E_USER_ERROR, true],
+            'E_RECOVERABLE_ERROR' => [E_RECOVERABLE_ERROR, true],
+            'E_WARNING' => [E_WARNING, false],
+            'E_CORE_WARNING' => [E_CORE_WARNING, false],
+            'E_COMPILE_WARNING' => [E_COMPILE_WARNING, false],
+            'E_USER_WARNING' => [E_USER_WARNING, false],
+            'E_NOTICE' => [E_NOTICE, false],
+            'E_USER_NOTICE' => [E_USER_NOTICE, false],
+            'E_STRICT' => [E_STRICT, false],
+            'E_DEPRECATED' => [E_DEPRECATED, false],
+            'E_USER_DEPRECATED' => [E_USER_DEPRECATED, false],
+            'invalid code' => ['hello', true],
+        ];
+    }
+
+    public function nameProvider()
+    {
+        return [
+            'E_ERROR' => [E_ERROR, 'PHP Fatal Error'],
+            'E_WARNING' => [E_WARNING, 'PHP Warning'],
+            'E_PARSE' => [E_PARSE, 'PHP Parse Error'],
+            'E_NOTICE' => [E_NOTICE, 'PHP Notice'],
+            'E_CORE_ERROR' => [E_CORE_ERROR, 'PHP Core Error'],
+            'E_CORE_WARNING' => [E_CORE_WARNING, 'PHP Core Warning'],
+            'E_COMPILE_ERROR' => [E_COMPILE_ERROR, 'PHP Compile Error'],
+            'E_COMPILE_WARNING' => [E_COMPILE_WARNING, 'PHP Compile Warning'],
+            'E_USER_ERROR' => [E_USER_ERROR, 'User Error'],
+            'E_USER_WARNING' => [E_USER_WARNING, 'User Warning'],
+            'E_USER_NOTICE' => [E_USER_NOTICE, 'User Notice'],
+            'E_STRICT' => [E_STRICT, 'PHP Strict'],
+            'E_RECOVERABLE_ERROR' => [E_RECOVERABLE_ERROR, 'PHP Recoverable Error'],
+            'E_DEPRECATED' => [E_DEPRECATED, 'PHP Deprecated'],
+            'E_USER_DEPRECATED' => [E_USER_DEPRECATED, 'User Deprecated'],
+            'invalid code' => ['hello', 'Unknown'],
+        ];
+    }
+
+    public function severityProvider()
+    {
+        return [
+            'E_ERROR' => [E_ERROR, 'error'],
+            'E_PARSE' => [E_PARSE, 'error'],
+            'E_CORE_ERROR' => [E_CORE_ERROR, 'error'],
+            'E_COMPILE_ERROR' => [E_COMPILE_ERROR, 'error'],
+            'E_USER_ERROR' => [E_USER_ERROR, 'error'],
+            'E_RECOVERABLE_ERROR' => [E_RECOVERABLE_ERROR, 'error'],
+            'E_WARNING' => [E_WARNING, 'warning'],
+            'E_CORE_WARNING' => [E_CORE_WARNING, 'warning'],
+            'E_COMPILE_WARNING' => [E_COMPILE_WARNING, 'warning'],
+            'E_USER_WARNING' => [E_USER_WARNING, 'warning'],
+            'E_NOTICE' => [E_NOTICE, 'info'],
+            'E_USER_NOTICE' => [E_USER_NOTICE, 'info'],
+            'E_STRICT' => [E_STRICT, 'info'],
+            'E_DEPRECATED' => [E_DEPRECATED, 'info'],
+            'E_USER_DEPRECATED' => [E_USER_DEPRECATED, 'info'],
+            'invalid code' => ['hello', 'error'],
+        ];
+    }
+
+    public function codeToStringProvider()
+    {
+        return [
+            'E_ERROR' => [E_ERROR, 'E_ERROR'],
+            'E_PARSE' => [E_PARSE, 'E_PARSE'],
+            'E_CORE_ERROR' => [E_CORE_ERROR, 'E_CORE_ERROR'],
+            'E_COMPILE_ERROR' => [E_COMPILE_ERROR, 'E_COMPILE_ERROR'],
+            'E_USER_ERROR' => [E_USER_ERROR, 'E_USER_ERROR'],
+            'E_RECOVERABLE_ERROR' => [E_RECOVERABLE_ERROR, 'E_RECOVERABLE_ERROR'],
+            'E_WARNING' => [E_WARNING, 'E_WARNING'],
+            'E_CORE_WARNING' => [E_CORE_WARNING, 'E_CORE_WARNING'],
+            'E_COMPILE_WARNING' => [E_COMPILE_WARNING, 'E_COMPILE_WARNING'],
+            'E_USER_WARNING' => [E_USER_WARNING, 'E_USER_WARNING'],
+            'E_NOTICE' => [E_NOTICE, 'E_NOTICE'],
+            'E_USER_NOTICE' => [E_USER_NOTICE, 'E_USER_NOTICE'],
+            'E_STRICT' => [E_STRICT, 'E_STRICT'],
+            'E_DEPRECATED' => [E_DEPRECATED, 'E_DEPRECATED'],
+            'E_USER_DEPRECATED' => [E_USER_DEPRECATED, 'E_USER_DEPRECATED'],
+            'invalid code' => ['hello', 'Unknown'],
+        ];
     }
 }

--- a/tests/Fakes/FakeClock.php
+++ b/tests/Fakes/FakeClock.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Bugsnag\Tests\Fakes;
+
+use Bugsnag\DateTime\ClockInterface;
+use DateTimeImmutable;
+
+final class FakeClock implements ClockInterface
+{
+    private $date;
+
+    public function __construct(DateTimeImmutable $date)
+    {
+        $this->date = $date;
+    }
+
+    public function now()
+    {
+        return $this->date;
+    }
+}

--- a/tests/HandlerTest.php
+++ b/tests/HandlerTest.php
@@ -121,25 +121,21 @@ class HandlerTest extends TestCase
     public function testErrorReportingSuppressed()
     {
         $this->runErrorHandlerTest(function () {
-            error_reporting(0);
-
             $this->client->setErrorReportingLevel(E_NOTICE);
             $this->client->expects($this->never())->method('notify');
 
             $handler = Handler::register($this->client);
-            $handler->errorHandler(E_NOTICE, 'Something broke', 'somefile.php', 123);
+            @$handler->errorHandler(E_NOTICE, 'Something broke', 'somefile.php', 123);
         });
     }
 
     public function testErrorReportingDefaultSuppressed()
     {
         $this->runErrorHandlerTest(function () {
-            error_reporting(0);
-
             $this->client->expects($this->never())->method('notify');
 
             $handler = Handler::register($this->client);
-            $handler->errorHandler(E_NOTICE, 'Something broke', 'somefile.php', 123);
+            @$handler->errorHandler(E_NOTICE, 'Something broke', 'somefile.php', 123);
         });
     }
 

--- a/tests/HttpClientTest.php
+++ b/tests/HttpClientTest.php
@@ -69,7 +69,7 @@ class HttpClientTest extends TestCase
             $headers = $options['headers'];
 
             $this->assertSame('6015a72ff14038114c3d12623dfb018f', $headers['Bugsnag-Api-Key']);
-            $this->assertArrayHasKey('Bugsnag-Sent-At', $headers);
+            Assert::matchesBugsnagDateFormat($headers['Bugsnag-Sent-At']);
             $this->assertSame('4.0', $headers['Bugsnag-Payload-Version']);
 
             return true;
@@ -98,7 +98,7 @@ class HttpClientTest extends TestCase
             $headers = $options['headers'];
 
             $this->assertSame('6015a72ff14038114c3d12623dfb018f', $headers['Bugsnag-Api-Key']);
-            $this->assertArrayHasKey('Bugsnag-Sent-At', $headers);
+            Assert::matchesBugsnagDateFormat($headers['Bugsnag-Sent-At']);
             $this->assertSame('4.0', $headers['Bugsnag-Payload-Version']);
 
             return true;
@@ -128,7 +128,7 @@ class HttpClientTest extends TestCase
             $headers = $options['headers'];
 
             $this->assertSame('6015a72ff14038114c3d12623dfb018f', $headers['Bugsnag-Api-Key']);
-            $this->assertArrayHasKey('Bugsnag-Sent-At', $headers);
+            Assert::matchesBugsnagDateFormat($headers['Bugsnag-Sent-At']);
             $this->assertSame('4.0', $headers['Bugsnag-Payload-Version']);
 
             return true;
@@ -173,7 +173,7 @@ class HttpClientTest extends TestCase
 
             $headers = $options['headers'];
             $this->assertSame('6015a72ff14038114c3d12623dfb018f', $headers['Bugsnag-Api-Key']);
-            $this->assertArrayHasKey('Bugsnag-Sent-At', $headers);
+            Assert::matchesBugsnagDateFormat($headers['Bugsnag-Sent-At']);
             $this->assertSame('4.0', $headers['Bugsnag-Payload-Version']);
 
             return true;

--- a/tests/ReportTest.php
+++ b/tests/ReportTest.php
@@ -37,7 +37,7 @@ class ReportTest extends TestCase
         $data = $this->report->toArray();
 
         $this->assertCount(3, $data['device']);
-        Assert::isType('string', $data['device']['time']);
+        Assert::matchesBugsnagDateFormat($data['device']['time']);
         $this->assertSame(php_uname('n'), $data['device']['hostname']);
         $this->assertSame(phpversion(), $data['device']['runtimeVersions']['php']);
     }

--- a/tests/phpt/configuration_should_warn_if_error_reporting_level_is_set_incorrectly.phpt
+++ b/tests/phpt/configuration_should_warn_if_error_reporting_level_is_set_incorrectly.phpt
@@ -1,0 +1,45 @@
+--TEST--
+Bugsnag\Configuration should warn if error reporting level is set incorrectly
+--FILE--
+<?php
+// PHPUnit 4 or PHP < 7.1 (or both) fail to write error_log calls to stdout, even
+// with php's 'php://stdout' stream. Forcing error logs to write to /dev/stdout
+// works around this
+ini_set('error_log', '/dev/stdout');
+
+$client = require __DIR__ . '/_prelude.php';
+
+echo "Including values in Bugsnag's errorReportingLevel that are not in error_reporting should log a warning\n";
+error_reporting(E_ALL & ~E_WARNING & ~E_USER_DEPRECATED);
+$client->setErrorReportingLevel(E_ERROR | E_WARNING | E_NOTICE | E_USER_DEPRECATED);
+
+echo "\nSetting Bugsnag's errorReportingLevel to null should be fine\n";
+$client->setErrorReportingLevel(null);
+
+echo "\nSetting Bugsnag's errorReportingLevel to a subset of error_reporting should be fine\n";
+$client->setErrorReportingLevel(E_ERROR);
+
+echo "\nSetting Bugsnag's errorReportingLevel to 0 should be fine\n";
+$client->setErrorReportingLevel(0);
+
+echo "\nSetting Bugsnag's errorReportingLevel to exclusively E_WARNING (which is missing from error_reporting) should log a warning\n";
+$client->setErrorReportingLevel(E_WARNING);
+
+echo "\nSetting both error_reporing and Bugsnag's errorReportingLevel to exclusively E_WARNING should be fine\n";
+error_reporting(E_WARNING);
+$client->setErrorReportingLevel(E_WARNING);
+?>
+--EXPECTF--
+Including values in Bugsnag's errorReportingLevel that are not in error_reporting should log a warning
+[%s] Bugsnag Warning: errorReportingLevel cannot contain values that are not in error_reporting. Any errors of these levels will be ignored: E_WARNING, E_USER_DEPRECATED.
+
+Setting Bugsnag's errorReportingLevel to null should be fine
+
+Setting Bugsnag's errorReportingLevel to a subset of error_reporting should be fine
+
+Setting Bugsnag's errorReportingLevel to 0 should be fine
+
+Setting Bugsnag's errorReportingLevel to exclusively E_WARNING (which is missing from error_reporting) should log a warning
+[%s] Bugsnag Warning: errorReportingLevel cannot contain values that are not in error_reporting. Any errors of these levels will be ignored: E_WARNING.
+
+Setting both error_reporing and Bugsnag's errorReportingLevel to exclusively E_WARNING should be fine

--- a/tests/phpt/handler_should_respect_error_suppression_operator_with_custom_reporting_level.phpt
+++ b/tests/phpt/handler_should_respect_error_suppression_operator_with_custom_reporting_level.phpt
@@ -3,8 +3,9 @@ Bugsnag\Handler should respect the error suppression operator with a custom repo
 --FILE--
 <?php
 $client = require __DIR__ . '/_prelude.php';
+
+error_reporting(E_ALL);
 $client->getConfig()->setErrorReportingLevel(E_ALL & ~E_USER_NOTICE);
-error_reporting(E_ALL & ~E_USER_WARNING);
 
 Bugsnag\Handler::register($client);
 
@@ -14,24 +15,20 @@ trigger_error('abc notice', E_USER_NOTICE);
 echo "Triggering a suppressed user notice that should be ignored by PHP and ignored by Bugsnag\n";
 @trigger_error('xyz notice', E_USER_NOTICE);
 
-echo "Triggering a user warning that should be ignored by PHP and reported by Bugsnag\n";
+echo "Triggering a user warning that should be reported by PHP and reported by Bugsnag\n";
 trigger_error('abc warning', E_USER_WARNING);
 
 echo "Triggering a suppressed user warning that should be ignored by PHP and ignored by Bugsnag\n";
 @trigger_error('xyz warning', E_USER_WARNING);
 ?>
---SKIPIF--
-<?php
-if (PHP_MAJOR_VERSION === 8) {
-    echo 'SKIP — PHP 8 changes the error suppression operator (PLAT-4822)';
-}
-?>
 --EXPECTF--
 Triggering a user notice that should be reported by PHP and ignored by Bugsnag
 
-Notice: abc notice in %s on line 9
+Notice: abc notice in %s on line 10
 Triggering a suppressed user notice that should be ignored by PHP and ignored by Bugsnag
-Triggering a user warning that should be ignored by PHP and reported by Bugsnag
+Triggering a user warning that should be reported by PHP and reported by Bugsnag
+
+Warning: abc warning in %s on line 16
 Triggering a suppressed user warning that should be ignored by PHP and ignored by Bugsnag
 Guzzle request made (1 event)!
 * Method: 'POST'


### PR DESCRIPTION
## 3.24.0 (2020-10-27)

This release changes how Bugsnag detects the error suppression operator in combination with the `errorReportingLevel` configuration option, for PHP 8 compatibility. Bugsnag's `errorReportingLevel` must now be a subset of `error_reporting` — i.e. every error level in `errorReportingLevel` must also be in `error_reporting`

If you use the `errorReportingLevel` option, you may need to change your Bugsnag or PHP configuration in order to report all expected errors. See [PR #611](https://github.com/bugsnag/bugsnag-php/pull/611) for more details

### Enhancements

* Improve the display of breadrumbs in the Bugsnag app by including milliseconds in timestamps
  [#612](https://github.com/bugsnag/bugsnag-php/pull/612)

### Fixes

* Make `Configuration::shouldIgnoreErrorCode` compatible with PHP 8 by requiring the `errorReportingLevel` option to be a subset of `error_reporting`
  [#611](https://github.com/bugsnag/bugsnag-php/pull/611)
