### PR TITLE
Fix invalid curl_setopt (v2)

### DIFF
--- a/.styleci.yml
+++ b/.styleci.yml
@@ -6,3 +6,7 @@ disabled:
 enabled:
   - long_array_syntax
   - unalign_double_arrow
+
+finder:
+  exclude:
+    - tests/fixtures

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,6 +30,7 @@ matrix:
 
 before_install:
   - if [[ $TRAVIS_PHP_VERSION =~ ^hhvm ]]; then echo 'hhvm.jit = false' >> /etc/hhvm/php.ini ; fi
+  - if [[ $TRAVIS_PHP_VERSION == "hhvm-3.6" ]]; then composer self-update --rollback; fi
 
 install:
   - if [ "$TRAVIS_PHP_VERSION" != "5.2" ]; then travis_retry composer install --no-interaction --prefer-source; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,9 @@ matrix:
     - php: 5.3
       dist: precise
     - php: 5.4
+      dist: precise
     - php: 5.5
+      dist: precise
     - php: 5.6
     - php: 7.0
     - php: 7.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 Changelog
 =========
 
+## 2.10.1 (TBD)
+
+### Bug Fixes
+
+* Fix invalid use of `curl_setopt`
+  [#614](https://github.com/bugsnag/bugsnag-php/pull/614)
+
 ## 2.10.0 (2019-06-12)
 
 ### Enhancements

--- a/src/Bugsnag/Notification.php
+++ b/src/Bugsnag/Notification.php
@@ -233,11 +233,7 @@ class Bugsnag_Notification
         curl_setopt($http, CURLOPT_CONNECTTIMEOUT, $this->config->timeout);
         curl_setopt($http, CURLOPT_SSL_VERIFYPEER, false);
         curl_setopt($http, CURLOPT_VERBOSE, false);
-        if (defined('HHVM_VERSION')) {
-            curl_setopt($http, CURLOPT_IPRESOLVE, CURL_IPRESOLVE_V4);
-        } else {
-            curl_setopt($http, CURL_IPRESOLVE_V4, true);
-        }
+        curl_setopt($http, CURLOPT_IPRESOLVE, CURL_IPRESOLVE_V4);
 
         if (!empty($this->config->curlOptions)) {
             foreach ($this->config->curlOptions as $option => $value) {


### PR DESCRIPTION
## Goal

In PHP 8, `curl_setopt` will now throw if an undefined option is used. We were using `CURL_IPRESOLVE_V4` as an option, when it's actually a value, so all error reports failed before being sent

AFAICT this has always been an error, but earlier PHP version silently ignored it — [see the docs from 2013](https://github.com/php/doc-en/commit/9810b1ec48a0a84fe7c5cbfd5dd0b15277057ce6#diff-717ba49111eccd44cb75e6b39de78d12c36f2d625be55b911055f5a5be133081R791-R803)

We need to make significant changes to the test suite to run the tests on newer PHP versions. We haven't don that now as this change is so small and isn't tested in the test suite anyway

## Changeset

- Fixed `curl_setop` usage
- Ignore fixtures on StyleCI so it passes
- Fix installing PHP 5.4/5.5 on Travis by using an older dist
- Fix HHVM 3.6 on Travis by using an older composer version

## Testing

This was tested manually as the test suite doesn't cover it — the changed function is always mocked