### PR TITLE
Add a default timeout & connect_timeout to Guzzle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 Changelog
 =========
 
+## TBD
+
+### Enhancements
+
+* Add a default timeout & connect_timeout to Guzzle instances created by bugsnag-php. This does not apply if you are providing a custom Guzzle instance.
+  [#616](https://github.com/bugsnag/bugsnag-php/pull/616)
+
 ## 3.24.0 (2020-10-27)
 
 This release changes how Bugsnag detects the error suppression operator in combination with the `errorReportingLevel` configuration option, for PHP 8 compatibility. Bugsnag's `errorReportingLevel` must now be a subset of `error_reporting` — i.e. every error level in `errorReportingLevel` must also be in `error_reporting`

--- a/src/Client.php
+++ b/src/Client.php
@@ -9,6 +9,7 @@ use Bugsnag\Callbacks\RequestContext;
 use Bugsnag\Callbacks\RequestMetaData;
 use Bugsnag\Callbacks\RequestSession;
 use Bugsnag\Callbacks\RequestUser;
+use Bugsnag\Internal\GuzzleCompat;
 use Bugsnag\Middleware\BreadcrumbData;
 use Bugsnag\Middleware\CallbackBridge;
 use Bugsnag\Middleware\NotificationSkipper;

--- a/src/GuzzleCompat.php
+++ b/src/GuzzleCompat.php
@@ -1,0 +1,88 @@
+<?php
+
+namespace Bugsnag;
+
+use GuzzleHttp;
+
+/**
+ * @internal
+ */
+final class GuzzleCompat
+{
+    /**
+     * @return bool
+     */
+    public static function isUsingGuzzle5()
+    {
+        if (defined(GuzzleHttp\ClientInterface::class.'::VERSION')) {
+            $version = constant(GuzzleHttp\ClientInterface::class.'::VERSION');
+
+            return version_compare($version, '5.0.0', '>=')
+                && version_compare($version, '6.0.0', '<');
+        }
+
+        return false;
+    }
+
+    /**
+     * Get the base URL/URI option name, which depends on the Guzzle version.
+     *
+     * @return string
+     */
+    public static function getBaseUriOptionName()
+    {
+        return self::isUsingGuzzle5() ? 'base_url' : 'base_uri';
+    }
+
+    /**
+     * Get the base URL/URI, which depends on the Guzzle version.
+     *
+     * @param GuzzleHttp\ClientInterface $guzzle
+     *
+     * @return mixed
+     */
+    public static function getBaseUri(GuzzleHttp\ClientInterface $guzzle)
+    {
+        return self::isUsingGuzzle5()
+            ? $guzzle->getBaseUrl()
+            : $guzzle->getConfig(self::getBaseUriOptionName());
+    }
+
+    /**
+     * Apply the given $requestOptions to the Guzzle $options array, if they are
+     * not already set.
+     *
+     * The layout of request options differs in Guzzle 5 to 6/7; in Guzzle 5
+     * request options live in a 'defaults' array, but in 6/7 they are in the
+     * top level
+     *
+     * @param array $options
+     * @param array $requestOptions
+     *
+     * @return array
+     */
+    public static function applyRequestOptions(array $options, array $requestOptions)
+    {
+        if (self::isUsingGuzzle5()) {
+            if (!isset($options['defaults'])) {
+                $options['defaults'] = [];
+            }
+
+            foreach ($requestOptions as $key => $value) {
+                if (!isset($options['defaults'][$key])) {
+                    $options['defaults'][$key] = $value;
+                }
+            }
+
+            return $options;
+        }
+
+        foreach ($requestOptions as $key => $value) {
+            if (!isset($options[$key])) {
+                $options[$key] = $value;
+            }
+        }
+
+        return $options;
+    }
+}

--- a/src/HttpClient.php
+++ b/src/HttpClient.php
@@ -3,6 +3,7 @@
 namespace Bugsnag;
 
 use Bugsnag\DateTime\Date;
+use Bugsnag\Internal\GuzzleCompat;
 use Exception;
 use GuzzleHttp\ClientInterface;
 use RuntimeException;

--- a/src/HttpClient.php
+++ b/src/HttpClient.php
@@ -267,10 +267,10 @@ class HttpClient
      */
     protected function post($uri, array $options = [])
     {
-        if (method_exists(ClientInterface::class, 'request')) {
-            $this->guzzle->request('POST', $uri, $options);
-        } else {
+        if (GuzzleCompat::isUsingGuzzle5()) {
             $this->guzzle->post($uri, $options);
+        } else {
+            $this->guzzle->request('POST', $uri, $options);
         }
     }
 

--- a/src/Internal/GuzzleCompat.php
+++ b/src/Internal/GuzzleCompat.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Bugsnag;
+namespace Bugsnag\Internal;
 
 use GuzzleHttp;
 

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -4,6 +4,7 @@ namespace Bugsnag\Tests;
 
 use Bugsnag\Client;
 use Bugsnag\Configuration;
+use Bugsnag\GuzzleCompat;
 use Bugsnag\Report;
 use Bugsnag\Tests\Fakes\FakeShutdownStrategy;
 use Exception;
@@ -149,7 +150,7 @@ class ClientTest extends TestCase
     public function testTheNotifyEndpointCanBeSetBySettingItOnAGuzzleInstance()
     {
         $guzzle = new Guzzle([
-            $this->getGuzzleBaseOptionName() => 'https://example.com',
+            GuzzleCompat::getBaseUriOptionName() => 'https://example.com',
         ]);
 
         $client = new Client(new Configuration('abc'), null, $guzzle);
@@ -173,7 +174,7 @@ class ClientTest extends TestCase
         $config->setNotifyEndpoint('https://foo.com');
 
         $guzzle = new Guzzle([
-            $this->getGuzzleBaseOptionName() => 'https://example.com',
+            GuzzleCompat::getBaseUriOptionName() => 'https://example.com',
         ]);
 
         $client = new Client($config, null, $guzzle);
@@ -195,14 +196,14 @@ class ClientTest extends TestCase
 
     public function testTheNotifyEndpointCanBeSetBySettingItOnAGuzzleInstanceWithAnArray()
     {
-        if (!$this->isUsingGuzzle5()) {
+        if (!GuzzleCompat::isUsingGuzzle5()) {
             $this->markTestSkipped(
                 'This test is not relevant on Guzzle >= 6 as arrays are not allowed'
             );
         }
 
         $guzzle = new Guzzle([
-            $this->getGuzzleBaseOptionName() => [
+            GuzzleCompat::getBaseUriOptionName() => [
                 'https://example.com/{version}', ['version' => '1.2'],
             ],
         ]);
@@ -215,7 +216,7 @@ class ClientTest extends TestCase
     public function testTheNotifyEndpointCanBeSetBySettingItOnAGuzzleInstanceWithAUriInstance()
     {
         $guzzle = new Guzzle([
-            $this->getGuzzleBaseOptionName() => new Uri('https://example.com:8080/hello/world'),
+            GuzzleCompat::getBaseUriOptionName() => new Uri('https://example.com:8080/hello/world'),
         ]);
 
         $client = new Client(new Configuration('abc'), null, $guzzle);
@@ -1113,7 +1114,7 @@ class ClientTest extends TestCase
     {
         $options = ['timeout' => 1, 'connect_timeout' => 2];
 
-        if ($this->isUsingGuzzle5()) {
+        if (GuzzleCompat::isUsingGuzzle5()) {
             $options = ['defaults' => $options];
         }
 
@@ -1128,7 +1129,7 @@ class ClientTest extends TestCase
 
     private function getGuzzleOption($guzzle, $name)
     {
-        if ($this->isUsingGuzzle5()) {
+        if (GuzzleCompat::isUsingGuzzle5()) {
             return $guzzle->getDefaultOption($name);
         }
 

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -4,7 +4,7 @@ namespace Bugsnag\Tests;
 
 use Bugsnag\Client;
 use Bugsnag\Configuration;
-use Bugsnag\GuzzleCompat;
+use Bugsnag\Internal\GuzzleCompat;
 use Bugsnag\Report;
 use Bugsnag\Tests\Fakes\FakeShutdownStrategy;
 use Exception;

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -1098,6 +1098,43 @@ class ClientTest extends TestCase
         $this->assertTrue($shutdownStrategy->wasRegistered());
     }
 
+    public function testMakeGuzzleCreatesAGuzzleInstanceWithATimeout()
+    {
+        $guzzle = Client::makeGuzzle();
+
+        $timeout = $this->getGuzzleOption($guzzle, 'timeout');
+        $connectTimeout = $this->getGuzzleOption($guzzle, 'connect_timeout');
+
+        $this->assertSame(Client::DEFAULT_TIMEOUT_S, $timeout);
+        $this->assertSame(Client::DEFAULT_TIMEOUT_S, $connectTimeout);
+    }
+
+    public function testMakeGuzzleCreatesTimeoutCanBeSpecified()
+    {
+        $options = ['timeout' => 1, 'connect_timeout' => 2];
+
+        if ($this->isUsingGuzzle5()) {
+            $options = ['defaults' => $options];
+        }
+
+        $guzzle = Client::makeGuzzle(null, $options);
+
+        $timeout = $this->getGuzzleOption($guzzle, 'timeout');
+        $connectTimeout = $this->getGuzzleOption($guzzle, 'connect_timeout');
+
+        $this->assertSame(1, $timeout);
+        $this->assertSame(2, $connectTimeout);
+    }
+
+    private function getGuzzleOption($guzzle, $name)
+    {
+        if ($this->isUsingGuzzle5()) {
+            return $guzzle->getDefaultOption($name);
+        }
+
+        return $guzzle->getConfig($name);
+    }
+
     private function expectGuzzlePostWith($uri, array $options = [])
     {
         $method = self::getGuzzleMethod();

--- a/tests/HttpClientTest.php
+++ b/tests/HttpClientTest.php
@@ -3,8 +3,8 @@
 namespace Bugsnag\Tests;
 
 use Bugsnag\Configuration;
-use Bugsnag\GuzzleCompat;
 use Bugsnag\HttpClient;
+use Bugsnag\Internal\GuzzleCompat;
 use Bugsnag\Report;
 use Exception;
 use GuzzleHttp\Client;

--- a/tests/HttpClientTest.php
+++ b/tests/HttpClientTest.php
@@ -3,6 +3,7 @@
 namespace Bugsnag\Tests;
 
 use Bugsnag\Configuration;
+use Bugsnag\GuzzleCompat;
 use Bugsnag\HttpClient;
 use Bugsnag\Report;
 use Exception;
@@ -41,7 +42,7 @@ class HttpClientTest extends TestCase
 
     private function setExpectedGuzzleParameters($expectation, $callback)
     {
-        if ($this->isUsingGuzzle5()) {
+        if (GuzzleCompat::isUsingGuzzle5()) {
             $expectation->with(
                 $this->config->getNotifyEndpoint(),
                 $this->callback($callback)

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -2,7 +2,7 @@
 
 namespace Bugsnag\Tests;
 
-use Bugsnag\GuzzleCompat;
+use Bugsnag\Internal\GuzzleCompat;
 use phpmock\phpunit\PHPMock;
 use PHPUnit\Framework\TestCase as BaseTestCase;
 use PHPUnit\Runner\Version as PhpUnitVersion;

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -2,7 +2,7 @@
 
 namespace Bugsnag\Tests;
 
-use GuzzleHttp\ClientInterface;
+use Bugsnag\GuzzleCompat;
 use phpmock\phpunit\PHPMock;
 use PHPUnit\Framework\TestCase as BaseTestCase;
 use PHPUnit\Runner\Version as PhpUnitVersion;
@@ -43,23 +43,7 @@ abstract class TestCase extends BaseTestCase
      */
     protected static function getGuzzleMethod()
     {
-        return method_exists(ClientInterface::class, 'request') ? 'request' : 'post';
-    }
-
-    /**
-     * @return string
-     */
-    protected function getGuzzleBaseOptionName()
-    {
-        return $this->isUsingGuzzle5() ? 'base_url' : 'base_uri';
-    }
-
-    /**
-     * @return bool
-     */
-    protected function isUsingGuzzle5()
-    {
-        return method_exists(ClientInterface::class, 'getBaseUrl');
+        return GuzzleCompat::isUsingGuzzle5() ? 'post' : 'request';
     }
 
     private function phpUnitVersion()


### PR DESCRIPTION
## Goal

By default Guzzle has no timeout, meaning it waits indefinitely for requests to finish. This PR applys a very conservative default timeout of 15 seconds to avoid blocking scripts forever*

This is only applied when Bugsnag constructs the Guzzle instance used; if one is provided in the constructor, no timeout will be added (though it can, of course, provide its own timeout value)

## Design

To avoid yet more Guzzle version checks, I've consolidated them into a new `GuzzleCompat` class

## Testing

Some basic unit tests check that a timeout is applied by `makeGuzzle`. Testing the timeout itself is a bit out of scope