### PR TITLE
Release v3.25.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 Changelog
 =========
 
+## TBD
+
+### Enhancements
+
+* Add a default timeout & connect_timeout to Guzzle instances created by bugsnag-php. This does not apply if you are providing a custom Guzzle instance.
+  [#616](https://github.com/bugsnag/bugsnag-php/pull/616)
+
 ## 3.24.0 (2020-10-27)
 
 This release changes how Bugsnag detects the error suppression operator in combination with the `errorReportingLevel` configuration option, for PHP 8 compatibility. Bugsnag's `errorReportingLevel` must now be a subset of `error_reporting` — i.e. every error level in `errorReportingLevel` must also be in `error_reporting`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 Changelog
 =========
 
-## TBD
+## 3.25.0 (2020-11-25)
 
 ### Enhancements
 

--- a/src/Configuration.php
+++ b/src/Configuration.php
@@ -82,7 +82,7 @@ class Configuration
      */
     protected $notifier = [
         'name' => 'Bugsnag PHP (Official)',
-        'version' => '3.24.0',
+        'version' => '3.25.0',
         'url' => 'https://bugsnag.com',
     ];
 

--- a/src/HttpClient.php
+++ b/src/HttpClient.php
@@ -3,6 +3,7 @@
 namespace Bugsnag;
 
 use Bugsnag\DateTime\Date;
+use Bugsnag\Internal\GuzzleCompat;
 use Exception;
 use GuzzleHttp\ClientInterface;
 use RuntimeException;
@@ -267,10 +268,10 @@ class HttpClient
      */
     protected function post($uri, array $options = [])
     {
-        if (method_exists(ClientInterface::class, 'request')) {
-            $this->guzzle->request('POST', $uri, $options);
-        } else {
+        if (GuzzleCompat::isUsingGuzzle5()) {
             $this->guzzle->post($uri, $options);
+        } else {
+            $this->guzzle->request('POST', $uri, $options);
         }
     }
 

--- a/src/Internal/GuzzleCompat.php
+++ b/src/Internal/GuzzleCompat.php
@@ -1,0 +1,88 @@
+<?php
+
+namespace Bugsnag\Internal;
+
+use GuzzleHttp;
+
+/**
+ * @internal
+ */
+final class GuzzleCompat
+{
+    /**
+     * @return bool
+     */
+    public static function isUsingGuzzle5()
+    {
+        if (defined(GuzzleHttp\ClientInterface::class.'::VERSION')) {
+            $version = constant(GuzzleHttp\ClientInterface::class.'::VERSION');
+
+            return version_compare($version, '5.0.0', '>=')
+                && version_compare($version, '6.0.0', '<');
+        }
+
+        return false;
+    }
+
+    /**
+     * Get the base URL/URI option name, which depends on the Guzzle version.
+     *
+     * @return string
+     */
+    public static function getBaseUriOptionName()
+    {
+        return self::isUsingGuzzle5() ? 'base_url' : 'base_uri';
+    }
+
+    /**
+     * Get the base URL/URI, which depends on the Guzzle version.
+     *
+     * @param GuzzleHttp\ClientInterface $guzzle
+     *
+     * @return mixed
+     */
+    public static function getBaseUri(GuzzleHttp\ClientInterface $guzzle)
+    {
+        return self::isUsingGuzzle5()
+            ? $guzzle->getBaseUrl()
+            : $guzzle->getConfig(self::getBaseUriOptionName());
+    }
+
+    /**
+     * Apply the given $requestOptions to the Guzzle $options array, if they are
+     * not already set.
+     *
+     * The layout of request options differs in Guzzle 5 to 6/7; in Guzzle 5
+     * request options live in a 'defaults' array, but in 6/7 they are in the
+     * top level
+     *
+     * @param array $options
+     * @param array $requestOptions
+     *
+     * @return array
+     */
+    public static function applyRequestOptions(array $options, array $requestOptions)
+    {
+        if (self::isUsingGuzzle5()) {
+            if (!isset($options['defaults'])) {
+                $options['defaults'] = [];
+            }
+
+            foreach ($requestOptions as $key => $value) {
+                if (!isset($options['defaults'][$key])) {
+                    $options['defaults'][$key] = $value;
+                }
+            }
+
+            return $options;
+        }
+
+        foreach ($requestOptions as $key => $value) {
+            if (!isset($options[$key])) {
+                $options[$key] = $value;
+            }
+        }
+
+        return $options;
+    }
+}

--- a/tests/HttpClientTest.php
+++ b/tests/HttpClientTest.php
@@ -4,6 +4,7 @@ namespace Bugsnag\Tests;
 
 use Bugsnag\Configuration;
 use Bugsnag\HttpClient;
+use Bugsnag\Internal\GuzzleCompat;
 use Bugsnag\Report;
 use Exception;
 use GuzzleHttp\Client;
@@ -41,7 +42,7 @@ class HttpClientTest extends TestCase
 
     private function setExpectedGuzzleParameters($expectation, $callback)
     {
-        if ($this->isUsingGuzzle5()) {
+        if (GuzzleCompat::isUsingGuzzle5()) {
             $expectation->with(
                 $this->config->getNotifyEndpoint(),
                 $this->callback($callback)

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -2,7 +2,7 @@
 
 namespace Bugsnag\Tests;
 
-use GuzzleHttp\ClientInterface;
+use Bugsnag\Internal\GuzzleCompat;
 use phpmock\phpunit\PHPMock;
 use PHPUnit\Framework\TestCase as BaseTestCase;
 use PHPUnit\Runner\Version as PhpUnitVersion;
@@ -43,23 +43,7 @@ abstract class TestCase extends BaseTestCase
      */
     protected static function getGuzzleMethod()
     {
-        return method_exists(ClientInterface::class, 'request') ? 'request' : 'post';
-    }
-
-    /**
-     * @return string
-     */
-    protected function getGuzzleBaseOptionName()
-    {
-        return $this->isUsingGuzzle5() ? 'base_url' : 'base_uri';
-    }
-
-    /**
-     * @return bool
-     */
-    protected function isUsingGuzzle5()
-    {
-        return method_exists(ClientInterface::class, 'getBaseUrl');
+        return GuzzleCompat::isUsingGuzzle5() ? 'post' : 'request';
     }
 
     private function phpUnitVersion()


### PR DESCRIPTION
### Enhancements

* Add a default timeout & connect_timeout to Guzzle instances created by bugsnag-php. This does not apply if you are providing a custom Guzzle instance.
  [#616](https://github.com/bugsnag/bugsnag-php/pull/616)