### PR TITLE
Remove 'ignore-platform-reqs' from PHP 8 CI

### DIFF
--- a/.github/workflows/test-package.yml
+++ b/.github/workflows/test-package.yml
@@ -19,7 +19,6 @@ jobs:
           guzzle-version: '^7.0'
         - php-version: 8.0
           guzzle-version: '^7.0'
-          composer-flags: '--ignore-platform-reqs'
 
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
## Goal

Remove the `ignore-platform-reqs` composer flag from PHP 8 CI. This was necessary to install dependencies on PHP 8 before they officially supported them, but is not necessary anymore