### PR TITLE
Disable XDebug on CI and register default callbacks in PHPT tests

### DIFF
--- a/.github/workflows/test-package.yml
+++ b/.github/workflows/test-package.yml
@@ -28,6 +28,7 @@ jobs:
       uses: shivammathur/setup-php@v2
       with:
         php-version: ${{ matrix.php-version }}
+        coverage: none
 
     - run: composer validate
 

--- a/tests/phpt/_prelude.php
+++ b/tests/phpt/_prelude.php
@@ -12,8 +12,12 @@ $config->setSessionEndpoint('http://localhost/sessions');
 
 $guzzle = new FakeGuzzle();
 
-return new Client(
+$client = new Client(
     $config,
     null,
     $guzzle
 );
+
+$client->registerDefaultCallbacks();
+
+return $client;

--- a/tests/phpt/handler_can_be_manually_called_multiple_times.phpt
+++ b/tests/phpt/handler_can_be_manually_called_multiple_times.phpt
@@ -17,7 +17,7 @@ $handler->exceptionHandler(new LogicException('terrible things'));
 --EXPECTF--
 array(1) {
   [0]=>
-  object(Exception)#15 (7) {
+  object(Exception)#%d (7) {
     ["message":protected]=>
     string(10) "bad things"
     ["string":"Exception":private]=>

--- a/tests/phpt/handler_should_call_the_previous_exception_handler.phpt
+++ b/tests/phpt/handler_should_call_the_previous_exception_handler.phpt
@@ -15,7 +15,7 @@ throw new RuntimeException('abc xyz');
 var_dump('I should not be reached');
 ?>
 --EXPECTF--
-object(RuntimeException)#15 (7) {
+object(RuntimeException)#%d (7) {
   ["message":protected]=>
   string(7) "abc xyz"
   ["string":"Exception":private]=>

--- a/tests/phpt/handler_should_handle_all_throwables.phpt
+++ b/tests/phpt/handler_should_handle_all_throwables.phpt
@@ -21,7 +21,7 @@ if (PHP_MAJOR_VERSION < 7) {
 }
 ?>
 --EXPECTF--
-object(DivisionByZeroError)#15 (7) {
+object(DivisionByZeroError)#%d (7) {
   ["message":protected]=>
   string(12) "22 / 0 = ???"
   ["string":"Error":private]=>

--- a/tests/phpt/handler_should_handle_all_throwables_being_reraised.phpt
+++ b/tests/phpt/handler_should_handle_all_throwables_being_reraised.phpt
@@ -22,7 +22,7 @@ if (PHP_MAJOR_VERSION < 7) {
 }
 ?>
 --EXPECTF--
-object(DivisionByZeroError)#15 (7) {
+object(DivisionByZeroError)#%d (7) {
   ["message":protected]=>
   string(12) "22 / 0 = ???"
   ["string":"Error":private]=>

--- a/tests/phpt/handler_should_handle_exceptions_caused_by_previous_exception_handler.phpt
+++ b/tests/phpt/handler_should_handle_exceptions_caused_by_previous_exception_handler.phpt
@@ -16,7 +16,7 @@ throw new RuntimeException('abc xyz');
 var_dump('I should not be reached');
 ?>
 --EXPECTF--
-object(RuntimeException)#15 (7) {
+object(RuntimeException)#%d (7) {
   ["message":protected]=>
   string(7) "abc xyz"
   ["string":"Exception":private]=>

--- a/tests/phpt/handler_should_handle_previous_exception_handler_reraising.phpt
+++ b/tests/phpt/handler_should_handle_previous_exception_handler_reraising.phpt
@@ -16,7 +16,7 @@ throw new RuntimeException('abc xyz');
 var_dump('I should not be reached');
 ?>
 --EXPECTF--
-object(RuntimeException)#15 (7) {
+object(RuntimeException)#%d (7) {
   ["message":protected]=>
   string(7) "abc xyz"
   ["string":"Exception":private]=>

--- a/tests/phpt/handler_should_handle_throwables_caused_by_previous_exception_handler.phpt
+++ b/tests/phpt/handler_should_handle_throwables_caused_by_previous_exception_handler.phpt
@@ -22,7 +22,7 @@ if (PHP_MAJOR_VERSION < 7) {
 }
 ?>
 --EXPECTF--
-object(RuntimeException)#15 (7) {
+object(RuntimeException)#%d (7) {
   ["message":protected]=>
   string(7) "abc xyz"
   ["string":"Exception":private]=>

--- a/tests/phpt/php7/handler_should_report_parse_errors_with_previous_handler.phpt
+++ b/tests/phpt/php7/handler_should_report_parse_errors_with_previous_handler.phpt
@@ -22,7 +22,7 @@ if (PHP_MAJOR_VERSION !== 7) {
 }
 ?>
 --EXPECTF--
-object(ParseError)#15 (7) {
+object(ParseError)#%d (7) {
   ["message":protected]=>
   string(28) "syntax error, unexpected '{'"
   ["string":"Error":private]=>

--- a/tests/phpt/php8/handler_should_report_parse_errors_with_previous_handler.phpt
+++ b/tests/phpt/php8/handler_should_report_parse_errors_with_previous_handler.phpt
@@ -22,7 +22,7 @@ if (PHP_MAJOR_VERSION !== 8) {
 }
 ?>
 --EXPECTF--
-object(ParseError)#15 (7) {
+object(ParseError)#%d (7) {
   ["message":protected]=>
   string(34) "syntax error, unexpected token "}""
   ["string":"Error":private]=>


### PR DESCRIPTION
## Goal

We're currently running CI with XDebug which has performance implications and also makes our PHPT tests fail because it emits a warning to stdout:
> Xdebug: [Config] The setting 'xdebug.default_enable' has been renamed, see the upgrading guide at https://xdebug.org/docs/upgrade_guide#changed-xdebug.default_enable (See: https://xdebug.org/docs/errors#CFG-C-CHANGED)

We don't use XDebug for anything so can safely disable it

Our PHPT tests also don't register the default callbacks, which are important as they attach metadata to events