### PR TITLE
Allow Bugsnag\Handler to handle OOMs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 Changelog
 =========
 
+## TBD
+
+### Enhancements
+
+* Out of memory errors will now be reported by increasing the memory limit by 5 MiB. Use the new `memoryLimitIncrease` configuration option to change the amount of memory, or set it to `null` to disable the increase entirely.
+  [#621](https://github.com/bugsnag/bugsnag-php/pull/621)
+
 ## 3.25.0 (2020-11-25)
 
 ### Enhancements

--- a/src/Client.php
+++ b/src/Client.php
@@ -935,4 +935,28 @@ class Client
     {
         return $this->config->getSessionClient();
     }
+
+    /**
+     * Set the amount to increase the memory_limit when an OOM is triggered.
+     *
+     * This is an amount of bytes or 'null' to disable increasing the limit.
+     *
+     * @param int|null $value
+     */
+    public function setMemoryLimitIncrease($value)
+    {
+        return $this->config->setMemoryLimitIncrease($value);
+    }
+
+    /**
+     * Get the amount to increase the memory_limit when an OOM is triggered.
+     *
+     * This will return 'null' if this feature is disabled.
+     *
+     * @return int|null
+     */
+    public function getMemoryLimitIncrease()
+    {
+        return $this->config->getMemoryLimitIncrease();
+    }
 }

--- a/src/Configuration.php
+++ b/src/Configuration.php
@@ -153,6 +153,15 @@ class Configuration
     protected $buildEndpoint = self::BUILD_ENDPOINT;
 
     /**
+     * The amount to increase the memory_limit to handle an OOM.
+     *
+     * The default is 5MiB and can be disabled by setting it to 'null'
+     *
+     * @var int|null
+     */
+    protected $memoryLimitIncrease = 5242880;
+
+    /**
      * Create a new config instance.
      *
      * @param string $apiKey your bugsnag api key
@@ -765,5 +774,31 @@ class Configuration
         }
 
         return $this->sessionClient;
+    }
+
+    /**
+     * Set the amount to increase the memory_limit when an OOM is triggered.
+     *
+     * This is an amount of bytes or 'null' to disable increasing the limit.
+     *
+     * @param int|null $value
+     */
+    public function setMemoryLimitIncrease($value)
+    {
+        $this->memoryLimitIncrease = $value;
+
+        return $this;
+    }
+
+    /**
+     * Get the amount to increase the memory_limit when an OOM is triggered.
+     *
+     * This will return 'null' if this feature is disabled.
+     *
+     * @return int|null
+     */
+    public function getMemoryLimitIncrease()
+    {
+        return $this->memoryLimitIncrease;
     }
 }

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -1127,6 +1127,25 @@ class ClientTest extends TestCase
         $this->assertSame(2, $connectTimeout);
     }
 
+    public function testMemoryLimitIncreaseDefault()
+    {
+        $this->assertSame(1024 * 1024 * 5, $this->client->getMemoryLimitIncrease());
+    }
+
+    public function testMemoryLimitIncreaseCanBeSet()
+    {
+        $this->client->setMemoryLimitIncrease(12345);
+
+        $this->assertSame(12345, $this->client->getMemoryLimitIncrease());
+    }
+
+    public function testMemoryLimitIncreaseCanBeSetToNull()
+    {
+        $this->client->setMemoryLimitIncrease(null);
+
+        $this->assertNull($this->client->getMemoryLimitIncrease());
+    }
+
     private function getGuzzleOption($guzzle, $name)
     {
         if (GuzzleCompat::isUsingGuzzle5()) {

--- a/tests/ConfigurationTest.php
+++ b/tests/ConfigurationTest.php
@@ -306,4 +306,23 @@ class ConfigurationTest extends TestCase
 
         $this->assertSame($expected, $this->config->getSessionEndpoint());
     }
+
+    public function testMemoryLimitIncreaseDefault()
+    {
+        $this->assertSame(1024 * 1024 * 5, $this->config->getMemoryLimitIncrease());
+    }
+
+    public function testMemoryLimitIncreaseCanBeSet()
+    {
+        $this->config->setMemoryLimitIncrease(12345);
+
+        $this->assertSame(12345, $this->config->getMemoryLimitIncrease());
+    }
+
+    public function testMemoryLimitIncreaseCanBeSetToNull()
+    {
+        $this->config->setMemoryLimitIncrease(null);
+
+        $this->assertNull($this->config->getMemoryLimitIncrease());
+    }
 }

--- a/tests/phpt/_prelude.php
+++ b/tests/phpt/_prelude.php
@@ -6,6 +6,8 @@ use Bugsnag\Client;
 use Bugsnag\Configuration;
 use Bugsnag\Tests\phpt\Utilities\FakeGuzzle;
 
+date_default_timezone_set('UTC');
+
 $config = new Configuration('11111111111111111111111111111111');
 $config->setNotifyEndpoint('http://localhost/notify');
 $config->setSessionEndpoint('http://localhost/sessions');

--- a/tests/phpt/handler_should_increase_memory_limit_by_configured_amount_on_oom.phpt
+++ b/tests/phpt/handler_should_increase_memory_limit_by_configured_amount_on_oom.phpt
@@ -1,0 +1,30 @@
+--TEST--
+Bugsnag\Handler should increase the memory limit by the configured amount when an OOM happens
+--FILE--
+<?php
+$client = require __DIR__ . '/_prelude.php';
+$client->setMemoryLimitIncrease(1024 * 1024 * 10);
+
+ini_set('memory_limit', '2M');
+var_dump(ini_get('memory_limit'));
+
+$client->registerCallback(function () {
+    var_dump(ini_get('memory_limit'));
+});
+
+Bugsnag\Handler::register($client);
+
+$a = str_repeat('a', 2147483647);
+
+echo "No OOM!\n";
+?>
+--EXPECTF--
+string(2) "2M"
+
+Fatal error: Allowed memory size of %d bytes exhausted (tried to allocate %d bytes) in %s on line 14
+string(8) "12582912"
+Guzzle request made (1 event)!
+* Method: 'POST'
+* URI: 'http://localhost/notify'
+* Events:
+    - Allowed memory size of %d bytes exhausted (tried to allocate %d bytes)

--- a/tests/phpt/handler_should_not_increase_memory_limit_when_memory_limit_increase_is_disabled.phpt
+++ b/tests/phpt/handler_should_not_increase_memory_limit_when_memory_limit_increase_is_disabled.phpt
@@ -1,0 +1,32 @@
+--TEST--
+Bugsnag\Handler should not increase the memory limit when memoryLimitIncrease is disabled
+--FILE--
+<?php
+$client = require __DIR__ . '/_prelude.php';
+$client->setMemoryLimitIncrease(null);
+
+ini_set('memory_limit', '5M');
+var_dump(ini_get('memory_limit'));
+
+$client->registerCallback(function () {
+    // This should be the same as the first var_dump, because we should not have
+    // increase the memory limit
+    var_dump(ini_get('memory_limit'));
+});
+
+Bugsnag\Handler::register($client);
+
+$a = str_repeat('a', 2147483647);
+
+echo "No OOM!\n";
+?>
+--EXPECTF--
+string(2) "5M"
+
+Fatal error: Allowed memory size of %d bytes exhausted (tried to allocate %d bytes) in %s on line 16
+string(2) "5M"
+Guzzle request made (1 event)!
+* Method: 'POST'
+* URI: 'http://localhost/notify'
+* Events:
+    - Allowed memory size of %d bytes exhausted (tried to allocate %d bytes)

--- a/tests/phpt/handler_should_report_oom_from_large_allocation.phpt
+++ b/tests/phpt/handler_should_report_oom_from_large_allocation.phpt
@@ -1,0 +1,19 @@
+--TEST--
+Bugsnag\Handler should report OOMs triggered by single large allocations
+--FILE--
+<?php
+$client = require __DIR__ . '/_prelude.php';
+
+Bugsnag\Handler::register($client);
+
+$a = str_repeat('a', PHP_INT_MAX);
+
+echo "No OOM!\n";
+?>
+--EXPECTF--
+Fatal error: Allowed memory size of %d bytes exhausted (tried to allocate %d bytes) in %s on line 6
+Guzzle request made (1 event)!
+* Method: 'POST'
+* URI: 'http://localhost/notify'
+* Events:
+    - Allowed memory size of %d bytes exhausted (tried to allocate %d bytes)

--- a/tests/phpt/handler_should_report_oom_from_large_allocation.phpt
+++ b/tests/phpt/handler_should_report_oom_from_large_allocation.phpt
@@ -4,14 +4,16 @@ Bugsnag\Handler should report OOMs triggered by single large allocations
 <?php
 $client = require __DIR__ . '/_prelude.php';
 
+ini_set('memory_limit', '5M');
+
 Bugsnag\Handler::register($client);
 
-$a = str_repeat('a', PHP_INT_MAX);
+$a = str_repeat('a', 2147483647);
 
 echo "No OOM!\n";
 ?>
 --EXPECTF--
-Fatal error: Allowed memory size of %d bytes exhausted (tried to allocate %d bytes) in %s on line 6
+Fatal error: Allowed memory size of %d bytes exhausted (tried to allocate %d bytes) in %s on line 8
 Guzzle request made (1 event)!
 * Method: 'POST'
 * URI: 'http://localhost/notify'

--- a/tests/phpt/handler_should_report_oom_from_small_allocations.phpt
+++ b/tests/phpt/handler_should_report_oom_from_small_allocations.phpt
@@ -1,0 +1,35 @@
+--TEST--
+Bugsnag\Handler should report OOMs triggered by many small allocations
+--FILE--
+<?php
+
+$client = require __DIR__ . '/_prelude.php';
+
+$handler = Bugsnag\Handler::register($client);
+
+ini_set('memory_limit', '5M');
+
+$i = 0;
+
+gc_disable();
+
+while ($i++ < 12345678) {
+    $a = new stdClass;
+    $a->b = $a;
+}
+
+echo "No OOM!\n";
+?>
+--SKIPIF--
+<?php
+if (PHP_MAJOR_VERSION < 7) {
+    echo "SKIP - PHP 5 does not run OOM in this test";
+}
+?>
+--EXPECTF--
+Fatal error: Allowed memory size of %d bytes exhausted (tried to allocate %d bytes) in %s on line %d
+Guzzle request made (1 event)!
+* Method: 'POST'
+* URI: 'http://localhost/notify'
+* Events:
+    - Allowed memory size of %d bytes exhausted (tried to allocate %d bytes)

--- a/tests/phpt/php5/handler_should_report_oom_from_small_allocations.phpt
+++ b/tests/phpt/php5/handler_should_report_oom_from_small_allocations.phpt
@@ -1,0 +1,34 @@
+--TEST--
+Bugsnag\Handler should report OOMs triggered by many small allocations
+--FILE--
+<?php
+
+$client = require __DIR__ . '/../_prelude.php';
+
+$handler = Bugsnag\Handler::register($client);
+
+ini_set('memory_limit', '5M');
+
+$size = 1024 * 256;
+
+$array = new SplFixedArray($size);
+
+for ($i = 0; $i < $size; ++$i) {
+    $array[$i] = str_repeat('a', 32);
+}
+
+echo "No OOM!\n";
+?>
+--SKIPIF--
+<?php
+if (PHP_MAJOR_VERSION !== 5) {
+    echo 'SKIP — this test does not run on PHP 7 & 8';
+}
+?>
+--EXPECTF--
+Fatal error: Allowed memory size of %d bytes exhausted (tried to allocate %d bytes) in %s on line 14
+Guzzle request made (1 event)!
+* Method: 'POST'
+* URI: 'http://localhost/notify'
+* Events:
+    - Allowed memory size of %d bytes exhausted (tried to allocate %d bytes)


### PR DESCRIPTION
## Goal

Currently we are able to report OOMs that are caused by a single, large allocation as PHP doesn't actually allocate the memory so there's plenty left for us to use. However, when an OOM happens due to lots of small allocations, we crash as there's not enough memory left to send the report

## Design

`Bugsnag\Handler` will now increase the memory limit on an OOM by the number of bytes specified in the new `memoryLimitIncrease` option (5MiB default)

To do this successfully, we need to reserve a bit of memory so that we can:

1. check if an error happened using `error_get_last`
1. check if it was an OOM
 
We don't reserve all of the memory that we need upfront, as this would be a big overhead on every request when it shouldn't be necessary most of the time. 32K was chosen because `error_get_last` can cause PHP to re-allocate chunks of memory that it has already allocated. This can lead to a second OOM if the chunks it attempts to re-allocate are larger than the available memory. 32K seems to be a happy medium between being small enough to not matter and large enough to allow `error_get_last` to be called, but this can be tweaked in future

## Changeset

- Added a new configuration option `memoryLimitIncrease` (5MiB default), with getters & setters in `Client` & `Configuration`
- `Handler` reserves 32K of memory when the shutdown function is registered
- `Handler` increases the current memory limit by `memoryLimitIncrease` if an OOM is detected

## Testing

New PHPT tests cause OOMs and check delivery