### PR TITLE
Add ability to discard events based on class/error names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ Changelog
 * Out of memory errors will now be reported by increasing the memory limit by 5 MiB. Use the new `memoryLimitIncrease` configuration option to change the amount of memory, or set it to `null` to disable the increase entirely.
   [#621](https://github.com/bugsnag/bugsnag-php/pull/621)
 
+* Add a "discard classes" configuration option that allows events to be discarded based on the exception class name or PHP error name
+  [#622](https://github.com/bugsnag/bugsnag-php/pull/622)
+
 ## 3.25.0 (2020-11-25)
 
 ### Enhancements

--- a/src/Client.php
+++ b/src/Client.php
@@ -959,4 +959,30 @@ class Client
     {
         return $this->config->getMemoryLimitIncrease();
     }
+
+    /**
+     * Set the array of classes that should not be sent to Bugsnag.
+     *
+     * @param array $discardClasses
+     *
+     * @return $this
+     */
+    public function setDiscardClasses(array $discardClasses)
+    {
+        $this->config->setDiscardClasses($discardClasses);
+
+        return $this;
+    }
+
+    /**
+     * Get the array of classes that should not be sent to Bugsnag.
+     *
+     * This can contain both fully qualified class names and regular expressions.
+     *
+     * @var array
+     */
+    public function getDiscardClasses()
+    {
+        return $this->config->getDiscardClasses();
+    }
 }

--- a/src/Client.php
+++ b/src/Client.php
@@ -12,6 +12,7 @@ use Bugsnag\Callbacks\RequestUser;
 use Bugsnag\Internal\GuzzleCompat;
 use Bugsnag\Middleware\BreadcrumbData;
 use Bugsnag\Middleware\CallbackBridge;
+use Bugsnag\Middleware\DiscardClasses;
 use Bugsnag\Middleware\NotificationSkipper;
 use Bugsnag\Middleware\SessionData;
 use Bugsnag\Request\BasicResolver;
@@ -137,6 +138,7 @@ class Client
         $this->sessionTracker = new SessionTracker($config, $this->http);
 
         $this->registerMiddleware(new NotificationSkipper($config));
+        $this->registerMiddleware(new DiscardClasses($config));
         $this->registerMiddleware(new BreadcrumbData($this->recorder));
         $this->registerMiddleware(new SessionData($this));
 

--- a/src/Configuration.php
+++ b/src/Configuration.php
@@ -162,6 +162,15 @@ class Configuration
     protected $memoryLimitIncrease = 5242880;
 
     /**
+     * An array of classes that should not be sent to Bugsnag.
+     *
+     * This can contain both fully qualified class names and regular expressions.
+     *
+     * @var array
+     */
+    protected $discardClasses = [];
+
+    /**
      * Create a new config instance.
      *
      * @param string $apiKey your bugsnag api key
@@ -800,5 +809,31 @@ class Configuration
     public function getMemoryLimitIncrease()
     {
         return $this->memoryLimitIncrease;
+    }
+
+    /**
+     * Set the array of classes that should not be sent to Bugsnag.
+     *
+     * @param array $discardClasses
+     *
+     * @return $this
+     */
+    public function setDiscardClasses(array $discardClasses)
+    {
+        $this->discardClasses = $discardClasses;
+
+        return $this;
+    }
+
+    /**
+     * Get the array of classes that should not be sent to Bugsnag.
+     *
+     * This can contain both fully qualified class names and regular expressions.
+     *
+     * @var array
+     */
+    public function getDiscardClasses()
+    {
+        return $this->discardClasses;
     }
 }

--- a/src/Middleware/DiscardClasses.php
+++ b/src/Middleware/DiscardClasses.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace Bugsnag\Middleware;
+
+use Bugsnag\Configuration;
+use Bugsnag\Report;
+
+class DiscardClasses
+{
+    /**
+     * @var \Bugsnag\Configuration
+     */
+    protected $config;
+
+    /**
+     * @param \Bugsnag\Configuration $config
+     */
+    public function __construct(Configuration $config)
+    {
+        $this->config = $config;
+    }
+
+    /**
+     * @param \Bugsnag\Report $report
+     * @param callable        $next
+     *
+     * @return void
+     */
+    public function __invoke(Report $report, callable $next)
+    {
+        $errors = $report->getErrors();
+
+        foreach ($this->config->getDiscardClasses() as $discardClass) {
+            foreach ($errors as $error) {
+                if ($error['errorClass'] === $discardClass
+                    || @preg_match($discardClass, $error['errorClass']) === 1
+                ) {
+                    syslog(LOG_INFO, sprintf(
+                        'Discarding event because error class "%s" matched discardClasses configuration',
+                        $error['errorClass']
+                    ));
+
+                    return;
+                }
+            }
+        }
+
+        $next($report);
+    }
+}

--- a/src/Report.php
+++ b/src/Report.php
@@ -645,6 +645,39 @@ class Report
     }
 
     /**
+     * Get a list of all errors in a fixed format of:
+     * - 'errorClass'
+     * - 'errorMessage'
+     * - 'type' (always 'php').
+     *
+     * @return array
+     */
+    public function getErrors()
+    {
+        $errors = [$this->toError()];
+        $previous = $this->previous;
+
+        while ($previous) {
+            $errors[] = $previous->toError();
+            $previous = $previous->previous;
+        }
+
+        return $errors;
+    }
+
+    /**
+     * @return array
+     */
+    private function toError()
+    {
+        return [
+            'errorClass' => $this->name,
+            'errorMessage' => $this->message,
+            'type' => 'php',
+        ];
+    }
+
+    /**
      * Get the array representation.
      *
      * @return array

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -10,6 +10,7 @@ use Bugsnag\Tests\Fakes\FakeShutdownStrategy;
 use Exception;
 use GuzzleHttp\Client as Guzzle;
 use GuzzleHttp\Psr7\Uri;
+use LogicException;
 use PHPUnit\Framework\MockObject\MockObject;
 
 /**
@@ -459,6 +460,37 @@ class ClientTest extends TestCase
         );
 
         $this->assertTrue($pipelineCompleted);
+    }
+
+    public function testItAddsDiscardClassesMiddlewareByDefault()
+    {
+        $syslog = $this->getFunctionMock('Bugsnag\Middleware', 'syslog');
+        $syslog->expects($this->once())->with(
+            LOG_INFO,
+            'Discarding event because error class "Exception" matched discardClasses configuration'
+        );
+
+        $client = Client::make('foo');
+        $client->setDiscardClasses([Exception::class]);
+
+        $report = Report::fromPHPThrowable(
+            $client->getConfig(),
+            new Exception('oh no')
+        );
+
+        $pipeline = $client->getPipeline();
+        $pipelineCompleted = false;
+
+        $pipeline->execute(
+            $report,
+            function () use (&$pipelineCompleted) {
+                $pipelineCompleted = true;
+
+                throw new LogicException('This should never be reached!');
+            }
+        );
+
+        $this->assertFalse($pipelineCompleted);
     }
 
     public function testBreadcrumbsWorks()

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -1146,6 +1146,25 @@ class ClientTest extends TestCase
         $this->assertNull($this->client->getMemoryLimitIncrease());
     }
 
+    public function testDiscardClassesDefault()
+    {
+        $this->assertSame([], $this->client->getDiscardClasses());
+    }
+
+    public function testDiscardClassesCanBeSet()
+    {
+        $discardClasses = [
+            \RuntimeException::class,
+            \LogicException::class,
+            \TypeError::class,
+            '/^(Under|Over)flowException$/',
+        ];
+
+        $this->client->setDiscardClasses($discardClasses);
+
+        $this->assertSame($discardClasses, $this->client->getDiscardClasses());
+    }
+
     private function getGuzzleOption($guzzle, $name)
     {
         if (GuzzleCompat::isUsingGuzzle5()) {

--- a/tests/ConfigurationTest.php
+++ b/tests/ConfigurationTest.php
@@ -325,4 +325,23 @@ class ConfigurationTest extends TestCase
 
         $this->assertNull($this->config->getMemoryLimitIncrease());
     }
+
+    public function testDiscardClassesDefault()
+    {
+        $this->assertSame([], $this->config->getDiscardClasses());
+    }
+
+    public function testDiscardClassesCanBeSet()
+    {
+        $discardClasses = [
+            \RuntimeException::class,
+            \LogicException::class,
+            \TypeError::class,
+            '/^(Under|Over)flowException$/',
+        ];
+
+        $this->config->setDiscardClasses($discardClasses);
+
+        $this->assertSame($discardClasses, $this->config->getDiscardClasses());
+    }
 }

--- a/tests/Fakes/SomeException.php
+++ b/tests/Fakes/SomeException.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Bugsnag\Tests\Fakes;
+
+use Exception;
+
+final class SomeException extends Exception
+{
+}

--- a/tests/Middleware/DiscardClassesTest.php
+++ b/tests/Middleware/DiscardClassesTest.php
@@ -1,0 +1,227 @@
+<?php
+
+namespace Bugsnag\Tests\Middleware;
+
+use Bugsnag\Configuration;
+use Bugsnag\ErrorTypes;
+use Bugsnag\Middleware\DiscardClasses;
+use Bugsnag\Report;
+use Bugsnag\Tests\TestCase;
+use Exception;
+use LogicException;
+use OverflowException;
+use UnderflowException;
+
+class DiscardClassesTest extends TestCase
+{
+    public function testShouldNotifyByDefault()
+    {
+        $syslog = $this->getFunctionMock('Bugsnag\Middleware', 'syslog');
+        $syslog->expects($this->never());
+
+        $config = new Configuration('API-KEY');
+        $middleware = new DiscardClasses($config);
+
+        $report = Report::fromPHPThrowable($config, new Exception());
+        $this->assertReportIsNotDiscarded($middleware, $report);
+
+        $report = Report::fromPHPThrowable($config, new LogicException());
+        $this->assertReportIsNotDiscarded($middleware, $report);
+    }
+
+    public function testShouldNotifyWhenExceptionIsNotInDiscardClasses()
+    {
+        $syslog = $this->getFunctionMock('Bugsnag\Middleware', 'syslog');
+        $syslog->expects($this->never());
+
+        $config = new Configuration('API-KEY');
+        $config->setDiscardClasses([LogicException::class]);
+
+        $middleware = new DiscardClasses($config);
+
+        $report = Report::fromPHPThrowable($config, new Exception());
+        $this->assertReportIsNotDiscarded($middleware, $report);
+
+        $report = Report::fromPHPThrowable($config, new UnderflowException());
+        $this->assertReportIsNotDiscarded($middleware, $report);
+    }
+
+    public function testShouldNotifyWhenExceptionDoesNotMatchRegex()
+    {
+        $syslog = $this->getFunctionMock('Bugsnag\Middleware', 'syslog');
+        $syslog->expects($this->never());
+
+        $config = new Configuration('API-KEY');
+        $config->setDiscardClasses(['/^\d+$/']);
+
+        $middleware = new DiscardClasses($config);
+
+        $report = Report::fromPHPThrowable($config, new Exception());
+        $this->assertReportIsNotDiscarded($middleware, $report);
+
+        $report = Report::fromPHPThrowable($config, new LogicException());
+        $this->assertReportIsNotDiscarded($middleware, $report);
+    }
+
+    public function testShouldDiscardExceptionsThatExactlyMatchADiscardedClass()
+    {
+        $syslog = $this->getFunctionMock('Bugsnag\Middleware', 'syslog');
+        $syslog->expects($this->once())->with(
+            LOG_INFO,
+            'Discarding event because error class "LogicException" matched discardClasses configuration'
+        );
+
+        $config = new Configuration('API-KEY');
+        $config->setDiscardClasses([LogicException::class]);
+
+        $middleware = new DiscardClasses($config);
+
+        $report = Report::fromPHPThrowable($config, new LogicException());
+        $this->assertReportIsDiscarded($middleware, $report);
+
+        $report = Report::fromPHPThrowable($config, new Exception());
+        $this->assertReportIsNotDiscarded($middleware, $report);
+    }
+
+    public function testShouldDiscardPreviousExceptionsThatExactlyMatchADiscardedClass()
+    {
+        $syslog = $this->getFunctionMock('Bugsnag\Middleware', 'syslog');
+        $syslog->expects($this->once())->with(
+            LOG_INFO,
+            'Discarding event because error class "LogicException" matched discardClasses configuration'
+        );
+
+        $config = new Configuration('API-KEY');
+        $config->setDiscardClasses([LogicException::class]);
+
+        $middleware = new DiscardClasses($config);
+
+        $report = Report::fromPHPThrowable($config, new Exception('', 0, new LogicException()));
+        $this->assertReportIsDiscarded($middleware, $report);
+
+        $report = Report::fromPHPThrowable($config, new Exception());
+        $this->assertReportIsNotDiscarded($middleware, $report);
+
+        $report = Report::fromPHPThrowable($config, new Exception('', 0, new UnderflowException()));
+        $this->assertReportIsNotDiscarded($middleware, $report);
+    }
+
+    public function testShouldDiscardExceptionsThatMatchADiscardClassRegex()
+    {
+        $syslog = $this->getFunctionMock('Bugsnag\Middleware', 'syslog');
+        $syslog->expects($this->exactly(3))->withConsecutive(
+            [LOG_INFO, 'Discarding event because error class "UnderflowException" matched discardClasses configuration'],
+            [LOG_INFO, 'Discarding event because error class "OverflowException" matched discardClasses configuration'],
+            [LOG_INFO, 'Discarding event because error class "OverflowException" matched discardClasses configuration']
+        );
+
+        $config = new Configuration('API-KEY');
+        $config->setDiscardClasses(['/^(Under|Over)flowException$/']);
+
+        $middleware = new DiscardClasses($config);
+
+        $report = Report::fromPHPThrowable($config, new UnderflowException());
+        $this->assertReportIsDiscarded($middleware, $report);
+
+        $report = Report::fromPHPThrowable($config, new OverflowException());
+        $this->assertReportIsDiscarded($middleware, $report);
+
+        $report = Report::fromPHPThrowable($config, new LogicException());
+        $this->assertReportIsNotDiscarded($middleware, $report);
+
+        $report = Report::fromPHPThrowable($config, new LogicException('', 0, new OverflowException()));
+        $this->assertReportIsDiscarded($middleware, $report);
+    }
+
+    public function testShouldDiscardErrorsThatExactlyMatchAGivenErrorName()
+    {
+        $syslog = $this->getFunctionMock('Bugsnag\Middleware', 'syslog');
+        $syslog->expects($this->once())->with(
+            LOG_INFO,
+            'Discarding event because error class "PHP Warning" matched discardClasses configuration'
+        );
+
+        $config = new Configuration('API-KEY');
+        $config->setDiscardClasses([ErrorTypes::getName(E_WARNING)]);
+
+        $middleware = new DiscardClasses($config);
+
+        $report = Report::fromPHPError($config, E_WARNING, 'warning', '/a/b/c.php', 123);
+        $this->assertReportIsDiscarded($middleware, $report);
+
+        $report = Report::fromPHPError($config, E_USER_WARNING, 'user warning', '/a/b/c.php', 123);
+        $this->assertReportIsNotDiscarded($middleware, $report);
+    }
+
+    public function testShouldDiscardErrorsThatMatchARegex()
+    {
+        $syslog = $this->getFunctionMock('Bugsnag\Middleware', 'syslog');
+        $syslog->expects($this->exactly(2))->withConsecutive(
+            [LOG_INFO, 'Discarding event because error class "PHP Notice" matched discardClasses configuration'],
+            [LOG_INFO, 'Discarding event because error class "User Notice" matched discardClasses configuration']
+        );
+
+        $config = new Configuration('API-KEY');
+        $config->setDiscardClasses(['/\bNotice\b/']);
+
+        $middleware = new DiscardClasses($config);
+
+        $report = Report::fromPHPError($config, E_NOTICE, 'notice', '/a/b/c.php', 123);
+        $this->assertReportIsDiscarded($middleware, $report);
+
+        $report = Report::fromPHPError($config, E_USER_NOTICE, 'user notice', '/a/b/c.php', 123);
+        $this->assertReportIsDiscarded($middleware, $report);
+
+        $report = Report::fromPHPError($config, E_WARNING, 'warning', '/a/b/c.php', 123);
+        $this->assertReportIsNotDiscarded($middleware, $report);
+    }
+
+    /**
+     * Assert that DiscardClasses calls the next middleware for this Report.
+     *
+     * @param DiscardClasses $middleware
+     * @param Report $report
+     *
+     * @return void
+     */
+    private function assertReportIsNotDiscarded(DiscardClasses $middleware, Report $report)
+    {
+        $wasCalled = $this->runMiddleware($middleware, $report);
+
+        $this->assertTrue($wasCalled, 'Expected the DiscardClasses middleware to call $next');
+    }
+
+    /**
+     * Assert that DiscardClasses does not call the next middleware for this Report.
+     *
+     * @param DiscardClasses $middleware
+     * @param Report $report
+     *
+     * @return void
+     */
+    private function assertReportIsDiscarded(DiscardClasses $middleware, Report $report)
+    {
+        $wasCalled = $this->runMiddleware($middleware, $report);
+
+        $this->assertFalse($wasCalled, 'Expected the DiscardClasses middleware not to call $next');
+    }
+
+    /**
+     * Run the given middleware against the report and return if it called $next.
+     *
+     * @param callable $middleware
+     * @param Report $report
+     *
+     * @return bool
+     */
+    private function runMiddleware(callable $middleware, Report $report)
+    {
+        $wasCalled = false;
+
+        $middleware($report, function () use (&$wasCalled) {
+            $wasCalled = true;
+        });
+
+        return $wasCalled;
+    }
+}


### PR DESCRIPTION
## Goal

Adds a "discard classes" configuration option that allows events to be discarded based on the exception class name or error name. By default, no events will be discarded

This accepts fully qualified class names and regular expressions. For example, to discard both `UnderflowException` and `OverflowException`s, either of the following would work:

```php
$bugsnag->setDiscardClasses([
    \UnderflowException::class,
    \OverflowException::class,
]);
```

or

```php
$bugsnag->setDiscardClasses([
    '/^(Under|Over)flowException$/',
]);
```

PHP errors (warnings, notices etc...) can also be discarded by the name displayed in the dashboard; this can be obtained using the `\Bugsnag\ErrorTypes::getName` method. For example, to discard all PHP notices:

```php
$bugsnag->setDiscardClasses([
    \Bugsnag\ErrorTypes::getName(E_NOTICE),
]);
```

As with exceptions, regexes can also be used:

```php
$bugsnag->setDiscardClasses([
    '/Notice/',
]);
```

Discarding applies to the entire exception chain, for example if `LogicException` is a discarded class, then a `RuntimeException` that wraps a `LogicException` will also be discarded:

```php
$bugsnag->setDiscardClasses([
    \LogicException::class
]);

// Would be discarded:
throw new RuntimeException('', 0, new LogicException());

// Would _not_ be discarded:
throw new RuntimeException();
```

NB: the same list is applied to exceptions and PHP errors, so regexes that are too loose can discard more than intended

## Changeset

- `discardClasses` configuration option with getters & setters in `Client` & `Configuration`
- `DiscardClasses` middleware which does the discarding (added by default in the `Client` constructor)
- `Report::getErrors` added as a way to get the full list of errors (i.e. including previous exceptions) in a standardised structure
- Unit tests