### PR TITLE
Avoid JSON encoding event payloads more than once

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 Changelog
 =========
 
+## TBD
+
+### Fixes
+
+* Avoid JSON encoding event payloads more than once, where possible
+  [#628](https://github.com/bugsnag/bugsnag-php/pull/628)
+
 ## 3.26.0 (2021-02-10)
 
 ### Enhancements

--- a/src/HttpClient.php
+++ b/src/HttpClient.php
@@ -255,6 +255,7 @@ class HttpClient
             'Bugsnag-Api-Key' => $this->config->getApiKey(),
             'Bugsnag-Sent-At' => Date::now(),
             'Bugsnag-Payload-Version' => $version,
+            'Content-Type' => 'application/json',
         ];
     }
 
@@ -324,7 +325,7 @@ class HttpClient
             $this->post(
                 $uri,
                 [
-                    'json' => $normalized,
+                    'body' => $normalized,
                     'headers' => $this->getHeaders(self::NOTIFY_PAYLOAD_VERSION),
                 ]
             );
@@ -340,15 +341,17 @@ class HttpClient
      *
      * @throws RuntimeException
      *
-     * @return array
+     * @return string the JSON encoded data after normalization
      */
     protected function normalize(array $data)
     {
         $body = json_encode($data);
 
-        if ($this->length($body) > static::MAX_SIZE) {
-            unset($data['events'][0]['metaData']);
+        if ($this->length($body) <= static::MAX_SIZE) {
+            return $body;
         }
+
+        unset($data['events'][0]['metaData']);
 
         $body = json_encode($data);
 
@@ -356,7 +359,7 @@ class HttpClient
             throw new RuntimeException('Payload too large');
         }
 
-        return $data;
+        return $body;
     }
 
     /**

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -70,8 +70,10 @@ class ClientTest extends TestCase
         $this->expectGuzzlePostWithCallback(
             $this->client->getNotifyEndpoint(),
             function ($options) {
-                $this->assertTrue(isset($options['json']['events'][0]['severity']));
-                $this->assertSame('info', $options['json']['events'][0]['severity']);
+                $payload = $this->getPayloadFromGuzzleOptions($options);
+
+                $this->assertTrue(isset($payload['events'][0]['severity']));
+                $this->assertSame('info', $payload['events'][0]['severity']);
 
                 return true;
             }
@@ -97,8 +99,10 @@ class ClientTest extends TestCase
         $this->expectGuzzlePostWithCallback(
             $this->client->getNotifyEndpoint(),
             function ($options) {
-                $this->assertTrue(isset($options['json']['events'][0]['severity']));
-                $this->assertSame('info', $options['json']['events'][0]['severity']);
+                $payload = $this->getPayloadFromGuzzleOptions($options);
+
+                $this->assertTrue(isset($payload['events'][0]['severity']));
+                $this->assertSame('info', $payload['events'][0]['severity']);
 
                 return true;
             }

--- a/tests/HttpClientTest.php
+++ b/tests/HttpClientTest.php
@@ -59,13 +59,15 @@ class HttpClientTest extends TestCase
     public function testHttpClient()
     {
         $verifyGuzzleParameters = function ($options) {
-            Assert::isType('array', $options);
-            Assert::isType('array', $options['json']['notifier']);
-            Assert::isType('array', $options['json']['events']);
-            $this->assertSame([], $options['json']['events'][0]['user']);
-            $this->assertSame(['foo' => 'bar'], $options['json']['events'][0]['metaData']);
-            $this->assertSame('6015a72ff14038114c3d12623dfb018f', $options['json']['apiKey']);
-            $this->assertSame('4.0', $options['json']['events'][0]['payloadVersion']);
+            $payload = $this->getPayloadFromGuzzleOptions($options);
+
+            Assert::isType('array', $payload);
+            Assert::isType('array', $payload['notifier']);
+            Assert::isType('array', $payload['events']);
+            $this->assertSame([], $payload['events'][0]['user']);
+            $this->assertSame(['foo' => 'bar'], $payload['events'][0]['metaData']);
+            $this->assertSame('6015a72ff14038114c3d12623dfb018f', $payload['apiKey']);
+            $this->assertSame('4.0', $payload['events'][0]['payloadVersion']);
 
             $headers = $options['headers'];
 
@@ -88,13 +90,15 @@ class HttpClientTest extends TestCase
     public function testHttpClientMultipleSend()
     {
         $verifyGuzzleParameters = function ($options) {
-            Assert::isType('array', $options);
-            Assert::isType('array', $options['json']['notifier']);
-            Assert::isType('array', $options['json']['events']);
-            $this->assertSame([], $options['json']['events'][0]['user']);
-            $this->assertSame(['foo' => 'bar'], $options['json']['events'][0]['metaData']);
-            $this->assertSame('6015a72ff14038114c3d12623dfb018f', $options['json']['apiKey']);
-            $this->assertSame('4.0', $options['json']['events'][0]['payloadVersion']);
+            $payload = $this->getPayloadFromGuzzleOptions($options);
+
+            Assert::isType('array', $payload);
+            Assert::isType('array', $payload['notifier']);
+            Assert::isType('array', $payload['events']);
+            $this->assertSame([], $payload['events'][0]['user']);
+            $this->assertSame(['foo' => 'bar'], $payload['events'][0]['metaData']);
+            $this->assertSame('6015a72ff14038114c3d12623dfb018f', $payload['apiKey']);
+            $this->assertSame('4.0', $payload['events'][0]['payloadVersion']);
 
             $headers = $options['headers'];
 
@@ -118,13 +122,15 @@ class HttpClientTest extends TestCase
     public function testMassiveMetaDataHttpClient()
     {
         $verifyGuzzleParameters = function ($options) {
-            Assert::isType('array', $options);
-            Assert::isType('array', $options['json']['notifier']);
-            Assert::isType('array', $options['json']['events']);
-            $this->assertSame([], $options['json']['events'][0]['user']);
-            $this->assertArrayNotHasKey('metaData', $options['json']['events'][0]);
-            $this->assertSame('6015a72ff14038114c3d12623dfb018f', $options['json']['apiKey']);
-            $this->assertSame('4.0', $options['json']['events'][0]['payloadVersion']);
+            $payload = $this->getPayloadFromGuzzleOptions($options);
+
+            Assert::isType('array', $payload);
+            Assert::isType('array', $payload['notifier']);
+            Assert::isType('array', $payload['events']);
+            $this->assertSame([], $payload['events'][0]['user']);
+            $this->assertArrayNotHasKey('metaData', $payload['events'][0]);
+            $this->assertSame('6015a72ff14038114c3d12623dfb018f', $payload['apiKey']);
+            $this->assertSame('4.0', $payload['events'][0]['payloadVersion']);
 
             $headers = $options['headers'];
 
@@ -164,13 +170,15 @@ class HttpClientTest extends TestCase
         $log->expects($this->once())->with($this->equalTo('Bugsnag Warning: Payload too large'));
 
         $verifyGuzzleParameters = function ($options) {
-            Assert::isType('array', $options);
-            Assert::isType('array', $options['json']['notifier']);
-            Assert::isType('array', $options['json']['events']);
-            $this->assertSame(['foo' => 'bar'], $options['json']['events'][0]['user']);
-            $this->assertSame([], $options['json']['events'][0]['metaData']);
-            $this->assertSame('6015a72ff14038114c3d12623dfb018f', $options['json']['apiKey']);
-            $this->assertSame('4.0', $options['json']['events'][0]['payloadVersion']);
+            $payload = $this->getPayloadFromGuzzleOptions($options);
+
+            Assert::isType('array', $payload);
+            Assert::isType('array', $payload['notifier']);
+            Assert::isType('array', $payload['events']);
+            $this->assertSame(['foo' => 'bar'], $payload['events'][0]['user']);
+            $this->assertSame([], $payload['events'][0]['metaData']);
+            $this->assertSame('6015a72ff14038114c3d12623dfb018f', $payload['apiKey']);
+            $this->assertSame('4.0', $payload['events'][0]['payloadVersion']);
 
             $headers = $options['headers'];
             $this->assertSame('6015a72ff14038114c3d12623dfb018f', $headers['Bugsnag-Api-Key']);

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -56,4 +56,16 @@ abstract class TestCase extends BaseTestCase
 
         return PhpUnitVersion::id();
     }
+
+    protected function getPayloadFromGuzzleOptions(array $options)
+    {
+        $this->assertArrayHasKey('body', $options);
+        Assert::isType('string', $options['body']);
+
+        $payload = json_decode($options['body'], true);
+
+        $this->assertSame(JSON_ERROR_NONE, json_last_error(), json_last_error_msg());
+
+        return $payload;
+    }
 }

--- a/tests/phpt/Utilities/FakeGuzzle.php
+++ b/tests/phpt/Utilities/FakeGuzzle.php
@@ -54,13 +54,19 @@ function reportRequest($method, $uri, $options)
     $numberOfEvents = 0;
     $errors = [];
 
-    if (isset($options['json']['events'])) {
-        $numberOfEvents = count($options['json']['events']);
+    if (isset($options['body'])) {
+        $payload = json_decode($options['body'], true);
+
+        if (json_last_error() !== JSON_ERROR_NONE) {
+            throw new RuntimeException('Unable to decode JSON body: '.json_last_error_msg());
+        }
+
+        $numberOfEvents = count($payload['events']);
         $errors = array_map(
             function ($event) {
                 return strtok($event['exceptions'][0]['message'], "\n");
             },
-            $options['json']['events']
+            $payload['events']
         );
     }
 


### PR DESCRIPTION
## Goal

Currently we JSON encode payloads three times:

1. once to check the payload size
2. once to re-check the payload size after _possibly_ removing metadata — this is unconditional so happens even if the payload is already small enough
3. once using Guzzle's `json` option

This PR ensures that we only JSON encode payloads once when possible. If a payload is too large to send after encoding, we will still do a second encode after removing metadata