### PR TITLE
Add php 8.1 to CI + minor CI improvements

### DIFF
--- a/.github/workflows/test-package.yml
+++ b/.github/workflows/test-package.yml
@@ -8,16 +8,16 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php-version: [ 5.5, 5.6, 7.0, 7.1, 7.2, 7.3, 7.4 ]
-        guzzle-version: [ '^5.3', '^6.0' ]
+        php-version: ['5.5', '5.6', '7.0', '7.1', '7.2', '7.3', '7.4']
+        guzzle-version: ['^5.3', '^6.0']
         include:
-        - php-version: 7.2
+        - php-version: '7.2'
           guzzle-version: '^7.0'
-        - php-version: 7.3
+        - php-version: '7.3'
           guzzle-version: '^7.0'
-        - php-version: 7.4
+        - php-version: '7.4'
           guzzle-version: '^7.0'
-        - php-version: 8.0
+        - php-version: '8.0'
           guzzle-version: '^7.0'
 
     steps:

--- a/.github/workflows/test-package.yml
+++ b/.github/workflows/test-package.yml
@@ -19,6 +19,9 @@ jobs:
           guzzle-version: '^7.0'
         - php-version: '8.0'
           guzzle-version: '^7.0'
+        - php-version: '8.1'
+          guzzle-version: '^7.0'
+          composer-flags: '--ignore-platform-req php'
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/test-package.yml
+++ b/.github/workflows/test-package.yml
@@ -32,6 +32,14 @@ jobs:
         php-version: ${{ matrix.php-version }}
         coverage: none
         extensions: intl, mbstring
+        # by default setup-php uses a production php.ini so force development values
+        ini-values: >-
+          zend.exception_ignore_args=Off,
+          zend.exception_string_param_max_len=15,
+          error_reporting=-1,
+          display_errors=On,
+          display_startup_errors=On,
+          zend.assertions=1
 
     - run: composer validate
 


### PR DESCRIPTION
## Goal

Adds PHP 8.1 to CI with `--ignore-platform-req php` to allow the latest PHPUnit to install

I've also:
- wrapped version numbers in quotes. This stops the YAML parser from converting them to integers or floats, e.g. `8.0` &rarr; `8` or `x.10` &rarr; `x.1` (see https://github.com/actions/runner/issues/849)
- set development php.ini settings as setup-php uses production settings by default (see shivammathur/setup-php#450)