### PR TITLE
Add `ReturnTypeWillChange` to `Bugsnag\Breadcrumbs\Recorder`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ Changelog
 
 * Avoid JSON encoding event payloads more than once, where possible
   [#628](https://github.com/bugsnag/bugsnag-php/pull/628)
+* Add the `ReturnTypeWillChange` to `Bugsnag\Breadcrumbs\Recorder` to avoid a deprecation in PHP 8.1
+  [#630](https://github.com/bugsnag/bugsnag-php/pull/630)
 
 ## 3.26.0 (2021-02-10)
 

--- a/src/Breadcrumbs/Recorder.php
+++ b/src/Breadcrumbs/Recorder.php
@@ -85,6 +85,7 @@ class Recorder implements Countable, Iterator
      *
      * @return int
      */
+    #[\ReturnTypeWillChange]
     public function count()
     {
         return count($this->breadcrumbs);
@@ -95,6 +96,7 @@ class Recorder implements Countable, Iterator
      *
      * @return \Bugsnag\Breadcrumbs\Breadcrumb
      */
+    #[\ReturnTypeWillChange]
     public function current()
     {
         return $this->breadcrumbs[($this->head + $this->position) % static::MAX_ITEMS];
@@ -105,6 +107,7 @@ class Recorder implements Countable, Iterator
      *
      * @return int
      */
+    #[\ReturnTypeWillChange]
     public function key()
     {
         return $this->position;
@@ -115,6 +118,7 @@ class Recorder implements Countable, Iterator
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function next()
     {
         $this->position++;
@@ -125,6 +129,7 @@ class Recorder implements Countable, Iterator
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function rewind()
     {
         $this->position = 0;
@@ -135,6 +140,7 @@ class Recorder implements Countable, Iterator
      *
      * @return int
      */
+    #[\ReturnTypeWillChange]
     public function valid()
     {
         return $this->position < $this->count();


### PR DESCRIPTION
## Goal

This suppresses a deprecation in PHP 8.1 which causes CI to fail, added by the ["add return type declarations for internal methods" RFC](https://wiki.php.net/rfc/internal_method_return_types)

We may eventually need to avoid implementing `Countable`/`Iterator` in this class as it's not necessary and `ReturnTypeWillChange` may be removed at some point in the future. As that's _technically_ a BC break (though one that is unlikely to affect anyone as this class is unlikely to be used externally) I've opted not to do that yet