### PR TITLE
Support sending arguments with stacktraces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 Changelog
 =========
 
+## 3.27.0 (UPCOMING)
+
+### Enhancements
+
+* Support sending arguments with stack traces, disabled by default.
+  [#632](https://github.com/bugsnag/bugsnag-php/pull/632)
+
 ## 3.26.1 (2021-09-09)
 
 ### Fixes

--- a/src/Client.php
+++ b/src/Client.php
@@ -656,6 +656,30 @@ class Client
     }
 
     /**
+     * Sets whether arguments should be captured in stack traces.
+     *
+     * @param bool $sendArguments whether to send arguments to Bugsnag
+     *
+     * @return $this
+     */
+    public function setSendArguments($sendArguments)
+    {
+        $this->config->setSendArguments($sendArguments);
+
+        return $this;
+    }
+
+    /**
+     * Is sending arguments in stack traces enabled?
+     *
+     * @return bool
+     */
+    public function shouldSendArguments()
+    {
+        return $this->config->shouldSendArguments();
+    }
+
+    /**
      * Sets the notifier to report as to Bugsnag.
      *
      * This should only be set by other notifier libraries.

--- a/src/Configuration.php
+++ b/src/Configuration.php
@@ -78,6 +78,13 @@ class Configuration
     protected $sendCode = true;
 
     /**
+     * If argument sending is enabled.
+     *
+     * @var bool
+     */
+    protected $sendArguments = false;
+
+    /**
      * The notifier to report as.
      *
      * @var string[]
@@ -402,6 +409,30 @@ class Configuration
     public function shouldSendCode()
     {
         return $this->sendCode;
+    }
+
+    /**
+     * Sets whether arguments should be captured in stack traces.
+     *
+     * @param bool $sendArguments whether to send arguments to Bugsnag
+     *
+     * @return $this
+     */
+    public function setSendArguments($sendArguments)
+    {
+        $this->sendArguments = $sendArguments;
+
+        return $this;
+    }
+
+    /**
+     * Is sending arguments in stack traces enabled?
+     *
+     * @return bool
+     */
+    public function shouldSendArguments()
+    {
+        return $this->sendArguments;
     }
 
     /**

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -1036,6 +1036,16 @@ class ClientTest extends TestCase
         $this->assertFalse($client->shouldSendCode());
     }
 
+    public function testSendArguments()
+    {
+        $client = Client::make('foo');
+        $this->assertFalse($client->shouldSendArguments());
+        $this->assertSame($client, $client->setSendArguments(true));
+        $this->assertTrue($client->shouldSendArguments());
+        $this->assertSame($client, $client->setSendArguments(false));
+        $this->assertFalse($client->shouldSendArguments());
+    }
+
     public function testBuildEndpoint()
     {
         $client = Client::make('foo');

--- a/tests/StacktraceTest.php
+++ b/tests/StacktraceTest.php
@@ -274,4 +274,24 @@ class StacktraceTest extends TestCase
         $topFrame = $stacktrace[0];
         $this->assertArrayNotHasKey('code', $topFrame);
     }
+
+    public function testArgumentsEnabled()
+    {
+        $config = new Configuration('key');
+        $config->setSendArguments(true);
+
+        $stacktrace = Stacktrace::generate($config)->toArray();
+
+        $this->assertEquals('Bugsnag\Tests\StacktraceTest::testArgumentsEnabled()', $stacktrace[0]['method']);
+    }
+
+    public function testArgumentsDisabled()
+    {
+        $config = new Configuration('key');
+        $config->setSendArguments(false);
+
+        $stacktrace = Stacktrace::generate($config)->toArray();
+
+        $this->assertEquals('Bugsnag\Tests\StacktraceTest::testArgumentsDisabled', $stacktrace[0]['method']);
+    }
 }


### PR DESCRIPTION
## Goal

As a developer, I'd like to see the arguments passed to functions in stack trace frames to enable me to better understand what happened and how to reproduce the issue. Closes #519.

## Design

The `Configuration` class has a mechanism for toggling if code should be sent. We can copy this design to add support for toggling if argument values should be included. Objects, arrays and resources are represented by noting their type but not their value. Quite a rabbit hole otherwise...

## Changeset

New `setSendArguments` and `shouldSendArguments` functions. Disabled by default, so no change in functionality for existing users.

## Testing

Unit tests.