### PR TITLE
Remove 'ignore-platform-req' for PHP 8.1

### DIFF
--- a/.github/workflows/test-package.yml
+++ b/.github/workflows/test-package.yml
@@ -21,7 +21,6 @@ jobs:
           guzzle-version: '^7.0'
         - php-version: '8.1'
           guzzle-version: '^7.0'
-          composer-flags: '--ignore-platform-req php'
 
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
## Goal

All of our dependencies can now run on PHP 8.1, which has just released, so we don't need the `--ignore-platform-req` flag anymore