### PR TITLE
Fix PHAR build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,9 @@
-FROM php:5.5.38-alpine
+FROM php:5.5-alpine
 
 ENV COMPOSER_ALLOW_SUPERUSER 1
 
-RUN curl -sS https://getcomposer.org/installer | php \
-    && mv composer.phar /usr/local/bin/composer
+RUN apk update && apk upgrade
+
+COPY --from=composer:2 /usr/bin/composer /usr/bin/composer
 
 ENTRYPOINT ["php"]

--- a/package.sh
+++ b/package.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 if [[ "$(docker images -q bugsnag/php:5.5 2> /dev/null)" == "" ]]; then
-    docker pull php:5.5.38-alpine
+    docker pull php:5.5-alpine
     docker build --no-cache -t bugsnag/php:5.5 .
 fi
 


### PR DESCRIPTION
## Goal

The CA certs in the docker image have finally expired so anything using SSL stopped working

Updating the packages fixes this as it pulls in new versions of curl/libssl/ca-certificates and friends

I've also switched over to copying Composer from their docker image as it's a bit faster than downloading & installing it, especially once cached