### PR TITLE
Add PHPStan at level 6

### DIFF
--- a/.github/workflows/test-package.yml
+++ b/.github/workflows/test-package.yml
@@ -49,3 +49,42 @@ jobs:
       run: composer update --prefer-dist --no-progress --no-suggest --no-interaction ${{ matrix.composer-flags }}
 
     - run: composer run-script test
+
+  phpstan:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        # TODO: we likely have to care about Guzzle's version too - ideally we'd
+        #       check our use of Guzzle is correct on each version
+        php-version: ['7.1', '8.1']
+        phpstan-version: ['~1.4']
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: install PHP
+      uses: shivammathur/setup-php@v2
+      with:
+        php-version: ${{ matrix.php-version }}
+        coverage: none
+        extensions: intl, mbstring
+        # by default setup-php uses a production php.ini so force development values
+        ini-values: >-
+          zend.exception_ignore_args=Off,
+          zend.exception_string_param_max_len=15,
+          error_reporting=-1,
+          display_errors=On,
+          display_startup_errors=On,
+          zend.assertions=1
+
+    # - name: require guzzle
+    #   run: composer require "guzzlehttp/guzzle:${{ matrix.guzzle-version }}" --no-update ${{ matrix.composer-flags }}
+
+    - name: require phpstan
+      run: composer require "phpstan/phpstan:${{ matrix.phpstan-version }}" --no-update ${{ matrix.composer-flags }}
+
+    - name: install dependencies
+      run: composer update --prefer-dist --no-progress --no-suggest --no-interaction ${{ matrix.composer-flags }}
+
+    - run: ./vendor/bin/phpstan

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,15 @@
 Changelog
 =========
 
+## TBD
+
+### Fixes
+
+* A number of errors in docblocks have been corrected
+  [xPaw](https://github.com/xPaw)
+  [#633](https://github.com/bugsnag/bugsnag-php/pull/633)
+  [#637](https://github.com/bugsnag/bugsnag-php/pull/637)
+
 ## 3.26.1 (2021-09-09)
 
 ### Fixes

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -5,3 +5,9 @@ parameters:
 
     paths:
         - src/
+
+    ignoreErrors:
+        -
+            message: "#^Property Bugsnag\\\\Handler\\:\\:\\$reservedMemory is never read, only written\\.$#"
+            count: 1
+            path: src/Handler.php

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,5 +1,5 @@
 parameters:
-    level: 1
+    level: 2
 
     treatPhpDocTypesAsCertain: false
 

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,5 +1,5 @@
 parameters:
-    level: 4
+    level: 5
 
     treatPhpDocTypesAsCertain: false
 

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,5 +1,5 @@
 parameters:
-    level: 2
+    level: 3
 
     treatPhpDocTypesAsCertain: false
 

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,0 +1,7 @@
+parameters:
+    level: 1
+
+    treatPhpDocTypesAsCertain: false
+
+    paths:
+        - src/

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,7 +1,8 @@
 parameters:
-    level: 5
+    level: 6
 
     treatPhpDocTypesAsCertain: false
+    checkMissingIterableValueType: false # TODO: remove this!
 
     paths:
         - src/

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,5 +1,5 @@
 parameters:
-    level: 3
+    level: 4
 
     treatPhpDocTypesAsCertain: false
 

--- a/src/Breadcrumbs/Recorder.php
+++ b/src/Breadcrumbs/Recorder.php
@@ -5,6 +5,9 @@ namespace Bugsnag\Breadcrumbs;
 use Countable;
 use Iterator;
 
+/**
+ * @implements Iterator<int, Breadcrumb>
+ */
 class Recorder implements Countable, Iterator
 {
     /**

--- a/src/Breadcrumbs/Recorder.php
+++ b/src/Breadcrumbs/Recorder.php
@@ -138,7 +138,7 @@ class Recorder implements Countable, Iterator
     /**
      * Is the current key position set?
      *
-     * @return int
+     * @return bool
      */
     #[\ReturnTypeWillChange]
     public function valid()

--- a/src/Client.php
+++ b/src/Client.php
@@ -949,6 +949,8 @@ class Client
      * This is an amount of bytes or 'null' to disable increasing the limit.
      *
      * @param int|null $value
+     *
+     * @return Configuration
      */
     public function setMemoryLimitIncrease($value)
     {

--- a/src/Client.php
+++ b/src/Client.php
@@ -471,7 +471,7 @@ class Client
     /**
      * Get the Bugsnag API Key.
      *
-     * @var string
+     * @return string
      */
     public function getApiKey()
     {
@@ -551,7 +551,7 @@ class Client
      *
      * @deprecated Use redactedKeys instead
      *
-     * @var string[]
+     * @return string[]
      */
     public function getFilters()
     {
@@ -675,7 +675,7 @@ class Client
     /**
      * Get the notifier to report as to Bugsnag.
      *
-     * @var string[]
+     * @return string[]
      */
     public function getNotifier()
     {
@@ -986,7 +986,7 @@ class Client
      *
      * This can contain both fully qualified class names and regular expressions.
      *
-     * @var array
+     * @return array
      */
     public function getDiscardClasses()
     {
@@ -1010,7 +1010,7 @@ class Client
     /**
      * Get the array of metadata keys that should be redacted.
      *
-     * @var string[]
+     * @return string[]
      */
     public function getRedactedKeys()
     {

--- a/src/Client.php
+++ b/src/Client.php
@@ -105,6 +105,7 @@ class Client
         $config = new Configuration($apiKey ?: $env->get('BUGSNAG_API_KEY'));
         $guzzle = static::makeGuzzle($notifyEndpoint ?: $env->get('BUGSNAG_ENDPOINT'));
 
+        // @phpstan-ignore-next-line
         $client = new static($config, null, $guzzle);
 
         if ($defaults) {

--- a/src/Client.php
+++ b/src/Client.php
@@ -587,7 +587,7 @@ class Client
      *
      * @param string $file
      *
-     * @return string
+     * @return bool
      */
     public function isInProject($file)
     {

--- a/src/Configuration.php
+++ b/src/Configuration.php
@@ -804,6 +804,8 @@ class Configuration
      * This is an amount of bytes or 'null' to disable increasing the limit.
      *
      * @param int|null $value
+     *
+     * @return $this
      */
     public function setMemoryLimitIncrease($value)
     {

--- a/src/Configuration.php
+++ b/src/Configuration.php
@@ -330,7 +330,7 @@ class Configuration
      *
      * @param string $file
      *
-     * @return string
+     * @return bool
      */
     public function isInProject($file)
     {

--- a/src/Configuration.php
+++ b/src/Configuration.php
@@ -317,7 +317,7 @@ class Configuration
      */
     public function setProjectRootRegex($projectRootRegex)
     {
-        if ($projectRootRegex && @preg_match($projectRootRegex, null) === false) {
+        if ($projectRootRegex && @preg_match($projectRootRegex, '') === false) {
             throw new InvalidArgumentException('Invalid project root regex: '.$projectRootRegex);
         }
 
@@ -359,7 +359,7 @@ class Configuration
      */
     public function setStripPathRegex($stripPathRegex)
     {
-        if ($stripPathRegex && @preg_match($stripPathRegex, null) === false) {
+        if ($stripPathRegex && @preg_match($stripPathRegex, '') === false) {
             throw new InvalidArgumentException('Invalid strip path regex: '.$stripPathRegex);
         }
 

--- a/src/Configuration.php
+++ b/src/Configuration.php
@@ -204,7 +204,7 @@ class Configuration
     /**
      * Get the Bugsnag API Key.
      *
-     * @var string
+     * @return string
      */
     public function getApiKey()
     {
@@ -288,7 +288,7 @@ class Configuration
      *
      * @deprecated Use redactedKeys instead
      *
-     * @var string[]
+     * @return string[]
      */
     public function getFilters()
     {
@@ -423,7 +423,7 @@ class Configuration
     /**
      * Get the notifier to report as to Bugsnag.
      *
-     * @var string[]
+     * @return string[]
      */
     public function getNotifier()
     {
@@ -843,7 +843,7 @@ class Configuration
      *
      * This can contain both fully qualified class names and regular expressions.
      *
-     * @var array
+     * @return array
      */
     public function getDiscardClasses()
     {
@@ -867,7 +867,7 @@ class Configuration
     /**
      * Get the array of metadata keys that should be redacted.
      *
-     * @var string[]
+     * @return string[]
      */
     public function getRedactedKeys()
     {

--- a/src/Configuration.php
+++ b/src/Configuration.php
@@ -133,7 +133,7 @@ class Configuration
     /**
      * A client to use to send sessions.
      *
-     * @var \GuzzleHttp\ClientInterface
+     * @var \GuzzleHttp\ClientInterface|null
      *
      * @deprecated This will be removed in the next major version.
      */

--- a/src/Handler.php
+++ b/src/Handler.php
@@ -311,8 +311,9 @@ class Handler
             && preg_match($this->oomRegex, $lastError['message'], $matches) === 1
         ) {
             $currentMemoryLimit = (int) $matches[1];
+            $newMemoryLimit = $currentMemoryLimit + $this->client->getMemoryLimitIncrease();
 
-            ini_set('memory_limit', $currentMemoryLimit + $this->client->getMemoryLimitIncrease());
+            ini_set('memory_limit', (string) $newMemoryLimit);
         }
 
         // Check if a fatal error caused this shutdown

--- a/src/Handler.php
+++ b/src/Handler.php
@@ -70,6 +70,7 @@ class Handler
             $client = Client::make($client);
         }
 
+        // @phpstan-ignore-next-line
         $handler = new static($client);
         $handler->registerBugsnagHandlers(true);
 

--- a/src/Handler.php
+++ b/src/Handler.php
@@ -197,6 +197,9 @@ class Handler
 
             return;
         } catch (Throwable $exceptionFromPreviousHandler) {
+            // TODO: if we drop support for PHP 5, we can remove this catch, which
+            //       fixes the PHPStan issue here
+            // @phpstan-ignore-next-line
         } catch (Exception $exceptionFromPreviousHandler) {
         }
 

--- a/src/HttpClient.php
+++ b/src/HttpClient.php
@@ -270,6 +270,8 @@ class HttpClient
     protected function post($uri, array $options = [])
     {
         if (GuzzleCompat::isUsingGuzzle5()) {
+            // TODO: validate this by running PHPStan with Guzzle 5
+            // @phpstan-ignore-next-line
             $this->guzzle->post($uri, $options);
         } else {
             $this->guzzle->request('POST', $uri, $options);

--- a/src/HttpClient.php
+++ b/src/HttpClient.php
@@ -262,8 +262,8 @@ class HttpClient
     /**
      * Send a POST request to Bugsnag.
      *
-     * @param string $uri  the uri to hit
-     * @param array  $data the request options
+     * @param string $uri the uri to hit
+     * @param array $options the request options
      *
      * @return void
      */

--- a/src/Internal/GuzzleCompat.php
+++ b/src/Internal/GuzzleCompat.php
@@ -43,8 +43,9 @@ final class GuzzleCompat
      */
     public static function getBaseUri(GuzzleHttp\ClientInterface $guzzle)
     {
+        // TODO: validate this by running PHPStan with Guzzle 5
         return self::isUsingGuzzle5()
-            ? $guzzle->getBaseUrl()
+            ? $guzzle->getBaseUrl() // @phpstan-ignore-line
             : $guzzle->getConfig(self::getBaseUriOptionName());
     }
 

--- a/src/Report.php
+++ b/src/Report.php
@@ -749,7 +749,7 @@ class Report
      * @param mixed $obj        the data to cleanup
      * @param bool  $isMetaData if it is meta data
      *
-     * @return array|null
+     * @return mixed
      */
     protected function cleanupObj($obj, $isMetaData)
     {

--- a/src/Report.php
+++ b/src/Report.php
@@ -143,6 +143,7 @@ class Report
      */
     public static function fromPHPError(Configuration $config, $code, $message, $file, $line, $fatal = false)
     {
+        // @phpstan-ignore-next-line
         $report = new static($config);
 
         $report->setPHPError($code, $message, $file, $line, $fatal)
@@ -162,6 +163,7 @@ class Report
      */
     public static function fromPHPThrowable(Configuration $config, $throwable)
     {
+        // @phpstan-ignore-next-line
         $report = new static($config);
 
         $report->setPHPThrowable($throwable)
@@ -182,6 +184,7 @@ class Report
      */
     public static function fromNamedError(Configuration $config, $name, $message = null)
     {
+        // @phpstan-ignore-next-line
         $report = new static($config);
 
         $report->setName($name)

--- a/src/Report.php
+++ b/src/Report.php
@@ -754,7 +754,7 @@ class Report
     protected function cleanupObj($obj, $isMetaData)
     {
         if (is_null($obj)) {
-            return;
+            return null;
         }
 
         if (is_array($obj)) {

--- a/src/Report.php
+++ b/src/Report.php
@@ -125,7 +125,7 @@ class Report
     /**
      * Attached session from SessionTracking.
      *
-     * @var array
+     * @var array|null
      */
     protected $session;
 

--- a/src/Report.php
+++ b/src/Report.php
@@ -337,6 +337,8 @@ class Report
     /**
      * Sets the unhandled flag.
      *
+     * @param bool $unhandled
+     *
      * @return $this
      */
     public function setUnhandled($unhandled)

--- a/src/Report.php
+++ b/src/Report.php
@@ -640,7 +640,7 @@ class Report
     /**
      * Sets the session data.
      *
-     * @return $this
+     * @return void
      */
     public function setSessionData(array $session)
     {

--- a/src/Report.php
+++ b/src/Report.php
@@ -232,6 +232,9 @@ class Report
      */
     public function setPHPThrowable($throwable)
     {
+        // TODO: if we drop support for PHP 5, we can remove this check for
+        //       'Exception', which fixes the PHPStan issue here
+        // @phpstan-ignore-next-line
         if (!$throwable instanceof Throwable && !$throwable instanceof Exception) {
             throw new InvalidArgumentException('The throwable must implement Throwable or extend Exception.');
         }

--- a/src/Request/BasicResolver.php
+++ b/src/Request/BasicResolver.php
@@ -130,7 +130,7 @@ class BasicResolver implements ResolverInterface
     protected static function parseInput(array $server, $input)
     {
         if (!$input) {
-            return;
+            return null;
         }
 
         if (isset($server['CONTENT_TYPE']) && stripos($server['CONTENT_TYPE'], 'application/json') === 0) {
@@ -142,5 +142,7 @@ class BasicResolver implements ResolverInterface
 
             return (array) $params ?: null;
         }
+
+        return null;
     }
 }

--- a/src/Request/ConsoleRequest.php
+++ b/src/Request/ConsoleRequest.php
@@ -103,5 +103,6 @@ class ConsoleRequest implements RequestInterface
      */
     public function getUserId()
     {
+        return null;
     }
 }

--- a/src/Request/NullRequest.php
+++ b/src/Request/NullRequest.php
@@ -51,7 +51,7 @@ class NullRequest implements RequestInterface
      */
     public function getContext()
     {
-        //
+        return null;
     }
 
     /**
@@ -61,6 +61,6 @@ class NullRequest implements RequestInterface
      */
     public function getUserId()
     {
-        //
+        return null;
     }
 }

--- a/src/Request/PhpRequest.php
+++ b/src/Request/PhpRequest.php
@@ -129,6 +129,8 @@ class PhpRequest implements RequestInterface
         if (isset($this->server['REQUEST_METHOD']) && isset($this->server['REQUEST_URI'])) {
             return $this->server['REQUEST_METHOD'].' '.strtok($this->server['REQUEST_URI'], '?');
         }
+
+        return null;
     }
 
     /**
@@ -169,5 +171,7 @@ class PhpRequest implements RequestInterface
         if (isset($this->server['REMOTE_ADDR'])) {
             return $this->server['REMOTE_ADDR'];
         }
+
+        return null;
     }
 }

--- a/src/SessionTracker.php
+++ b/src/SessionTracker.php
@@ -11,26 +11,36 @@ class SessionTracker
      * The current session payload version.
      *
      * @deprecated Use {HttpClient::SESSION_PAYLOAD_VERSION} instead.
+     *
+     * @var string
      */
     protected static $SESSION_PAYLOAD_VERSION = HttpClient::SESSION_PAYLOAD_VERSION;
 
     /**
      * The amount of time between each sending attempt.
+     *
+     * @var int
      */
     protected static $DELIVERY_INTERVAL = 30;
 
     /**
      * The maximum amount of sessions to hold onto.
+     *
+     * @var int
      */
     protected static $MAX_SESSION_COUNT = 50;
 
     /**
      * The key for storing session counts.
+     *
+     * @var string
      */
     protected static $SESSION_COUNTS_KEY = 'bugsnag-session-counts';
 
     /**
      * The key for storing last sent data.
+     *
+     * @var string
      */
     protected static $SESSIONS_LAST_SENT_KEY = 'bugsnag-sessions-last-sent';
 

--- a/src/SessionTracker.php
+++ b/src/SessionTracker.php
@@ -117,6 +117,8 @@ class SessionTracker
     /**
      * @param Configuration $config
      *
+     * @return void
+     *
      * @deprecated Change the Configuration via the Client object instead.
      */
     public function setConfig(Configuration $config)

--- a/src/Stacktrace.php
+++ b/src/Stacktrace.php
@@ -225,7 +225,7 @@ class Stacktrace
     protected function getCode($path, $line, $numLines)
     {
         if (empty($path) || empty($line) || !file_exists($path)) {
-            return;
+            return null;
         }
 
         try {
@@ -244,7 +244,7 @@ class Stacktrace
 
             return $code;
         } catch (RuntimeException $ex) {
-            // do nothing
+            return null;
         }
     }
 

--- a/src/Stacktrace.php
+++ b/src/Stacktrace.php
@@ -74,7 +74,7 @@ class Stacktrace
      *
      * @param \Bugsnag\Configuration $config    the configuration instance
      * @param array                  $backtrace the associated backtrace
-     * @param int                    $topFile   the top file to use
+     * @param string                 $topFile   the top file to use
      * @param int                    $topLine   the top line to use
      *
      * @return static

--- a/src/Stacktrace.php
+++ b/src/Stacktrace.php
@@ -62,6 +62,7 @@ class Stacktrace
      */
     public static function fromFrame(Configuration $config, $file, $line)
     {
+        // @phpstan-ignore-next-line
         $stacktrace = new static($config);
         $stacktrace->addFrame($file, $line, '[unknown]');
 
@@ -80,6 +81,7 @@ class Stacktrace
      */
     public static function fromBacktrace(Configuration $config, array $backtrace, $topFile, $topLine)
     {
+        // @phpstan-ignore-next-line
         $stacktrace = new static($config);
 
         // PHP backtrace's are misaligned, we need to shift the file/line down a frame

--- a/src/Stacktrace.php
+++ b/src/Stacktrace.php
@@ -216,9 +216,9 @@ class Stacktrace
     /**
      * Extract the code for the given file and lines.
      *
-     * @param string $path     the path to the file
-     * @param int    $line     the line to centre about
-     * @param string $numLines the number of lines to fetch
+     * @param string $path the path to the file
+     * @param int $line the line to centre about
+     * @param int $numLines the number of lines to fetch
      *
      * @return string[]|null
      */
@@ -251,9 +251,9 @@ class Stacktrace
     /**
      * Get the start and end positions for the given line.
      *
-     * @param int    $line the line to centre about
-     * @param string $num  the number of lines to fetch
-     * @param int    $max  the maximum line number
+     * @param int $line the line to centre about
+     * @param int $num the number of lines to fetch
+     * @param int $max the maximum line number
      *
      * @return int[]
      */


### PR DESCRIPTION
## Goal

PHPStan is a static analyser for PHP that can [catch a bunch of potential bugs in code](https://phpstan.org/blog/find-bugs-in-your-code-without-writing-tests)

This PR is based on https://github.com/bugsnag/bugsnag-php/pull/633, but runs at level 6 instead of max — PHPStan has 9 error levels (currently) that go from loosest (1) - strictest (9)

For the most part this is only changes to comments, but there are a couple of code changes too:

- methods that can return `null` need an explicit `return null` statement — a bare `return` or no `return` at all [are both errors](https://phpstan.org/r/37d47edc-c51c-40b8-b32a-652994a843c0)
- passing an `int` to `ini_set` and passing `null` to `preg_match` are flagged as errors, so these have been fixed

Additionally, some errors have been ignored:

- some of our Guzzle compatibility code errors because we check for methods that don't exist on new versions. We'll need to run PHPStan against multiple versions of Guzzle to fully check these (this will be done in a future PR)
- some code exists for PHP 5 compatibility, but PHPStan doesn't run on PHP <7.1 so this errors as well. When we drop PHP 5 support we can also remove this compatibility code, which will solve these errors
- we use `new static(...)` in a few places, which is unsafe as there's guarantee that child classes will share the same constructor signature ([see this article](https://phpstan.org/blog/solving-phpstan-error-unsafe-usage-of-new-static)). We can't fix this without a potential BC break, so have to ignore this for now

## Design

This PR stops at level 6 because this is where the levels become tricky to update to. Level 6 specifically adds checking for iterable types, e.g. a bare `array` should really be `array<KeyType, ValueType>`. I've turned this option off for now as we get around 100 errors from it, but this will be turned on in a future PR. Until then, I've not advanced any further as additional errors can appear as a consequence of adding stricter iterable types

## Testing

PHPStan now runs on CI on both PHP 7.1 & 8.1