### PR TITLE
Support enums in metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ Changelog
   [xPaw](https://github.com/xPaw)
   [#633](https://github.com/bugsnag/bugsnag-php/pull/633)
   [#637](https://github.com/bugsnag/bugsnag-php/pull/637)
+* Handle serialising pure enums when added as metadata. Previously a pure enum would be JSON encoded as `null`, but will now be converted to a string like `EnumName::CaseName`
+  [#639](https://github.com/bugsnag/bugsnag-php/pull/639)
 
 ## 3.26.1 (2021-09-09)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@ Changelog
 
 ## TBD
 
+### Enhancements
+
+* Improve serialisation of backed enums. Previously a backed enum would JSON encode to their backing value, but will now include the enum name like `EnumName::CaseName (value)`
+  [#639](https://github.com/bugsnag/bugsnag-php/pull/639)
+
 ### Fixes
 
 * A number of errors in docblocks have been corrected

--- a/phpstan/baseline-less-than-8.1.neon
+++ b/phpstan/baseline-less-than-8.1.neon
@@ -1,2 +1,7 @@
 parameters:
-    ignoreErrors: []
+    ignoreErrors:
+        - '#Class UnitEnum not found\.#'
+        - '#.*invalid type UnitEnum\.#'
+        - '#.*unknown class UnitEnum\.#'
+        - '#Class BackedEnum not found\.#'
+        - '#.*unknown class BackedEnum\.#'

--- a/src/Report.php
+++ b/src/Report.php
@@ -779,7 +779,7 @@ class Report
         }
 
         if (is_object($obj)) {
-            if ($obj instanceof UnitEnum && !$obj instanceof BackedEnum) {
+            if ($obj instanceof UnitEnum) {
                 return $this->enumToString($obj);
             }
 
@@ -850,6 +850,13 @@ class Report
     private function enumToString(UnitEnum $enum)
     {
         // e.g. My\Enum::SomeCase
-        return sprintf('%s::%s', get_class($enum), $enum->name);
+        $string = sprintf('%s::%s', get_class($enum), $enum->name);
+
+        // add the value, if there is one
+        if ($enum instanceof BackedEnum) {
+            $string .= sprintf(' (%s)', $enum->value);
+        }
+
+        return $string;
     }
 }

--- a/src/Report.php
+++ b/src/Report.php
@@ -2,11 +2,13 @@
 
 namespace Bugsnag;
 
+use BackedEnum;
 use Bugsnag\Breadcrumbs\Breadcrumb;
 use Bugsnag\DateTime\Date;
 use Exception;
 use InvalidArgumentException;
 use Throwable;
+use UnitEnum;
 
 class Report
 {
@@ -777,6 +779,10 @@ class Report
         }
 
         if (is_object($obj)) {
+            if ($obj instanceof UnitEnum && !$obj instanceof BackedEnum) {
+                return $this->enumToString($obj);
+            }
+
             return $this->cleanupObj(json_decode(json_encode($obj), true), $isMetaData);
         }
 
@@ -832,5 +838,18 @@ class Report
         }
 
         return $array;
+    }
+
+    /**
+     * Convert the given enum to a string.
+     *
+     * @param UnitEnum $enum
+     *
+     * @return string
+     */
+    private function enumToString(UnitEnum $enum)
+    {
+        // e.g. My\Enum::SomeCase
+        return sprintf('%s::%s', get_class($enum), $enum->name);
     }
 }

--- a/tests/phpt/php8.1/backed_enums_can_be_added_as_metadata.phpt
+++ b/tests/phpt/php8.1/backed_enums_can_be_added_as_metadata.phpt
@@ -30,7 +30,7 @@ var_dump($client->getMetaData()['data']);
 echo "\n";
 
 $client->notifyException(new \Exception('hello'), function (\Bugsnag\Report $report): void {
-    echo "Backed enums should serialise to their backing value\n";
+    echo "Backed enums should be converted to string representation when serialised\n";
     var_dump($report->toArray()['metaData']['data']);
     echo "\n";
 });
@@ -54,16 +54,16 @@ array(4) {
   enum(Some\Namespace\IntBackedEnum::Circle)
 }
 
-Backed enums should serialise to their backing value
+Backed enums should be converted to string representation when serialised
 array(4) {
   ["admin"]=>
-  string(5) "admin"
+  string(46) "Some\Namespace\StringBackedEnum::Admin (admin)"
   ["user"]=>
-  string(4) "user"
+  string(44) "Some\Namespace\StringBackedEnum::User (user)"
   ["square"]=>
-  int(1)
+  string(40) "Some\Namespace\IntBackedEnum::Square (1)"
   ["circle"]=>
-  int(2)
+  string(40) "Some\Namespace\IntBackedEnum::Circle (2)"
 }
 
 Guzzle request made (1 event)!

--- a/tests/phpt/php8.1/backed_enums_can_be_added_as_metadata.phpt
+++ b/tests/phpt/php8.1/backed_enums_can_be_added_as_metadata.phpt
@@ -1,0 +1,73 @@
+--TEST--
+Backed enums can be added as metadata
+--FILE--
+<?php
+namespace Some\Namespace;
+
+enum StringBackedEnum: string {
+    case Admin = 'admin';
+    case User = 'user';
+}
+
+enum IntBackedEnum: int {
+    case Square = 1;
+    case Circle = 2;
+}
+
+$client = require __DIR__ . '/../_prelude.php';
+
+$client->setMetaData([
+    'data' => [
+        'admin' => StringBackedEnum::Admin,
+        'user' => StringBackedEnum::User,
+        'square' => IntBackedEnum::Square,
+        'circle' => IntBackedEnum::Circle,
+    ],
+]);
+
+echo "Backed enums should be stored as objects\n";
+var_dump($client->getMetaData()['data']);
+echo "\n";
+
+$client->notifyException(new \Exception('hello'), function (\Bugsnag\Report $report): void {
+    echo "Backed enums should serialise to their backing value\n";
+    var_dump($report->toArray()['metaData']['data']);
+    echo "\n";
+});
+?>
+--SKIPIF--
+<?php
+if (version_compare(PHP_VERSION, '8.1.0', '<')) {
+    echo 'SKIP — this test requires PHP 8.1+ for enum support';
+}
+?>
+--EXPECTF--
+Backed enums should be stored as objects
+array(4) {
+  ["admin"]=>
+  enum(Some\Namespace\StringBackedEnum::Admin)
+  ["user"]=>
+  enum(Some\Namespace\StringBackedEnum::User)
+  ["square"]=>
+  enum(Some\Namespace\IntBackedEnum::Square)
+  ["circle"]=>
+  enum(Some\Namespace\IntBackedEnum::Circle)
+}
+
+Backed enums should serialise to their backing value
+array(4) {
+  ["admin"]=>
+  string(5) "admin"
+  ["user"]=>
+  string(4) "user"
+  ["square"]=>
+  int(1)
+  ["circle"]=>
+  int(2)
+}
+
+Guzzle request made (1 event)!
+* Method: 'POST'
+* URI: 'http://localhost/notify'
+* Events:
+    - hello

--- a/tests/phpt/php8.1/pure_enums_can_be_added_as_metadata.phpt
+++ b/tests/phpt/php8.1/pure_enums_can_be_added_as_metadata.phpt
@@ -1,0 +1,86 @@
+--TEST--
+Pure enums can be added as metadata
+--FILE--
+<?php
+namespace Some\Namespace;
+
+enum MyPureEnum {
+    case TheFirstCase;
+    case SecondCase;
+    case CaseNumberThree;
+}
+
+namespace Another\Namespace;
+
+enum AnotherPureEnum {
+    case One;
+    case Two;
+}
+
+$client = require __DIR__ . '/../_prelude.php';
+
+$client->setMetaData([
+    'data' => [
+        'first case' => \Some\Namespace\MyPureEnum::TheFirstCase,
+        'second case' => \Some\Namespace\MyPureEnum::SecondCase,
+        'third case' => \Some\Namespace\MyPureEnum::CaseNumberThree,
+        'unrelated thing' => 'yes',
+        'case one' => \Another\Namespace\AnotherPureEnum::One,
+        'case two' => \Another\Namespace\AnotherPureEnum::Two,
+    ],
+]);
+
+echo "Pure enums should be stored as objects\n";
+var_dump($client->getMetaData()['data']);
+echo "\n";
+
+$client->notifyException(new \Exception('hello'), function (\Bugsnag\Report $report): void {
+    echo "Pure enums should be converted to a string representation when serialised\n";
+    var_dump($report->toArray()['metaData']['data']);
+    echo "\n";
+});
+?>
+--SKIPIF--
+<?php
+if (version_compare(PHP_VERSION, '8.1.0', '<')) {
+    echo 'SKIP — this test requires PHP 8.1+ for enum support';
+}
+?>
+--EXPECTF--
+Pure enums should be stored as objects
+array(6) {
+  ["first case"]=>
+  enum(Some\Namespace\MyPureEnum::TheFirstCase)
+  ["second case"]=>
+  enum(Some\Namespace\MyPureEnum::SecondCase)
+  ["third case"]=>
+  enum(Some\Namespace\MyPureEnum::CaseNumberThree)
+  ["unrelated thing"]=>
+  string(3) "yes"
+  ["case one"]=>
+  enum(Another\Namespace\AnotherPureEnum::One)
+  ["case two"]=>
+  enum(Another\Namespace\AnotherPureEnum::Two)
+}
+
+Pure enums should be converted to a string representation when serialised
+array(6) {
+  ["first case"]=>
+  string(39) "Some\Namespace\MyPureEnum::TheFirstCase"
+  ["second case"]=>
+  string(37) "Some\Namespace\MyPureEnum::SecondCase"
+  ["third case"]=>
+  string(42) "Some\Namespace\MyPureEnum::CaseNumberThree"
+  ["unrelated thing"]=>
+  string(3) "yes"
+  ["case one"]=>
+  string(38) "Another\Namespace\AnotherPureEnum::One"
+  ["case two"]=>
+  string(38) "Another\Namespace\AnotherPureEnum::Two"
+}
+
+Guzzle request made (1 event)!
+* Method: 'POST'
+* URI: 'http://localhost/notify'
+* Events:
+    - hello


### PR DESCRIPTION
## Goal

This PR improves our handling of enums when added as metadata

PHP has two types of enums, "pure" and "backed". A pure enum contains only cases with no values, whereas a backed enum has a string or int value for each case. For example:

```php
enum PureEnum {
    case One;
    case Two;
}

enum StringBackedEnum: string {
    case One = 'one';
    case Two = 'two';
}

enum IntBackedEnum: int {
    case One = 1;
    case Two = 2;
}
```

Currently when a pure enum is added as metadata it falls into our generic object handling, which ends up converting it to `null` as [there is no default serialisation for pure enums](https://3v4l.org/CinD6#v8.1.2)

This PR fixes this by converting the enum to a string in the form `EnumName::CaseName`, e.g. `PureEnum::One` using the example above

Backed enums aren't broken as they are converted into their backing values, e.g. `StringBackedEnum::One` is serialised as the string `one`. This could be improved however, given the enum name is usually more important than the raw value

This PR changes backed enums to be serialised in the form `EnumName::CaseName (value)`, e.g. `IntBackedEnum::One (1)`

These changes result in the following being shown in the Bugsnag dashboard:

<img width="513" alt="image" src="https://user-images.githubusercontent.com/282732/152200249-2c710dab-2dcf-4254-bc97-0df0227ca28c.png">

## Testing

Two new PHPT tests have been added; one that tests pure enums and one that tests backed enums. PHPT tests are being used because PHP versions without enum support will fail to compile files that declare enums, making it a bit awkward to unit test