### PR TITLE
Swap use of deprecated `strftime` to `date`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ Changelog
   [#637](https://github.com/bugsnag/bugsnag-php/pull/637)
 * Handle serialising pure enums when added as metadata. Previously a pure enum would be JSON encoded as `null`, but will now be converted to a string like `EnumName::CaseName`
   [#639](https://github.com/bugsnag/bugsnag-php/pull/639)
+* Remove use of the deprecated `strftime` function
+  [#640](https://github.com/bugsnag/bugsnag-php/pull/640)
 
 ## 3.26.1 (2021-09-09)
 

--- a/src/SessionTracker.php
+++ b/src/SessionTracker.php
@@ -141,7 +141,7 @@ class SessionTracker
      */
     public function startSession()
     {
-        $currentTime = strftime('%Y-%m-%dT%H:%M:00');
+        $currentTime = date('Y-m-d\TH:i:00');
 
         $session = [
             'id' => uniqid('', true),

--- a/tests/SessionTrackerTest.php
+++ b/tests/SessionTrackerTest.php
@@ -501,7 +501,7 @@ class SessionTrackerTest extends TestCase
     }
 
     /**
-     * @runInSeparateProcess as we need to mock 'strftime' and 'time'
+     * @runInSeparateProcess as we need to mock 'date' and 'time'
      */
     public function testThereIsAMaximumNumberOfSessionsThatWillBeSent()
     {
@@ -544,7 +544,7 @@ class SessionTrackerTest extends TestCase
             ->method('sendSessions')
             ->with($this->callback($expectCallback));
 
-        $strftimeReturnValues = array_map(
+        $dateReturnValues = array_map(
             function ($minute) {
                 $minute = str_pad($minute, 2, '0', STR_PAD_LEFT);
 
@@ -556,11 +556,11 @@ class SessionTrackerTest extends TestCase
 
         $invocation = 0;
 
-        $strftime = $this->getFunctionMock('Bugsnag', 'strftime');
-        $strftime->expects($this->exactly($sessionsToGenerate))
+        $date = $this->getFunctionMock('Bugsnag', 'date');
+        $date->expects($this->exactly($sessionsToGenerate))
             ->withAnyParameters()
-            ->willReturnCallback(function () use ($strftimeReturnValues, &$invocation) {
-                return $strftimeReturnValues[$invocation++];
+            ->willReturnCallback(function () use ($dateReturnValues, &$invocation) {
+                return $dateReturnValues[$invocation++];
             });
 
         // Mock 'time' to return a negative value, which will stop 'startSession'


### PR DESCRIPTION
## Goal

PHP 8.1 deprecated `strftime`, which we were using to get the current minute for counting sessions. This is easily replaced with the `date` function: https://3v4l.org/GkoF3

```php
var_dump(strftime('%Y-%m-%dT%H:%M:00')); // => 2022-02-03T10:49:00
var_dump(date('Y-m-d\TH:i:00')); // => 2022-02-03T10:49:00
```

This should have caused unit tests to fail, but didn't. This is because the `SessionTrackerTest` runs after the `HandlerTest`, which registers error handlers that affect PHPUnit's reporting of the deprecation. This will be fixed in a separate PR