### PR TITLE
Fix session throttling when storage backend doesn't store integers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ Changelog
   [#639](https://github.com/bugsnag/bugsnag-php/pull/639)
 * Remove use of the deprecated `strftime` function
   [#640](https://github.com/bugsnag/bugsnag-php/pull/640)
+* Fix session throttling when storage backend doesn't store integers
+  [#643](https://github.com/bugsnag/bugsnag-php/pull/643)
 
 ## 3.26.1 (2021-09-09)
 

--- a/src/SessionTracker.php
+++ b/src/SessionTracker.php
@@ -437,8 +437,12 @@ class SessionTracker
         if (is_callable($this->storageFunction)) {
             $lastSent = call_user_func($this->storageFunction, self::$SESSIONS_LAST_SENT_KEY);
 
-            if (is_int($lastSent)) {
-                return $lastSent;
+            // $lastSent may be a string despite us storing an integer because
+            // some storage backends will convert all values into strings
+            // note: some invalid integers pass 'is_numeric' (e.g. bigger than
+            // PHP_INT_MAX) but these get cast to '0', which is the default anyway
+            if (is_numeric($lastSent)) {
+                return (int) $lastSent;
             }
 
             return 0;


### PR DESCRIPTION
## Goal

We currently require an integer to be returned by the session storage backend when storing the last time we sent sessions. This allows us to throttle the delivery of session data to once every 30 seconds. However, some storage backends convert all values to strings, which breaks this check and causes a session to be sent on every request

This PR loosens the check to allow any numeric value instead of specifically an integer