### PR TITLE
Add feature flags & experiments API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 Changelog
 =========
 
+## TBD
+
+### Enhancements
+
+* New APIs to support feature flag and experiment functionality. For more information, please see https://docs.bugsnag.com/product/features-experiments.
+  [#646](https://github.com/bugsnag/bugsnag-php/pull/646)
+
 ## 3.27.0 (2022-02-07)
 
 ### Enhancements

--- a/src/Client.php
+++ b/src/Client.php
@@ -22,7 +22,7 @@ use Bugsnag\Shutdown\ShutdownStrategyInterface;
 use Composer\CaBundle\CaBundle;
 use GuzzleHttp;
 
-class Client
+class Client implements FeatureDataStore
 {
     /**
      * The default event notification endpoint.
@@ -804,6 +804,54 @@ class Client
     public function getMetaData()
     {
         return $this->config->getMetaData();
+    }
+
+    /**
+     * Add a single feature flag to all future reports.
+     *
+     * @param string $name
+     * @param string|null $variant
+     *
+     * @return void
+     */
+    public function addFeatureFlag($name, $variant = null)
+    {
+        $this->config->addFeatureFlag($name, $variant);
+    }
+
+    /**
+     * Add multiple feature flags to all future reports.
+     *
+     * @param FeatureFlag[] $featureFlags
+     * @phpstan-param list<FeatureFlag> $featureFlags
+     *
+     * @return void
+     */
+    public function addFeatureFlags(array $featureFlags)
+    {
+        $this->config->addFeatureFlags($featureFlags);
+    }
+
+    /**
+     * Remove the feature flag with the given name from all future reports.
+     *
+     * @param string $name
+     *
+     * @return void
+     */
+    public function clearFeatureFlag($name)
+    {
+        $this->config->clearFeatureFlag($name);
+    }
+
+    /**
+     * Remove all feature flags from all future reports.
+     *
+     * @return void
+     */
+    public function clearFeatureFlags()
+    {
+        $this->config->clearFeatureFlags();
     }
 
     /**

--- a/src/FeatureDataStore.php
+++ b/src/FeatureDataStore.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace Bugsnag;
+
+interface FeatureDataStore
+{
+    /**
+     * Add a single feature flag.
+     *
+     * @param string $name
+     * @param string|null $variant
+     *
+     * @return void
+     */
+    public function addFeatureFlag($name, $variant = null);
+
+    /**
+     * Add multiple feature flags.
+     *
+     * The new flags will be merged with any existing feature flags, with the
+     * newer variant values taking precedence
+     *
+     * @param array $featureFlags
+     * @phpstan-param list<FeatureFlag> $featureFlags
+     *
+     * @return void
+     */
+    public function addFeatureFlags(array $featureFlags);
+
+    /**
+     * Remove a single feature flag by name.
+     *
+     * @param string $name
+     *
+     * @return void
+     */
+    public function clearFeatureFlag($name);
+
+    /**
+     * Remove all feature flags.
+     *
+     * @return void
+     */
+    public function clearFeatureFlags();
+}

--- a/src/FeatureFlag.php
+++ b/src/FeatureFlag.php
@@ -1,0 +1,81 @@
+<?php
+
+namespace Bugsnag;
+
+final class FeatureFlag
+{
+    /**
+     * A name that identifies this feature flag.
+     *
+     * @var string
+     */
+    private $name;
+
+    /**
+     * An optional variant for this feature flag.
+     *
+     * @var string|null
+     */
+    private $variant;
+
+    /**
+     * @param string $name a name that identifies this feature flag
+     * @param string|null $variant an optional variant for this feature flag.
+     */
+    public function __construct($name, $variant = null)
+    {
+        $this->name = $name;
+
+        // ensure the variant can only be null or a string as the API only
+        // accepts strings (null values will be omitted from the payload)
+        if ($variant !== null && !is_string($variant)) {
+            $json = json_encode($variant);
+
+            // if JSON encoding fails, omit the variant
+            $variant = $json === false ? null : $json;
+        }
+
+        $this->variant = $variant;
+    }
+
+    /**
+     * Get the feature flag's name.
+     *
+     * @return string
+     */
+    public function getName()
+    {
+        return $this->name;
+    }
+
+    /**
+     * Get the feature flag's variant.
+     *
+     * @return string|null
+     */
+    public function getVariant()
+    {
+        return $this->variant;
+    }
+
+    /**
+     * Convert this feature flag into the format used by the Bugsnag Event API.
+     *
+     * This has two forms, either with a variant:
+     *   { "featureFlag": "name", "variant": "variant" }
+     *
+     * or if the feature flag has no variant:
+     *   { "featureFlag": "no variant" }
+     *
+     * @return array[]
+     * @phpstan-return array{featureFlag: string, variant?: string}
+     */
+    public function toArray()
+    {
+        if (is_string($this->variant)) {
+            return ['featureFlag' => $this->name, 'variant' => $this->variant];
+        }
+
+        return ['featureFlag' => $this->name];
+    }
+}

--- a/src/Internal/FeatureFlagDelegate.php
+++ b/src/Internal/FeatureFlagDelegate.php
@@ -1,0 +1,94 @@
+<?php
+
+namespace Bugsnag\Internal;
+
+use Bugsnag\FeatureFlag;
+
+/**
+ * @internal
+ */
+final class FeatureFlagDelegate
+{
+    /**
+     * @var FeatureFlag[]
+     * @phpstan-var list<FeatureFlag>
+     */
+    private $storage = [];
+
+    /**
+     * @param string $name
+     * @param string|null $variant
+     *
+     * @return void
+     */
+    public function add($name, $variant)
+    {
+        // ensure we're not about to add a duplicate flag
+        $this->remove($name);
+
+        $this->storage[] = new FeatureFlag($name, $variant);
+    }
+
+    /**
+     * @param FeatureFlag[] $featureFlags
+     * @phpstan-param list<FeatureFlag> $featureFlags
+     *
+     * @return void
+     */
+    public function merge(array $featureFlags)
+    {
+        foreach ($featureFlags as $flag) {
+            if ($flag instanceof FeatureFlag) {
+                $this->remove($flag->getName());
+
+                $this->storage[] = $flag;
+            }
+        }
+    }
+
+    /**
+     * @param string $name
+     *
+     * @return void
+     */
+    public function remove($name)
+    {
+        foreach ($this->storage as $index => $flag) {
+            if ($flag->getName() === $name) {
+                unset($this->storage[$index]);
+
+                // reindex the array to prevent holes
+                $this->storage = array_values($this->storage);
+
+                break;
+            }
+        }
+    }
+
+    /**
+     * @return void
+     */
+    public function clear()
+    {
+        $this->storage = [];
+    }
+
+    /**
+     * Convert the list of stored feature flags into the format used by the
+     * Bugsnag Event API.
+     *
+     * For example: [{ "featureFlag": "name", "variant": "variant" }, ...]
+     *
+     * @return array[]
+     * @phpstan-return list<array{featureFlag: string, variant?: string}>
+     */
+    public function toArray()
+    {
+        return array_map(
+            function (FeatureFlag $flag) {
+                return $flag->toArray();
+            },
+            $this->storage
+        );
+    }
+}

--- a/tests/ConfigurationTest.php
+++ b/tests/ConfigurationTest.php
@@ -3,6 +3,7 @@
 namespace Bugsnag\Tests;
 
 use Bugsnag\Configuration;
+use Bugsnag\FeatureFlag;
 
 class ConfigurationTest extends TestCase
 {
@@ -357,5 +358,69 @@ class ConfigurationTest extends TestCase
         $this->config->setRedactedKeys($redactedKeys);
 
         $this->assertSame($redactedKeys, $this->config->getRedactedKeys());
+    }
+
+    public function testFeatureFlagsCanBeAddedToConfiguration()
+    {
+        $this->config->addFeatureFlag('a name');
+        $this->config->addFeatureFlag('another name', 'with variant');
+
+        $expected = [
+            ['featureFlag' => 'a name'],
+            ['featureFlag' => 'another name', 'variant' => 'with variant'],
+        ];
+
+        $actual = $this->config->getFeatureFlagsCopy()->toArray();
+
+        $this->assertSame($expected, $actual);
+    }
+
+    public function testMultipleFeatureFlagsCanBeAddedToConfigurationAtOnce()
+    {
+        $this->config->addFeatureFlag('a name');
+        $this->config->addFeatureFlags([
+            new FeatureFlag('another name', 'with variant'),
+            new FeatureFlag('name3'),
+            new FeatureFlag('four', 'yes'),
+        ]);
+
+        $expected = [
+            ['featureFlag' => 'a name'],
+            ['featureFlag' => 'another name', 'variant' => 'with variant'],
+            ['featureFlag' => 'name3'],
+            ['featureFlag' => 'four', 'variant' => 'yes'],
+        ];
+
+        $actual = $this->config->getFeatureFlagsCopy()->toArray();
+
+        $this->assertSame($expected, $actual);
+    }
+
+    public function testAFeatureFlagCanBeRemovedFromConfiguration()
+    {
+        $this->config->addFeatureFlag('a name');
+        $this->config->addFeatureFlag('another name', 'with variant');
+
+        $this->config->clearFeatureFlag('another name');
+
+        $expected = [
+            ['featureFlag' => 'a name'],
+        ];
+
+        $actual = $this->config->getFeatureFlagsCopy()->toArray();
+
+        $this->assertSame($expected, $actual);
+    }
+
+    public function testAllFeatureFlagsCanBeRemovedFromConfiguration()
+    {
+        $this->config->addFeatureFlag('a name');
+        $this->config->addFeatureFlag('another name', 'with variant');
+
+        $this->config->clearFeatureFlags();
+
+        $actual = $this->config->getFeatureFlagsCopy()->toArray();
+
+        $this->assertSame([], $actual);
     }
 }

--- a/tests/FeatureFlagTest.php
+++ b/tests/FeatureFlagTest.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace Bugsnag\Tests;
+
+use Bugsnag\FeatureFlag;
+
+class FeatureFlagTest extends TestCase
+{
+    /**
+     * @dataProvider variantDataProvider
+     *
+     * @param mixed $variant
+     * @param string|null $expected
+     *
+     * @return void
+     */
+    public function testVariantIsCoercedToStringOrNull($variant, $expected)
+    {
+        $flag = new FeatureFlag('name', $variant);
+
+        $this->assertSame($expected, $flag->getVariant());
+    }
+
+    public function variantDataProvider()
+    {
+        return [
+            ['a variant', 'a variant'],
+            [null, null],
+            [1234, '1234'],
+            [12.34, '12.34'],
+            [true, 'true'],
+            [false, 'false'],
+            ['', ''],
+            [(object) ['a' => 'hello', 'b' => 'hi'], '{"a":"hello","b":"hi"}'],
+            [new FeatureFlag('x'), '{}'],
+            [['a', 'b', 'c'], '["a","b","c"]'],
+        ];
+    }
+
+    public function testToArrayWithOnlyName()
+    {
+        $flag = new FeatureFlag('this is the name');
+
+        $expected = ['featureFlag' => 'this is the name'];
+
+        $this->assertSame($expected, $flag->toArray());
+    }
+
+    public function testToArrayWithNameAndNullVariant()
+    {
+        $flag = new FeatureFlag('this is the name', null);
+
+        $expected = ['featureFlag' => 'this is the name'];
+
+        $this->assertSame($expected, $flag->toArray());
+    }
+
+    public function testToArrayWithNameAndVariant()
+    {
+        $flag = new FeatureFlag('this is the name', 'and this is the variant');
+
+        $expected = [
+            'featureFlag' => 'this is the name',
+            'variant' => 'and this is the variant',
+        ];
+
+        $this->assertSame($expected, $flag->toArray());
+    }
+}

--- a/tests/Internal/FeatureFlagDelegateTest.php
+++ b/tests/Internal/FeatureFlagDelegateTest.php
@@ -1,0 +1,110 @@
+<?php
+
+namespace Bugsnag\Tests;
+
+use Bugsnag\FeatureFlag;
+use Bugsnag\Internal\FeatureFlagDelegate;
+
+class FeatureFlagDelegateTest extends TestCase
+{
+    public function testAdd()
+    {
+        $delegate = new FeatureFlagDelegate();
+
+        $delegate->add('a name', null);
+        $delegate->add('another name', 'a variant');
+
+        $expected = [
+            ['featureFlag' => 'a name'],
+            ['featureFlag' => 'another name', 'variant' => 'a variant'],
+        ];
+
+        $this->assertSame($expected, $delegate->toArray());
+    }
+
+    public function testMerge()
+    {
+        $delegate = new FeatureFlagDelegate();
+
+        $delegate->add('name', null);
+        $delegate->merge([
+            new FeatureFlag('2flag', '2variant'),
+            new FeatureFlag('flag', 'abc'),
+        ]);
+
+        $expected = [
+            ['featureFlag' => 'name'],
+            ['featureFlag' => '2flag', 'variant' => '2variant'],
+            ['featureFlag' => 'flag', 'variant' => 'abc'],
+        ];
+
+        $this->assertSame($expected, $delegate->toArray());
+
+        $delegate->merge([
+            // replace the 'name' flag with one that has a variant
+            new FeatureFlag('name', 'with variant'),
+            new FeatureFlag('final flag'),
+        ]);
+
+        $expected = [
+            ['featureFlag' => '2flag', 'variant' => '2variant'],
+            ['featureFlag' => 'flag', 'variant' => 'abc'],
+            ['featureFlag' => 'name', 'variant' => 'with variant'],
+            ['featureFlag' => 'final flag'],
+        ];
+
+        $this->assertSame($expected, $delegate->toArray());
+    }
+
+    public function testMergeIgnoresIncorrectTypes()
+    {
+        $delegate = new FeatureFlagDelegate();
+
+        $delegate->merge([
+            new FeatureFlag('2flag', '2variant'),
+            null,
+            'hello',
+            1234,
+            new FeatureFlag('3flag', '3variant'),
+        ]);
+
+        $expected = [
+            ['featureFlag' => '2flag', 'variant' => '2variant'],
+            ['featureFlag' => '3flag', 'variant' => '3variant'],
+        ];
+
+        $this->assertSame($expected, $delegate->toArray());
+    }
+
+    public function testRemove()
+    {
+        $delegate = new FeatureFlagDelegate();
+
+        $delegate->add('a name', null);
+        $delegate->add('another name', 'a variant');
+
+        $delegate->remove('a name');
+
+        $expected = [
+            ['featureFlag' => 'another name', 'variant' => 'a variant'],
+        ];
+
+        $this->assertSame($expected, $delegate->toArray());
+
+        $delegate->remove('another name');
+
+        $this->assertSame([], $delegate->toArray());
+    }
+
+    public function testClear()
+    {
+        $delegate = new FeatureFlagDelegate();
+
+        $delegate->add('a name', null);
+        $delegate->add('another name', 'a variant');
+
+        $delegate->clear();
+
+        $this->assertSame([], $delegate->toArray());
+    }
+}


### PR DESCRIPTION
## Goal

This PR adds the [feature flags & experiments API](https://docs.bugsnag.com/product/features-experiments) to Bugsnag PHP. The API exists in the `Client`, `Configuration` and `Report` classes, which implement the new `FeatureDataStore` interface:

```php
interface FeatureDataStore
{
    public function addFeatureFlag($name, $variant = null);
    public function addFeatureFlags(array $featureFlags);
    public function clearFeatureFlag($name);
    public function clearFeatureFlags();
}
```

Feature flags are stored on both the `Configuration` and `Report` (the `Client` forwards method calls on to the `Configuration`), allowing feature flags to be added globally (via `Configuration`) or to individual reports as required