### PR TITLE
Use Composer 2.2 when building bugsnag.phar

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,6 @@ ENV COMPOSER_ALLOW_SUPERUSER 1
 
 RUN apk update && apk upgrade
 
-COPY --from=composer:2 /usr/bin/composer /usr/bin/composer
+COPY --from=composer:2.2 /usr/bin/composer /usr/bin/composer
 
 ENTRYPOINT ["php"]


### PR DESCRIPTION
## Goal

Composer 2.3 dropped support for older PHP versions, but we have to use PHP 5.5 to build `bugsnag.phar` as it's our earliest supported version