### PR TITLE
[3.x] Adds `NullableShutdownStrategy`

### DIFF
--- a/src/Shutdown/NullableShutdownStrategy.php
+++ b/src/Shutdown/NullableShutdownStrategy.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Bugsnag\Shutdown;
+
+use Bugsnag\Client;
+
+/**
+ * Class NullableShutdownStrategy.
+ */
+class NullableShutdownStrategy implements ShutdownStrategyInterface
+{
+    /**
+     * @param Client $client
+     *
+     * @return void
+     */
+    public function registerShutdownStrategy(Client $client)
+    {
+        // ...
+    }
+}


### PR DESCRIPTION
This pull request adds an new `NullableShutdownStrategy ` implementation that can be used in scenarios where customers don't want to actually register a shutdown function.

Check https://github.com/bugsnag/bugsnag-laravel/pull/493 for more details.