### PR TITLE
Allow configuring the maximum number off breadcrumbs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 Changelog
 =========
 
+## TBD
+
+### Enhancements
+
+* The maximum number of breadcrumbs can now be configured between 0-100 (inclusive)
+  [#652](https://github.com/bugsnag/bugsnag-php/pull/652)
+
 ## 3.28.0 (2022-05-18)
 
 ### Enhancements

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ Changelog
 * The maximum number of breadcrumbs can now be configured between 0-100 (inclusive)
   [#652](https://github.com/bugsnag/bugsnag-php/pull/652)
 
+* Raised the default maximum number of breadcrumbs to 50
+  [#652](https://github.com/bugsnag/bugsnag-php/pull/652)
+
 ## 3.28.0 (2022-05-18)
 
 ### Enhancements

--- a/src/Breadcrumbs/Recorder.php
+++ b/src/Breadcrumbs/Recorder.php
@@ -15,42 +15,24 @@ class Recorder implements Countable, Iterator
      *
      * @var int
      */
-    const MAX_ITEMS = 25;
+    private $maxBreadcrumbs = 25;
 
     /**
      * The recorded breadcrumbs.
      *
      * @var \Bugsnag\Breadcrumbs\Breadcrumb[]
      */
-    protected $breadcrumbs = [];
-
-    /**
-     * The head position.
-     *
-     * @var int
-     */
-    protected $head = 0;
-
-    /**
-     * The pointer position.
-     *
-     * @var int
-     */
-    protected $pointer = 0;
+    private $breadcrumbs = [];
 
     /**
      * The iteration position.
      *
      * @var int
      */
-    protected $position = 0;
+    private $position = 0;
 
     /**
      * Record a breadcrumb.
-     *
-     * We're recording a maximum of 25 breadcrumbs. Once we've recorded 25, we
-     * start wrapping back around and replacing the earlier ones. In order to
-     * indicate the start of the list, we advance a head pointer.
      *
      * @param \Bugsnag\Breadcrumbs\Breadcrumb $breadcrumb
      *
@@ -58,16 +40,12 @@ class Recorder implements Countable, Iterator
      */
     public function record(Breadcrumb $breadcrumb)
     {
-        // advance the head by one if we've caught up
-        if ($this->breadcrumbs && $this->pointer === $this->head) {
-            $this->head = ($this->head + 1) % static::MAX_ITEMS;
+        $this->breadcrumbs[] = $breadcrumb;
+
+        // drop the oldest breadcrumb if we're over the max
+        if ($this->count() > $this->maxBreadcrumbs) {
+            array_shift($this->breadcrumbs);
         }
-
-        // record the new breadcrumb
-        $this->breadcrumbs[$this->pointer] = $breadcrumb;
-
-        // advance the pointer so we set the next breadcrumb in the next slot
-        $this->pointer = ($this->pointer + 1) % static::MAX_ITEMS;
     }
 
     /**
@@ -77,10 +55,48 @@ class Recorder implements Countable, Iterator
      */
     public function clear()
     {
-        $this->head = 0;
-        $this->pointer = 0;
         $this->position = 0;
         $this->breadcrumbs = [];
+    }
+
+    /**
+     * Set the maximum number of breadcrumbs that are allowed to be stored.
+     *
+     * This must be an integer between 0 and 100 (inclusive).
+     *
+     * @param int $maxBreadcrumbs
+     *
+     * @return void
+     */
+    public function setMaxBreadcrumbs($maxBreadcrumbs)
+    {
+        if (!is_int($maxBreadcrumbs) || $maxBreadcrumbs < 0 || $maxBreadcrumbs > 100) {
+            error_log(
+                'Bugsnag Warning: maxBreadcrumbs should be an integer between 0 and 100 (inclusive)'
+            );
+
+            return;
+        }
+
+        $this->maxBreadcrumbs = $maxBreadcrumbs;
+
+        // drop the oldest breadcrumbs if we're over the max
+        if ($this->count() > $this->maxBreadcrumbs) {
+            $this->breadcrumbs = array_slice(
+                $this->breadcrumbs,
+                $this->count() - $this->maxBreadcrumbs
+            );
+        }
+    }
+
+    /**
+     * Get the maximum number of breadcrumbs that are allowed to be stored.
+     *
+     * @return int
+     */
+    public function getMaxBreadcrumbs()
+    {
+        return $this->maxBreadcrumbs;
     }
 
     /**
@@ -102,7 +118,7 @@ class Recorder implements Countable, Iterator
     #[\ReturnTypeWillChange]
     public function current()
     {
-        return $this->breadcrumbs[($this->head + $this->position) % static::MAX_ITEMS];
+        return $this->breadcrumbs[$this->position];
     }
 
     /**

--- a/src/Breadcrumbs/Recorder.php
+++ b/src/Breadcrumbs/Recorder.php
@@ -15,7 +15,7 @@ class Recorder implements Countable, Iterator
      *
      * @var int
      */
-    private $maxBreadcrumbs = 25;
+    private $maxBreadcrumbs = 50;
 
     /**
      * The recorded breadcrumbs.

--- a/src/Client.php
+++ b/src/Client.php
@@ -1066,4 +1066,24 @@ class Client implements FeatureDataStore
     {
         return $this->config->getRedactedKeys();
     }
+
+    /**
+     * @param int $maxBreadcrumbs
+     *
+     * @return $this
+     */
+    public function setMaxBreadcrumbs($maxBreadcrumbs)
+    {
+        $this->recorder->setMaxBreadcrumbs($maxBreadcrumbs);
+
+        return $this;
+    }
+
+    /**
+     * @return int
+     */
+    public function getMaxBreadcrumbs()
+    {
+        return $this->recorder->getMaxBreadcrumbs();
+    }
 }

--- a/tests/Breadcrumbs/RecorderTest.php
+++ b/tests/Breadcrumbs/RecorderTest.php
@@ -91,6 +91,7 @@ class RecorderTest extends TestCase
     public function testManyRecorded()
     {
         $recorder = new Recorder();
+        $recorder->setMaxBreadcrumbs(25);
 
         $one = new Breadcrumb('Foo', 'error');
         $two = new Breadcrumb('Bar', 'user');

--- a/tests/Middleware/BreadcrumbsDataTest.php
+++ b/tests/Middleware/BreadcrumbsDataTest.php
@@ -111,6 +111,7 @@ class BreadcrumbsDataTest extends TestCase
     {
         $breadcrumbs = null;
         $middleware = new BreadcrumbData($this->recorder);
+        $this->recorder->setMaxBreadcrumbs(25);
 
         $this->recorder->record(new Breadcrumb('Foo', 'error', ['foo' => 'bar']));
 


### PR DESCRIPTION
## Goal

To align with other platforms, the maximum number of breadcrumbs can now be configured between 0-100 (inclusive) and the default maximum number of breadcrumbs has been raised to 50