### PR TITLE
Add `Report::getFeatureFlags` to allow accessing feature flags in callbacks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ Changelog
 * Raised the default maximum number of breadcrumbs to 50
   [#652](https://github.com/bugsnag/bugsnag-php/pull/652)
 
+* Add a `Report::getFeatureFlags` method to allow accessing feature flags in callbacks
+  [#653](https://github.com/bugsnag/bugsnag-php/pull/653)
+
 ## 3.28.0 (2022-05-18)
 
 ### Enhancements

--- a/src/Internal/FeatureFlagDelegate.php
+++ b/src/Internal/FeatureFlagDelegate.php
@@ -74,21 +74,12 @@ final class FeatureFlagDelegate
     }
 
     /**
-     * Convert the list of stored feature flags into the format used by the
-     * Bugsnag Event API.
+     * Get the list of stored feature flags as an array.
      *
-     * For example: [{ "featureFlag": "name", "variant": "variant" }, ...]
-     *
-     * @return array[]
-     * @phpstan-return list<array{featureFlag: string, variant?: string}>
+     * @return \Bugsnag\FeatureFlag[]
      */
     public function toArray()
     {
-        return array_map(
-            function (FeatureFlag $flag) {
-                return $flag->toArray();
-            },
-            $this->storage
-        );
+        return $this->storage;
     }
 }

--- a/src/Report.php
+++ b/src/Report.php
@@ -633,6 +633,16 @@ class Report implements FeatureDataStore
     }
 
     /**
+     * Get the list of feature flags for this report.
+     *
+     * @return \Bugsnag\FeatureFlag[]
+     */
+    public function getFeatureFlags()
+    {
+        return $this->featureFlags->toArray();
+    }
+
+    /**
      * Set the current user.
      *
      * @param array $user the current user

--- a/src/Report.php
+++ b/src/Report.php
@@ -763,7 +763,12 @@ class Report implements FeatureDataStore
             'metaData' => $this->cleanupObj($this->getMetaData(), true),
             'unhandled' => $this->getUnhandled(),
             'severityReason' => $this->getSeverityReason(),
-            'featureFlags' => $this->featureFlags->toArray(),
+            'featureFlags' => array_map(
+                function (FeatureFlag $flag) {
+                    return $flag->toArray();
+                },
+                $this->featureFlags->toArray()
+            ),
         ];
 
         if ($hash = $this->getGroupingHash()) {

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -1261,13 +1261,13 @@ class ClientTest extends TestCase
         $this->client->addFeatureFlag('another name', 'with variant');
 
         $expected = [
-            ['featureFlag' => 'a name'],
-            ['featureFlag' => 'another name', 'variant' => 'with variant'],
+            new FeatureFlag('a name'),
+            new FeatureFlag('another name', 'with variant'),
         ];
 
         $actual = $this->client->getConfig()->getFeatureFlagsCopy()->toArray();
 
-        $this->assertSame($expected, $actual);
+        $this->assertEquals($expected, $actual);
     }
 
     public function testMultipleFeatureFlagsCanBeAddedToClientAtOnce()
@@ -1280,15 +1280,15 @@ class ClientTest extends TestCase
         ]);
 
         $expected = [
-            ['featureFlag' => 'a name'],
-            ['featureFlag' => 'another name', 'variant' => 'with variant'],
-            ['featureFlag' => 'name3'],
-            ['featureFlag' => 'four', 'variant' => 'yes'],
+            new FeatureFlag('a name'),
+            new FeatureFlag('another name', 'with variant'),
+            new FeatureFlag('name3'),
+            new FeatureFlag('four', 'yes'),
         ];
 
         $actual = $this->client->getConfig()->getFeatureFlagsCopy()->toArray();
 
-        $this->assertSame($expected, $actual);
+        $this->assertEquals($expected, $actual);
     }
 
     public function testAFeatureFlagCanBeRemovedFromClient()
@@ -1299,12 +1299,12 @@ class ClientTest extends TestCase
         $this->client->clearFeatureFlag('another name');
 
         $expected = [
-            ['featureFlag' => 'a name'],
+            new FeatureFlag('a name'),
         ];
 
         $actual = $this->client->getConfig()->getFeatureFlagsCopy()->toArray();
 
-        $this->assertSame($expected, $actual);
+        $this->assertEquals($expected, $actual);
     }
 
     public function testAllFeatureFlagsCanBeRemovedFromClient()

--- a/tests/ConfigurationTest.php
+++ b/tests/ConfigurationTest.php
@@ -366,13 +366,13 @@ class ConfigurationTest extends TestCase
         $this->config->addFeatureFlag('another name', 'with variant');
 
         $expected = [
-            ['featureFlag' => 'a name'],
-            ['featureFlag' => 'another name', 'variant' => 'with variant'],
+            new FeatureFlag('a name'),
+            new FeatureFlag('another name', 'with variant'),
         ];
 
         $actual = $this->config->getFeatureFlagsCopy()->toArray();
 
-        $this->assertSame($expected, $actual);
+        $this->assertEquals($expected, $actual);
     }
 
     public function testMultipleFeatureFlagsCanBeAddedToConfigurationAtOnce()
@@ -385,15 +385,15 @@ class ConfigurationTest extends TestCase
         ]);
 
         $expected = [
-            ['featureFlag' => 'a name'],
-            ['featureFlag' => 'another name', 'variant' => 'with variant'],
-            ['featureFlag' => 'name3'],
-            ['featureFlag' => 'four', 'variant' => 'yes'],
+            new FeatureFlag('a name'),
+            new FeatureFlag('another name', 'with variant'),
+            new FeatureFlag('name3'),
+            new FeatureFlag('four', 'yes'),
         ];
 
         $actual = $this->config->getFeatureFlagsCopy()->toArray();
 
-        $this->assertSame($expected, $actual);
+        $this->assertEquals($expected, $actual);
     }
 
     public function testAFeatureFlagCanBeRemovedFromConfiguration()
@@ -404,12 +404,12 @@ class ConfigurationTest extends TestCase
         $this->config->clearFeatureFlag('another name');
 
         $expected = [
-            ['featureFlag' => 'a name'],
+            new FeatureFlag('a name'),
         ];
 
         $actual = $this->config->getFeatureFlagsCopy()->toArray();
 
-        $this->assertSame($expected, $actual);
+        $this->assertEquals($expected, $actual);
     }
 
     public function testAllFeatureFlagsCanBeRemovedFromConfiguration()

--- a/tests/Internal/FeatureFlagDelegateTest.php
+++ b/tests/Internal/FeatureFlagDelegateTest.php
@@ -15,11 +15,11 @@ class FeatureFlagDelegateTest extends TestCase
         $delegate->add('another name', 'a variant');
 
         $expected = [
-            ['featureFlag' => 'a name'],
-            ['featureFlag' => 'another name', 'variant' => 'a variant'],
+            new FeatureFlag('a name'),
+            new FeatureFlag('another name', 'a variant'),
         ];
 
-        $this->assertSame($expected, $delegate->toArray());
+        $this->assertEquals($expected, $delegate->toArray());
     }
 
     public function testMerge()
@@ -33,12 +33,12 @@ class FeatureFlagDelegateTest extends TestCase
         ]);
 
         $expected = [
-            ['featureFlag' => 'name'],
-            ['featureFlag' => '2flag', 'variant' => '2variant'],
-            ['featureFlag' => 'flag', 'variant' => 'abc'],
+            new FeatureFlag('name'),
+            new FeatureFlag('2flag', '2variant'),
+            new FeatureFlag('flag', 'abc'),
         ];
 
-        $this->assertSame($expected, $delegate->toArray());
+        $this->assertEquals($expected, $delegate->toArray());
 
         $delegate->merge([
             // replace the 'name' flag with one that has a variant
@@ -47,13 +47,13 @@ class FeatureFlagDelegateTest extends TestCase
         ]);
 
         $expected = [
-            ['featureFlag' => '2flag', 'variant' => '2variant'],
-            ['featureFlag' => 'flag', 'variant' => 'abc'],
-            ['featureFlag' => 'name', 'variant' => 'with variant'],
-            ['featureFlag' => 'final flag'],
+            new FeatureFlag('2flag', '2variant'),
+            new FeatureFlag('flag', 'abc'),
+            new FeatureFlag('name', 'with variant'),
+            new FeatureFlag('final flag'),
         ];
 
-        $this->assertSame($expected, $delegate->toArray());
+        $this->assertEquals($expected, $delegate->toArray());
     }
 
     public function testMergeIgnoresIncorrectTypes()
@@ -69,11 +69,11 @@ class FeatureFlagDelegateTest extends TestCase
         ]);
 
         $expected = [
-            ['featureFlag' => '2flag', 'variant' => '2variant'],
-            ['featureFlag' => '3flag', 'variant' => '3variant'],
+            new FeatureFlag('2flag', '2variant'),
+            new FeatureFlag('3flag', '3variant'),
         ];
 
-        $this->assertSame($expected, $delegate->toArray());
+        $this->assertEquals($expected, $delegate->toArray());
     }
 
     public function testRemove()
@@ -86,10 +86,10 @@ class FeatureFlagDelegateTest extends TestCase
         $delegate->remove('a name');
 
         $expected = [
-            ['featureFlag' => 'another name', 'variant' => 'a variant'],
+            new FeatureFlag('another name', 'a variant'),
         ];
 
-        $this->assertSame($expected, $delegate->toArray());
+        $this->assertEquals($expected, $delegate->toArray());
 
         $delegate->remove('another name');
 

--- a/tests/ReportTest.php
+++ b/tests/ReportTest.php
@@ -795,12 +795,18 @@ class ReportTest extends TestCase
         $this->report->addFeatureFlag('a name');
         $this->report->addFeatureFlag('another name', 'with variant');
 
-        $expected = [
+        $expectedEventApi = [
             ['featureFlag' => 'a name'],
             ['featureFlag' => 'another name', 'variant' => 'with variant'],
         ];
 
-        $this->assertSame($expected, $this->report->toArray()['featureFlags']);
+        $expectedGetter = [
+            new FeatureFlag('a name'),
+            new FeatureFlag('another name', 'with variant'),
+        ];
+
+        $this->assertSame($expectedEventApi, $this->report->toArray()['featureFlags']);
+        $this->assertEquals($expectedGetter, $this->report->getFeatureFlags());
     }
 
     public function testMultipleFeatureFlagsCanBeAddedToAReportAtOnce()
@@ -812,14 +818,22 @@ class ReportTest extends TestCase
             new FeatureFlag('four', 'yes'),
         ]);
 
-        $expected = [
+        $expectedEventApi = [
             ['featureFlag' => 'a name'],
             ['featureFlag' => 'another name', 'variant' => 'with variant'],
             ['featureFlag' => 'name3'],
             ['featureFlag' => 'four', 'variant' => 'yes'],
         ];
 
-        $this->assertSame($expected, $this->report->toArray()['featureFlags']);
+        $expectedGetter = [
+            new FeatureFlag('a name'),
+            new FeatureFlag('another name', 'with variant'),
+            new FeatureFlag('name3'),
+            new FeatureFlag('four', 'yes'),
+        ];
+
+        $this->assertSame($expectedEventApi, $this->report->toArray()['featureFlags']);
+        $this->assertEquals($expectedGetter, $this->report->getFeatureFlags());
     }
 
     public function testAFeatureFlagCanBeRemovedFromAReport()
@@ -829,11 +843,11 @@ class ReportTest extends TestCase
 
         $this->report->clearFeatureFlag('another name');
 
-        $expected = [
-            ['featureFlag' => 'a name'],
-        ];
+        $expectedEventApi = [['featureFlag' => 'a name']];
+        $expectedGetter = [new FeatureFlag('a name')];
 
-        $this->assertSame($expected, $this->report->toArray()['featureFlags']);
+        $this->assertSame($expectedEventApi, $this->report->toArray()['featureFlags']);
+        $this->assertEquals($expectedGetter, $this->report->getFeatureFlags());
     }
 
     public function testAllFeatureFlagsCanBeRemovedFromAReport()
@@ -844,6 +858,7 @@ class ReportTest extends TestCase
         $this->report->clearFeatureFlags();
 
         $this->assertSame([], $this->report->toArray()['featureFlags']);
+        $this->assertSame([], $this->report->getFeatureFlags());
     }
 
     public function testReportFeatureFlagsAreInitialisedFromConfiguration()
@@ -855,13 +870,20 @@ class ReportTest extends TestCase
 
         $report->addFeatureFlag('yet another feature flag');
 
-        $expected = [
+        $expectedEventApi = [
             ['featureFlag' => 'a name'],
             ['featureFlag' => 'another name', 'variant' => 'with variant'],
             ['featureFlag' => 'yet another feature flag'],
         ];
 
-        $this->assertSame($expected, $report->toArray()['featureFlags']);
+        $expectedGetter = [
+            new FeatureFlag('a name'),
+            new FeatureFlag('another name', 'with variant'),
+            new FeatureFlag('yet another feature flag'),
+        ];
+
+        $this->assertSame($expectedEventApi, $report->toArray()['featureFlags']);
+        $this->assertEquals($expectedGetter, $report->getFeatureFlags());
     }
 
     public function testMutatingReportFeatureFlagsDoesNotAffectConfiguration()
@@ -872,17 +894,41 @@ class ReportTest extends TestCase
 
         $report->addFeatureFlag('another name');
 
-        $expected = [
+        $expectedEventApi = [
             ['featureFlag' => 'a name'],
             ['featureFlag' => 'another name'],
         ];
 
-        $this->assertSame($expected, $report->toArray()['featureFlags']);
+        $expectedGetter = [
+            new FeatureFlag('a name'),
+            new FeatureFlag('another name'),
+        ];
+
+        $this->assertSame($expectedEventApi, $report->toArray()['featureFlags']);
+        $this->assertEquals($expectedGetter, $report->getFeatureFlags());
 
         $expected = [
             new FeatureFlag('a name'),
         ];
 
         $this->assertEquals($expected, $this->config->getFeatureFlagsCopy()->toArray());
+    }
+
+    public function testFeatureFlagsCanBeAccessedFromAReport()
+    {
+        $this->config->addFeatureFlag('a name');
+        $this->config->addFeatureFlag('another name', 'with variant');
+
+        $report = Report::fromNamedError($this->config, 'Name', 'Message');
+
+        $report->addFeatureFlag('yet another feature flag');
+
+        $expected = [
+            new FeatureFlag('a name'),
+            new FeatureFlag('another name', 'with variant'),
+            new FeatureFlag('yet another feature flag'),
+        ];
+
+        $this->assertEquals($expected, $report->getFeatureFlags());
     }
 }

--- a/tests/ReportTest.php
+++ b/tests/ReportTest.php
@@ -880,9 +880,9 @@ class ReportTest extends TestCase
         $this->assertSame($expected, $report->toArray()['featureFlags']);
 
         $expected = [
-            ['featureFlag' => 'a name'],
+            new FeatureFlag('a name'),
         ];
 
-        $this->assertSame($expected, $this->config->getFeatureFlagsCopy()->toArray());
+        $this->assertEquals($expected, $this->config->getFeatureFlagsCopy()->toArray());
     }
 }


### PR DESCRIPTION
Add `Report::getFeatureFlags` to allow accessing feature flags in callbacks. This returns a list of `FeatureFlag` instances (the same class used in `addFeatureFlags`)

I've changed the return value of `FeatureFlagDelegate::toArray` to the raw array of feature flags to support this. The `Report::toArray` now handles formatting the list of feature flags for the Event API