### PR TITLE
fix: Allow Phake to mock `Report` in PHP < 8

### DIFF
--- a/src/Report.php
+++ b/src/Report.php
@@ -920,7 +920,7 @@ class Report implements FeatureDataStore
      *
      * @return string
      */
-    private function enumToString(UnitEnum $enum)
+    private function enumToString($enum)
     {
         // e.g. My\Enum::SomeCase
         $string = sprintf('%s::%s', get_class($enum), $enum->name);


### PR DESCRIPTION
## Goal
This is a fix for this issue: https://github.com/bugsnag/bugsnag-php/issues/655

When you create a mock with [Phake](https://phake.github.io/doc/), Phake goes and creates mock classes for every type that's referenced in a method signature on the class. _This includes private methods_, in order to support [this feature](https://phake.github.io/doc/mocks/#calling-private-and-protected-methods-on-mocks).

So as long as the new `UnitEnum` type is used on a method signature (even a private one), Phake cannot create a mock for it in older PHP versions.

This is an issue for us as we test our wrapper of the Bugsnag client, using Phake to mock the `\Bugsnag\Report` object.

## Changeset
- Remove strong typing in method signature that uses `UnitEnum` (only available in PHP8)