### PR TITLE
PHP 8.2 - Replace deprecated utf8_encode function to mb string

### DIFF
--- a/src/Report.php
+++ b/src/Report.php
@@ -848,7 +848,7 @@ class Report implements FeatureDataStore
         }
 
         if (is_string($obj)) {
-            return (function_exists('mb_detect_encoding') && !mb_detect_encoding($obj, 'UTF-8', true)) ? utf8_encode($obj) : $obj;
+            return (function_exists('mb_detect_encoding') && !mb_detect_encoding($obj, 'UTF-8', true)) ? mb_convert_encoding($obj, 'UTF-8', 'ISO-8859-1') : $obj;
         }
 
         if (is_object($obj)) {


### PR DESCRIPTION
## Exception:

![stacktrace-bugsnag](https://user-images.githubusercontent.com/12158575/235398724-823b1660-331d-405a-a7ce-a429998327d3.png)

## Solution: 
https://php.watch/versions/8.2/utf8_encode-utf8_decode-deprecated

In order to keep the project compatible with PHP 8.2 this function must be replaced to avoid PHP Fatal errors.