### PR TITLE
Allow PHP 7.2+ to handle invalid UTF-8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,15 @@
 Changelog
 =========
 
+## TBD
+
+### Fixes
+
+* Avoid deprecated `utf8_encode` function
+  [gabrielrbarbosa](https://github.com/gabrielrbarbosa)
+  [#661](https://github.com/bugsnag/bugsnag-php/pull/661)
+  [#662](https://github.com/bugsnag/bugsnag-php/pull/662)
+
 ## 3.29.0 (2022-10-19)
 
 ### Enhancements

--- a/src/Report.php
+++ b/src/Report.php
@@ -863,7 +863,7 @@ class Report implements FeatureDataStore
             // if we have the mbstring extension available, use that to detect
             // encodings and handle conversions to UTF-8
             if (function_exists('mb_check_encoding') && !mb_check_encoding($obj, 'UTF-8')) {
-                return mb_convert_encoding($obj, 'UTF-8', 'ISO-8859-1');
+                return mb_convert_encoding($obj, 'UTF-8', mb_list_encodings());
             }
 
             return $obj;

--- a/src/Report.php
+++ b/src/Report.php
@@ -848,7 +848,25 @@ class Report implements FeatureDataStore
         }
 
         if (is_string($obj)) {
-            return (function_exists('mb_detect_encoding') && !mb_detect_encoding($obj, 'UTF-8', true)) ? mb_convert_encoding($obj, 'UTF-8', 'ISO-8859-1') : $obj;
+            // on PHP 7.2+ we can use the 'JSON_INVALID_UTF8_SUBSTITUTE' flag to
+            // substitute invalid UTF-8 characters when encoding so can return
+            // strings as-is and let PHP handle invalid UTF-8
+            // note: we check PHP 7.2+ specifically rather than if the flag
+            // exists because some code defines the flag as '0' when it doesn't
+            // exist to avoid having to check for it existing. This completely
+            // breaks the flag as it will not function, so we can't know if the
+            // flag can be used just from it being defined
+            if (version_compare(PHP_VERSION, '7.2', '>=')) {
+                return $obj;
+            }
+
+            // if we have the mbstring extension available, use that to detect
+            // encodings and handle conversions to UTF-8
+            if (function_exists('mb_check_encoding') && !mb_check_encoding($obj, 'UTF-8')) {
+                return mb_convert_encoding($obj, 'UTF-8', 'ISO-8859-1');
+            }
+
+            return $obj;
         }
 
         if (is_object($obj)) {

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -1412,4 +1412,41 @@ class ClientTest extends TestCase
 
         $this->client->flush();
     }
+
+    public function testCanHandleInvalidUtf8InMetadata()
+    {
+        if (version_compare(PHP_VERSION, '7.2', '>=')) {
+            // U+FFFD (REPLACEMENT CHARACTER)
+            $expectedReplacement = "\xef\xbf\xbd";
+        } else {
+            $expectedReplacement = 'À';
+        }
+
+        $this->expectGuzzlePostWithCallback(
+            $this->client->getNotifyEndpoint(),
+            function ($options) use ($expectedReplacement) {
+                $payload = $this->getPayloadFromGuzzleOptions($options);
+
+                $expected = [
+                    'invalid UTF-8' => [
+                        'c0 is not valid as the first byte' => $expectedReplacement.'AAA',
+                    ],
+                ];
+
+                $this->assertSame($expected, $payload['events'][0]['metaData']);
+
+                return true;
+            }
+        );
+
+        $this->client->notifyException(new Exception('Something broke'), function ($report) {
+            $report->setMetaData([
+                'invalid UTF-8' => [
+                    'c0 is not valid as the first byte' => "\xc0AAA",
+                ],
+            ]);
+        });
+
+        $this->client->flush();
+    }
 }

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -1419,7 +1419,7 @@ class ClientTest extends TestCase
             // U+FFFD (REPLACEMENT CHARACTER)
             $expectedReplacement = "\xef\xbf\xbd";
         } else {
-            $expectedReplacement = 'À';
+            $expectedReplacement = 'ﾀ';
         }
 
         $this->expectGuzzlePostWithCallback(


### PR DESCRIPTION
## Goal

Follow up to #661 to make use of the PHP 7.2+ `JSON_INVALID_UTF8_SUBSTITUTE` flag, which means we don't have to try to cleanup invalid UTF-8 ourselves

I've also changed our use of `mb_convert_encoding` to guess the string's encoding, rather than assume `ISO-8859-1`