### PR TITLE
v2.x: Add missing timeout property

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 Changelog
 =========
 
+## TBD
+
+### Bug Fixes
+
+* Fix PHP 8.2 deprecation notice by adding missing `timeout` property to `Bugsnag_Configuration`
+  [#664](https://github.com/bugsnag/bugsnag-php/pull/664)
+
 ## 2.10.1 (2020-11-17)
 
 ### Bug Fixes

--- a/src/Bugsnag/Configuration.php
+++ b/src/Bugsnag/Configuration.php
@@ -40,6 +40,7 @@ class Bugsnag_Configuration
     public $errorReportingLevel;
 
     public $curlOptions = array();
+    public $timeout;
 
     public $debug = false;
 


### PR DESCRIPTION
## Goal

Add missing timeout property as PHP 8.2 deprecated adding dynamic properties to classes

The timeout property didn't need to be dynamic, it just wasn't added as a real property