### PR TITLE
PHP 8.4 compatibility

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
         "homepage": "https://bugsnag.com"
     }],
     "require": {
-        "php": ">=5.5",
+        "php": ">=8.1",
         "composer/ca-bundle": "^1.0",
         "guzzlehttp/guzzle": "^5.0|^6.0|^7.0"
     },

--- a/src/Client.php
+++ b/src/Client.php
@@ -123,9 +123,9 @@ class Client implements FeatureDataStore
      */
     public function __construct(
         Configuration $config,
-        ResolverInterface $resolver = null,
-        GuzzleHttp\ClientInterface $guzzle = null,
-        ShutdownStrategyInterface $shutdownStrategy = null
+        ?ResolverInterface $resolver = null,
+        ?GuzzleHttp\ClientInterface $guzzle = null,
+        ?ShutdownStrategyInterface $shutdownStrategy = null
     ) {
         $guzzle = $guzzle ?: self::makeGuzzle();
 
@@ -327,7 +327,7 @@ class Client implements FeatureDataStore
      *
      * @return void
      */
-    public function notifyException($throwable, callable $callback = null)
+    public function notifyException($throwable, ?callable $callback = null)
     {
         $report = Report::fromPHPThrowable($this->config, $throwable);
 
@@ -343,7 +343,7 @@ class Client implements FeatureDataStore
      *
      * @return void
      */
-    public function notifyError($name, $message, callable $callback = null)
+    public function notifyError($name, $message, ?callable $callback = null)
     {
         $report = Report::fromNamedError($this->config, $name, $message);
 
@@ -360,7 +360,7 @@ class Client implements FeatureDataStore
      *
      * @return void
      */
-    public function notify(Report $report, callable $callback = null)
+    public function notify(Report $report, ?callable $callback = null)
     {
         $this->pipeline->execute($report, function ($report) use ($callback) {
             if ($callback) {
@@ -511,7 +511,7 @@ class Client implements FeatureDataStore
      *
      * @return $this
      */
-    public function setNotifyReleaseStages(array $notifyReleaseStages = null)
+    public function setNotifyReleaseStages(?array $notifyReleaseStages = null)
     {
         $this->config->setNotifyReleaseStages($notifyReleaseStages);
 

--- a/src/Configuration.php
+++ b/src/Configuration.php
@@ -253,7 +253,7 @@ class Configuration implements FeatureDataStore
      *
      * @return $this
      */
-    public function setNotifyReleaseStages(array $notifyReleaseStages = null)
+    public function setNotifyReleaseStages(?array $notifyReleaseStages = null)
     {
         $this->notifyReleaseStages = $notifyReleaseStages;
 

--- a/src/DateTime/Date.php
+++ b/src/DateTime/Date.php
@@ -9,7 +9,7 @@ final class Date
     /**
      * @return string
      */
-    public static function now(ClockInterface $clock = null)
+    public static function now(?ClockInterface $clock = null)
     {
         if ($clock === null) {
             $clock = new Clock();

--- a/src/ErrorTypes.php
+++ b/src/ErrorTypes.php
@@ -65,11 +65,6 @@ class ErrorTypes
             'severity' => 'info',
         ],
 
-        E_STRICT => [
-            'name' => 'PHP Strict',
-            'severity' => 'info',
-        ],
-
         E_RECOVERABLE_ERROR => [
             'name' => 'PHP Recoverable Error',
             'severity' => 'error',
@@ -204,9 +199,6 @@ class ErrorTypes
 
             case E_USER_NOTICE:
                 return 'E_USER_NOTICE';
-
-            case E_STRICT:
-                return 'E_STRICT';
 
             case E_RECOVERABLE_ERROR:
                 return 'E_RECOVERABLE_ERROR';

--- a/src/Request/PhpRequest.php
+++ b/src/Request/PhpRequest.php
@@ -50,7 +50,7 @@ class PhpRequest implements RequestInterface
      *
      * @return void
      */
-    public function __construct(array $server, array $session, array $cookies, array $headers, array $input = null)
+    public function __construct(array $server, array $session, array $cookies, array $headers, ?array $input = null)
     {
         $this->server = $server;
         $this->session = $session;

--- a/src/SessionTracker.php
+++ b/src/SessionTracker.php
@@ -116,7 +116,7 @@ class SessionTracker
      *                                is deprecated and $http will be required
      *                                in the next major version.
      */
-    public function __construct(Configuration $config, HttpClient $http = null)
+    public function __construct(Configuration $config, ?HttpClient $http = null)
     {
         $this->config = $config;
         $this->http = $http === null


### PR DESCRIPTION
## Goal

Fix #670

## Design

<!-- Why was this approach used? -->

## Changeset

<!-- What changed? -->

Remove E_STRICT and add explicit nullable types. This requires changing the minimum PHP version. Supposedly E_STRICT hasn't been used since PHP 8 so it should be safe to remove: https://php.watch/versions/8.4/E_STRICT-deprecated

## Testing

<!-- How was it tested? What manual and automated tests were
     run/added? -->

I can only confirm this fixes the errors, I haven't tested it otherwise.