### PR TITLE
Redact user fields according to filters

### DIFF
--- a/src/Report.php
+++ b/src/Report.php
@@ -764,7 +764,7 @@ class Report implements FeatureDataStore
         $event = [
             'app' => $this->config->getAppData(),
             'device' => array_merge(['time' => $this->time], $this->config->getDeviceData()),
-            'user' => $this->getUser(),
+            'user' => $this->cleanupObj($this->getUser(), true),
             'context' => $this->getContext(),
             'payloadVersion' => HttpClient::NOTIFY_PAYLOAD_VERSION,
             'severity' => $this->getSeverity(),

--- a/tests/ReportTest.php
+++ b/tests/ReportTest.php
@@ -117,6 +117,22 @@ class ReportTest extends TestCase
         $this->assertSame(['foo' => 'bar'], $this->report->toArray()['user']);
     }
 
+    public function testUserDefaultFilters()
+    {
+        $this->report->setUser(['foo' => 'bar', 'password' => 'mypass', 'custom_field' => 'some data']);
+
+        $this->assertSame(['foo' => 'bar', 'password' => '[FILTERED]', 'custom_field' => 'some data'], $this->report->toArray()['user']);
+    }
+
+    public function testUserCustomFilters()
+    {
+        $this->config->setFilters(['custom_field']);
+
+        $this->report->setUser(['foo' => 'bar', 'password' => 'mypass', 'custom_field' => 'some data']);
+
+        $this->assertSame(['foo' => 'bar', 'password' => 'mypass', 'custom_field' => '[FILTERED]'], $this->report->toArray()['user']);
+    }
+
     public function testDefaultFilters()
     {
         $metadata = array_reduce(


### PR DESCRIPTION
## Goal
In case user data contains more sensitive information, apply filters to it.
Same process as filtering metadata.

## Changeset
User object wrapped in cleanup function.

## Testing
Manual tests. Added unit tests for user fields filtering.