### PR TITLE
Set default endpoints based on API key

### DIFF
--- a/.github/workflows/test-package.yml
+++ b/.github/workflows/test-package.yml
@@ -25,8 +25,9 @@ jobs:
           guzzle-version: '^7.0'
         - php-version: '8.3'
           guzzle-version: '^7.0'
-        - php-version: '8.4'
-          guzzle-version: '^7.9'
+        # PHP 8.4 skipped pending PLAT-14402
+        #- php-version: '8.4'
+        #  guzzle-version: '^7.9'
 
     steps:
     - uses: actions/checkout@v2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 Changelog
 =========
 
+## 3.30.0 (2025-06-??)
+
+### Enhancements
+
+* Set default endpoints based on API key
+  [#679](https://github.com/bugsnag/bugsnag-php/pull/679)
+
 ## 3.29.3 (2025-03-06)
 
 ### Fixes

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     "require-dev": {
         "guzzlehttp/psr7": "^1.3|^2.0",
         "mtdowling/burgomaster": "dev-master#72151eddf5f0cf101502b94bf5031f9c53501a04",
-        "phpunit/phpunit": "^4.8.36|^7.5.15|^9.3.10",
+        "phpunit/phpunit": "^4.8.36|^7.5.15|^9.3.10|^10.5.46",
         "php-mock/php-mock-phpunit": "^1.1|^2.1",
         "sebastian/version": ">=1.0.3"
     },

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     "require-dev": {
         "guzzlehttp/psr7": "^1.3|^2.0",
         "mtdowling/burgomaster": "dev-master#72151eddf5f0cf101502b94bf5031f9c53501a04",
-        "phpunit/phpunit": "^4.8.36|^7.5.15|^9.3.10|^10.5.46",
+        "phpunit/phpunit": "^4.8.36|^7.5.15|^9.3.10",
         "php-mock/php-mock-phpunit": "^1.1|^2.1",
         "sebastian/version": ">=1.0.3"
     },

--- a/src/Configuration.php
+++ b/src/Configuration.php
@@ -8,19 +8,34 @@ use InvalidArgumentException;
 class Configuration implements FeatureDataStore
 {
     /**
-     * The default endpoint for event notifications.
+     * The default endpoint for event notifications with Bugsnag.
      */
     const NOTIFY_ENDPOINT = 'https://notify.bugsnag.com';
 
     /**
-     * The default endpoint for session tracking.
+     * The default endpoint for session tracking with Bugsnag.
      */
     const SESSION_ENDPOINT = 'https://sessions.bugsnag.com';
 
     /**
-     * The default endpoint for build notifications.
+     * The default endpoint for build notifications with Bugsnag.
      */
     const BUILD_ENDPOINT = 'https://build.bugsnag.com';
+
+    /**
+     * The default endpoint for event notifications with InsightHub.
+     */
+    const HUB_NOTIFY_ENDPOINT = 'https://notify.insighthub.smartbear.com';
+
+    /**
+     * The default endpoint for session tracking with InsightHub.
+     */
+    const HUB_SESSION_ENDPOINT = 'https://sessions.insighthub.smartbear.com';
+
+    /**
+     * The default endpoint for build notifications with InsightHub.
+     */
+    const HUB_BUILD_ENDPOINT = 'https://build.insighthub.smartbear.com';
 
     /**
      * @var string
@@ -150,17 +165,17 @@ class Configuration implements FeatureDataStore
     /**
      * @var string
      */
-    protected $notifyEndpoint = self::NOTIFY_ENDPOINT;
+    protected $notifyEndpoint;
 
     /**
      * @var string
      */
-    protected $sessionEndpoint = self::SESSION_ENDPOINT;
+    protected $sessionEndpoint;
 
     /**
      * @var string
      */
-    protected $buildEndpoint = self::BUILD_ENDPOINT;
+    protected $buildEndpoint;
 
     /**
      * The amount to increase the memory_limit to handle an OOM.
@@ -201,13 +216,34 @@ class Configuration implements FeatureDataStore
         if (!is_string($apiKey)) {
             throw new InvalidArgumentException('Invalid API key');
         }
-
         $this->apiKey = $apiKey;
+
+        if ($this->isHubApiKey()) {
+            $this->notifyEndpoint = self::HUB_NOTIFY_ENDPOINT;
+            $this->sessionEndpoint = self::HUB_SESSION_ENDPOINT;
+            $this->buildEndpoint = self::HUB_BUILD_ENDPOINT;
+        } else {
+            $this->notifyEndpoint = self::NOTIFY_ENDPOINT;
+            $this->sessionEndpoint = self::SESSION_ENDPOINT;
+            $this->buildEndpoint = self::BUILD_ENDPOINT;
+        }
+
         $this->fallbackType = php_sapi_name();
         $this->featureFlags = new FeatureFlagDelegate();
 
         // Add PHP runtime version to device data
         $this->mergeDeviceData(['runtimeVersions' => ['php' => phpversion()]]);
+    }
+
+    /**
+     * Checks if the API Key is associated with the InsightHub instance.
+     *
+     * @return bool
+     */
+    public function isHubApiKey()
+    {
+        // Does the API key start with 00000
+        return strpos($this->apiKey, '00000') === 0;
     }
 
     /**

--- a/tests/ConfigurationTest.php
+++ b/tests/ConfigurationTest.php
@@ -302,7 +302,7 @@ class ConfigurationTest extends TestCase
     {
         $expected = 'https://notify.bugsnag.com';
 
-        $this->assertSame($expected, $this->config->getSessionEndpoint());
+        $this->assertSame($expected, $this->config->getNotifyEndpoint());
     }
 
     public function testTheNotifyEndpointForHubHasASensibleDefault()
@@ -310,7 +310,7 @@ class ConfigurationTest extends TestCase
         $expected = 'https://notify.insighthub.smartbear.com';
         $this->config = new Configuration('00000123123123123');
 
-        $this->assertSame($expected, $this->config->getSessionEndpoint());
+        $this->assertSame($expected, $this->config->getNotifyEndpoint());
     }
 
     public function testTheSessionEndpointHasASensibleDefault()
@@ -332,7 +332,7 @@ class ConfigurationTest extends TestCase
     {
         $expected = 'https://build.bugsnag.com';
 
-        $this->assertSame($expected, $this->config->getSessionEndpoint());
+        $this->assertSame($expected, $this->config->getBuildEndpoint());
     }
 
     public function testTheBuildEndpointForHubHasASensibleDefault()
@@ -340,7 +340,7 @@ class ConfigurationTest extends TestCase
         $expected = 'https://build.insighthub.smartbear.com';
         $this->config = new Configuration('00000123123123123');
 
-        $this->assertSame($expected, $this->config->getSessionEndpoint());
+        $this->assertSame($expected, $this->config->getBuildEndpoint());
     }
 
     public function testTheSessionEndpointCanBeSetIfNecessary()

--- a/tests/ConfigurationTest.php
+++ b/tests/ConfigurationTest.php
@@ -298,9 +298,47 @@ class ConfigurationTest extends TestCase
         $this->assertTrue($this->config->shouldCaptureSessions());
     }
 
+    public function testTheNotifyEndpointHasASensibleDefault()
+    {
+        $expected = 'https://notify.bugsnag.com';
+
+        $this->assertSame($expected, $this->config->getSessionEndpoint());
+    }
+
+    public function testTheNotifyEndpointForHubHasASensibleDefault()
+    {
+        $expected = 'https://notify.insighthub.smartbear.com';
+        $this->config = new Configuration('00000123123123123');
+
+        $this->assertSame($expected, $this->config->getSessionEndpoint());
+    }
+
     public function testTheSessionEndpointHasASensibleDefault()
     {
         $expected = 'https://sessions.bugsnag.com';
+
+        $this->assertSame($expected, $this->config->getSessionEndpoint());
+    }
+
+    public function testTheSessionEndpointForHubHasASensibleDefault()
+    {
+        $expected = 'https://sessions.insighthub.smartbear.com';
+        $this->config = new Configuration('00000123123123123');
+
+        $this->assertSame($expected, $this->config->getSessionEndpoint());
+    }
+
+    public function testTheBuildEndpointHasASensibleDefault()
+    {
+        $expected = 'https://build.bugsnag.com';
+
+        $this->assertSame($expected, $this->config->getSessionEndpoint());
+    }
+
+    public function testTheBuildEndpointForHubHasASensibleDefault()
+    {
+        $expected = 'https://build.insighthub.smartbear.com';
+        $this->config = new Configuration('00000123123123123');
 
         $this->assertSame($expected, $this->config->getSessionEndpoint());
     }


### PR DESCRIPTION
## Goal

Set default endpoints based on API key. If no endpoint is configured, payloads should be sent to *.insighthub.smartbear.com if the API key starts with `00000`.

## Changeset

The unit tests have started failing with PHP 8.4 before this change due to a language deprecation.  A ticket has been raised to investigate that further.

## Testing

Unit tests added and I've run some manual tests locally with an example app, verifying that the requested host is as expected for different API keys.

