### PR TITLE
Add support for Guzzle 8

### DIFF
--- a/.github/workflows/test-package.yml
+++ b/.github/workflows/test-package.yml
@@ -29,6 +29,20 @@ jobs:
           guzzle-version: '^7.9'
         - php-version: '8.5'
           guzzle-version: '^7.10'
+        - php-version: '7.4'
+          guzzle-version: '^8.0'
+        - php-version: '8.0'
+          guzzle-version: '^8.0'
+        - php-version: '8.1'
+          guzzle-version: '^8.0'
+        - php-version: '8.2'
+          guzzle-version: '^8.0'
+        - php-version: '8.3'
+          guzzle-version: '^8.0'
+        - php-version: '8.4'
+          guzzle-version: '^8.0'
+        - php-version: '8.5'
+          guzzle-version: '^8.0'
 
     steps:
     - uses: actions/checkout@v2

--- a/composer.json
+++ b/composer.json
@@ -13,10 +13,10 @@
     "require": {
         "php": ">=5.5",
         "composer/ca-bundle": "^1.0",
-        "guzzlehttp/guzzle": "^5.0|^6.0|^7.0"
+        "guzzlehttp/guzzle": "^5.0|^6.0|^7.0|^8.0"
     },
     "require-dev": {
-        "guzzlehttp/psr7": "^1.3|^2.0",
+        "guzzlehttp/psr7": "^1.3|^2.0|^3.0",
         "mtdowling/burgomaster": "dev-master#72151eddf5f0cf101502b94bf5031f9c53501a04",
         "phpunit/phpunit": "^4.8.36|^7.5.15|^9.3.10",
         "php-mock/php-mock-phpunit": "^1.1|^2.1",

--- a/src/Internal/GuzzleCompat.php
+++ b/src/Internal/GuzzleCompat.php
@@ -43,10 +43,16 @@ final class GuzzleCompat
      */
     public static function getBaseUri(GuzzleHttp\ClientInterface $guzzle)
     {
-        // TODO: validate this by running PHPStan with Guzzle 5
-        return self::isUsingGuzzle5()
-            ? $guzzle->getBaseUrl() // @phpstan-ignore-line
-            : $guzzle->getConfig(self::getBaseUriOptionName());
+        if (self::isUsingGuzzle5()) {
+            // TODO: validate this by running PHPStan with Guzzle 5
+            return $guzzle->getBaseUrl(); // @phpstan-ignore-line
+        }
+
+        // Guzzle 8 removed 'getConfig' from ClientInterface, but it still
+        // exists on the concrete Client class
+        return method_exists($guzzle, 'getConfig')
+            ? $guzzle->getConfig(self::getBaseUriOptionName())
+            : null;
     }
 
     /**

--- a/tests/phpt/Utilities/FakeGuzzle.php
+++ b/tests/phpt/Utilities/FakeGuzzle.php
@@ -18,6 +18,9 @@ $fakeGuzzleMapping = [
     5 => FakeGuzzle5::class,
     6 => FakeGuzzle6::class,
     7 => FakeGuzzle7::class,
+    // the Guzzle 7 implementation also satisfies Guzzle 8's ClientInterface,
+    // which is the same as Guzzle 7's but without 'getConfig'
+    8 => FakeGuzzle7::class,
 ];
 
 // Parse a version number like '1.0.0' into the major version only (1)

--- a/tests/phpt/Utilities/FakeGuzzle7.php
+++ b/tests/phpt/Utilities/FakeGuzzle7.php
@@ -10,7 +10,7 @@ use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\ResponseInterface;
 
 /**
- * A Guzzle 7 compatible implementation of ClientInterface for use in PHPT tests.
+ * A Guzzle 7 and 8 compatible implementation of ClientInterface for use in PHPT tests.
  *
  * This should never be used directly; use 'FakeGuzzle' instead!
  */


### PR DESCRIPTION
## Goal

Guzzle 8.0.0 was released on July 20th. Lots of people want to use it, and thus popular packages in the ecosystem like this one need to be updated to support it.

## Design

Minimal changes needed to add support.

## Changeset

Minimal changes needed to add support.

## Testing

CI